### PR TITLE
fix(website): SMI-6162 merge Featured into uniform grid, fix stretched OG images

### DIFF
--- a/packages/website/src/components/BlogPostCard.astro
+++ b/packages/website/src/components/BlogPostCard.astro
@@ -7,7 +7,6 @@ interface Props {
   author?: string | undefined
   category?: string | undefined
   tags?: string[] | undefined
-  featured?: boolean | undefined
   readingTime?: number | undefined
   ogImage?: string | undefined
 }
@@ -20,7 +19,6 @@ const {
   author = 'Skillsmith Team',
   category,
   tags = [],
-  featured = false,
   readingTime,
   ogImage,
 } = Astro.props
@@ -37,22 +35,24 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
   class:list={[
     'block group rounded-xl border transition-all duration-200',
     'bg-dark-900 hover:bg-dark-800/50',
-    featured
-      ? 'border-primary-500/30 hover:border-primary-500/50'
-      : 'border-dark-800 hover:border-dark-700',
+    'border-dark-800 hover:border-dark-700',
   ]}
 >
   {
-    ogImage && (
-      <div class="aspect-video overflow-hidden rounded-t-xl">
+    ogImage ? (
+      <div class="aspect-[1200/630] overflow-hidden rounded-t-xl">
         <img
           src={ogImage}
           alt={title}
           width="640"
-          height="360"
+          height="336"
           class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
           loading="lazy"
         />
+      </div>
+    ) : (
+      <div class="aspect-[1200/630] overflow-hidden rounded-t-xl bg-gradient-to-br from-dark-800 to-dark-900 relative">
+        <div class="absolute inset-0 bg-primary-500/5" />
       </div>
     )
   }
@@ -63,13 +63,6 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
         category && (
           <span class="px-2 py-1 text-xs font-medium rounded-full bg-primary-500/10 text-primary-400">
             {category}
-          </span>
-        )
-      }
-      {
-        featured && (
-          <span class="px-2 py-1 text-xs font-medium rounded-full bg-amber-500/10 text-amber-400">
-            Featured
           </span>
         )
       }

--- a/packages/website/src/content.config.ts
+++ b/packages/website/src/content.config.ts
@@ -19,7 +19,6 @@ const blog = defineCollection({
       .enum(['Guides', 'Tutorials', 'Case Studies', 'News', 'Engineering'])
       .default('Guides'),
     tags: z.array(z.string()).default([]),
-    featured: z.boolean().default(false),
     draft: z.boolean().default(false),
     ogImage: z.string().optional(),
     schemaType: z.enum(['HowTo', 'FAQ']).optional(),

--- a/packages/website/src/content/blog/agent-memory-architecture.md
+++ b/packages/website/src/content/blog/agent-memory-architecture.md
@@ -6,7 +6,6 @@ date: 2026-05-15
 updated: 2026-05-15
 category: "Engineering"
 tags: ["memory", "architecture", "agents", "retrieval", "embeddings", "mcp", "claude-code"]
-featured: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/agent-memory-architecture/01-three-layer-architecture"
 ---
 

--- a/packages/website/src/content/blog/agent-skill-framework.md
+++ b/packages/website/src/content/blog/agent-skill-framework.md
@@ -6,7 +6,6 @@ date: 2026-01-23
 updated: 2026-01-23
 category: "Guides"
 tags: ["agents", "skills", "architecture", "claude-code", "context-window", "multi-agent"]
-featured: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/agent-skill-framework/01-agent-skill-matrix"
 ---
 

--- a/packages/website/src/content/blog/building-skillsmith-claude-flow.md
+++ b/packages/website/src/content/blog/building-skillsmith-claude-flow.md
@@ -6,7 +6,6 @@ date: 2026-02-20
 updated: 2026-02-20
 category: "Engineering"
 tags: ["claude-flow", "claude-flow-v3", "multi-agent", "hive-mind", "sparc", "sparc-methodology", "wave-planner", "launchpad", "plan-review", "agentic-engineering", "ai-development", "claude-code", "ai-engineering", "developer-productivity", "mcp-server"]
-featured: true
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/claude-flow-v3-presentation/slide-01-cover"
 ---

--- a/packages/website/src/content/blog/catching-skills-that-hide-their-instructions.md
+++ b/packages/website/src/content/blog/catching-skills-that-hide-their-instructions.md
@@ -6,7 +6,6 @@ date: 2026-06-27
 updated: 2026-06-27
 category: "Engineering"
 tags: ["security", "quarantine", "threat-detection", "unicode", "agent-skills", "engineering"]
-featured: true
 draft: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-detection/disguised-instructions-hero"
 ---

--- a/packages/website/src/content/blog/catching-skills-that-hide-their-instructions.md
+++ b/packages/website/src/content/blog/catching-skills-that-hide-their-instructions.md
@@ -7,10 +7,10 @@ updated: 2026-06-27
 category: "Engineering"
 tags: ["security", "quarantine", "threat-detection", "unicode", "agent-skills", "engineering"]
 draft: true
-ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-detection/disguised-instructions-hero"
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-detection/unicode-deception-hero"
 ---
 
-![Two lines of text that look identical, with one revealed to contain lookalike letters and invisible gaps](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/quarantine-detection/disguised-instructions-hero)
+![Two lines of text that look identical, with one revealed to contain lookalike letters and invisible gaps](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/quarantine-detection/unicode-deception-hero)
 
 Read this line, then read it again: `ignore all previous instructions`.
 
@@ -162,7 +162,7 @@ We re-scored about 3,000 distinct real skills from the live registry across thre
       },
       "image": {
         "@type": "ImageObject",
-        "url": "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-detection/disguised-instructions-hero"
+        "url": "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-detection/unicode-deception-hero"
       },
       "keywords": ["quarantine", "threat detection", "unicode security", "homoglyph", "skillsmith", "agent skills"]
     },

--- a/packages/website/src/content/blog/dependency-intelligence.md
+++ b/packages/website/src/content/blog/dependency-intelligence.md
@@ -6,7 +6,6 @@ date: 2026-03-10
 updated: 2026-03-10
 category: "Engineering"
 tags: ["dependency-intelligence", "mcp-server", "skill-dependencies", "claude-code", "wave-planner", "agentic-engineering", "mcp-tools"]
-featured: true
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/dependency-intelligence/01-hero"
 ---

--- a/packages/website/src/content/blog/enterprise-reference-architecture.md
+++ b/packages/website/src/content/blog/enterprise-reference-architecture.md
@@ -6,7 +6,6 @@ date: 2026-05-15
 updated: 2026-05-15
 category: "Engineering"
 tags: ["architecture", "enterprise", "supabase", "rbac", "sso", "private-registry", "mcp", "reference-architecture", "elastic-license"]
-featured: true
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/enterprise-reference-architecture/01-system-overview"
 ---

--- a/packages/website/src/content/blog/how-skillsmith-indexes-skills.md
+++ b/packages/website/src/content/blog/how-skillsmith-indexes-skills.md
@@ -6,7 +6,6 @@ date: 2026-02-02
 updated: 2026-05-01
 category: "Engineering"
 tags: ["indexer", "search", "embeddings", "github", "scoring", "developers"]
-featured: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/indexer/indexer-pipeline-hero"
 ---
 

--- a/packages/website/src/content/blog/private-registry-walkthrough.md
+++ b/packages/website/src/content/blog/private-registry-walkthrough.md
@@ -5,7 +5,6 @@ author: "Skillsmith Team"
 date: 2026-08-23
 category: "Tutorials"
 tags: ["private-registry", "enterprise", "tutorial", "skills"]
-featured: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/01-skills-list-approved"
 schemaType: "HowTo"
 howToSteps:

--- a/packages/website/src/content/blog/private-registry-walkthrough.md
+++ b/packages/website/src/content/blog/private-registry-walkthrough.md
@@ -5,7 +5,7 @@ author: "Skillsmith Team"
 date: 2026-08-23
 category: "Tutorials"
 tags: ["private-registry", "enterprise", "tutorial", "skills"]
-ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/01-skills-list-approved"
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/02-private-shelf-hero"
 schemaType: "HowTo"
 howToSteps:
   - name: "Find your namespace"
@@ -53,7 +53,7 @@ Neither button works for the person who published the submission, even if that p
 
 Once a teammate approves it, the skill moves into the "Skills" section with an "Approved" badge, ready for the whole team.
 
-![Approved skill in the private registry, with version, badge, and description](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/01-skills-list-approved)
+![A locked vault of skills at the center of a team's private registry, connected to review, approval, and security icons](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/02-private-shelf-hero)
 
 ## Install it with the CLI
 

--- a/packages/website/src/content/blog/private-skill-registry-launch.md
+++ b/packages/website/src/content/blog/private-skill-registry-launch.md
@@ -5,7 +5,6 @@ author: "Skillsmith Team"
 date: 2026-08-23
 category: "News"
 tags: ["private-registry", "enterprise", "product-launch"]
-featured: true
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/01-skills-list-approved"
 ---

--- a/packages/website/src/content/blog/private-skill-registry-launch.md
+++ b/packages/website/src/content/blog/private-skill-registry-launch.md
@@ -6,7 +6,7 @@ date: 2026-08-23
 category: "News"
 tags: ["private-registry", "enterprise", "product-launch"]
 draft: false
-ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/01-skills-list-approved"
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/02-private-shelf-hero"
 ---
 
 Picture a platform engineer who spends an afternoon writing a Claude skill that walks through her team's exact deploy runbook: which Terraform workspace to touch first, which Slack channel gets the rollback plan, who to page when the database owner is asleep. It's a genuinely useful skill. It's also full of internal service names, channel handles, and a company acronym that means nothing outside her building. Publishing it to Skillsmith's public registry was never an option, so it would have sat on her laptop, shared the old way: a Slack message with a zip file attached, hoping the next person remembered to ask for it.
@@ -19,7 +19,7 @@ Each team gets its own namespace, a short prefix like `acme-corp/`, so a skill p
 
 Here's what changed on the day-to-day: a team member writes a skill and submits it through Claude. It doesn't go live. It lands on the team admin's dashboard as a pending submission, sitting in a waiting room until someone reviews it.
 
-![The private registry dashboard showing an approved skill listing](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/01-skills-list-approved)
+![A locked vault of skills at the center of a team's private registry, connected to review, approval, and security icons](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/02-private-shelf-hero)
 
 An admin reads the description, checks the version, and approves it. Only then does the skill move from submitted to installable. Reject it, and it never reaches a single laptop. Nobody, not even the person who wrote it, can approve their own submission: a second set of eyes is built into the door, not bolted on after the fact.
 

--- a/packages/website/src/content/blog/security-advisory-cve-2026-33768.md
+++ b/packages/website/src/content/blog/security-advisory-cve-2026-33768.md
@@ -5,7 +5,6 @@ author: "Skillsmith Team"
 date: 2026-03-29
 category: "Engineering"
 tags: ["security", "advisory", "infrastructure", "vercel"]
-featured: false
 draft: false
 ---
 

--- a/packages/website/src/content/blog/security-quarantine-safe-installation.md
+++ b/packages/website/src/content/blog/security-quarantine-safe-installation.md
@@ -6,7 +6,6 @@ date: 2026-02-02
 updated: 2026-02-12
 category: "Engineering"
 tags: ["security", "trust-tiers", "static-analysis", "quarantine", "installation", "safety"]
-featured: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/security/security-shield-hero"
 ---
 

--- a/packages/website/src/content/blog/supply-chain-hardening.md
+++ b/packages/website/src/content/blog/supply-chain-hardening.md
@@ -5,7 +5,6 @@ author: "Skillsmith Team"
 date: 2026-04-03
 category: "Engineering"
 tags: ["security", "supply-chain", "infrastructure", "dependencies"]
-featured: true
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/supply-chain/supply-chain-hero"
 ---

--- a/packages/website/src/content/blog/the-function-we-almost-deleted.md
+++ b/packages/website/src/content/blog/the-function-we-almost-deleted.md
@@ -6,7 +6,6 @@ date: 2026-08-14
 updated: 2026-08-15
 category: "Engineering"
 tags: ["dead-code", "code-health", "developer-tooling", "open-source", "engineering-culture", "monorepo", "code-quality"]
-featured: false
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/the-function-we-almost-deleted/01-hero"
 ---

--- a/packages/website/src/content/blog/the-parking-garage-with-no-gate.md
+++ b/packages/website/src/content/blog/the-parking-garage-with-no-gate.md
@@ -6,7 +6,6 @@ date: 2026-08-15
 updated: 2026-08-16
 category: "Engineering"
 tags: ["docker", "developer-tooling", "engineering-culture", "infrastructure", "agentic-engineering"]
-featured: false
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/the-parking-garage-with-no-gate/01-hero"
 ---

--- a/packages/website/src/content/blog/user-focused-competitive-landscape.md
+++ b/packages/website/src/content/blog/user-focused-competitive-landscape.md
@@ -5,7 +5,6 @@ author: "Skillsmith Team"
 date: 2026-02-16
 category: "Guides"
 tags: ["skills", "security", "registries", "competitive-landscape", "discovery", "trust-tiers"]
-featured: true
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/user-focused-landscape/01-skill-didnt-work"
 ---

--- a/packages/website/src/content/blog/why-the-quarantine-system-needed-a-database-guard.md
+++ b/packages/website/src/content/blog/why-the-quarantine-system-needed-a-database-guard.md
@@ -7,10 +7,10 @@ updated: 2026-06-25
 category: "Engineering"
 tags: ["security", "quarantine", "data-integrity", "infrastructure", "engineering", "database"]
 draft: true
-ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-hardening/quarantine-audit-hero"
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-hardening/database-guard-hero"
 ---
 
-![Database rows with warning indicators and a CHECK constraint guard](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/quarantine-hardening/quarantine-audit-hero)
+![Database rows with warning indicators and a CHECK constraint guard](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/quarantine-hardening/database-guard-hero)
 
 Skillsmith's quarantine system sits between the public registry and the skills you can install. It blocks malicious content, stale references, and dead repositories from reaching your agent. Going into our June 2026 audit, it held ~5,582 quarantined records across a registry of ~73,347 skills.
 
@@ -206,7 +206,7 @@ No alert was configured for `quarantine_reason IS NULL`. The rows were written b
       },
       "image": {
         "@type": "ImageObject",
-        "url": "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-hardening/quarantine-audit-hero"
+        "url": "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-hardening/database-guard-hero"
       },
       "keywords": ["quarantine", "data integrity", "database", "security", "skillsmith", "agent skills"]
     },

--- a/packages/website/src/content/blog/why-the-quarantine-system-needed-a-database-guard.md
+++ b/packages/website/src/content/blog/why-the-quarantine-system-needed-a-database-guard.md
@@ -6,7 +6,6 @@ date: 2026-06-25
 updated: 2026-06-25
 category: "Engineering"
 tags: ["security", "quarantine", "data-integrity", "infrastructure", "engineering", "database"]
-featured: true
 draft: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/quarantine-hardening/quarantine-audit-hero"
 ---

--- a/packages/website/src/pages/blog/index.astro
+++ b/packages/website/src/pages/blog/index.astro
@@ -13,10 +13,6 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 )
 
-// Separate featured and regular posts
-const featuredPosts = posts.filter((post) => post.data.featured)
-const regularPosts = posts.filter((post) => !post.data.featured)
-
 // Get unique categories
 const categories = [...new Set(posts.map((post) => post.data.category).filter(Boolean))]
 
@@ -101,54 +97,26 @@ const blogJsonLd = {
         </div>
       ) : (
         <>
-          {/* Featured Posts */}
-          {featuredPosts.length > 0 && (
-            <section class="mb-16">
-              <h2 class="text-sm font-semibold uppercase tracking-wider text-dark-400 mb-6">
-                Featured
-              </h2>
-              <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-1">
-                {featuredPosts.map((post) => (
-                  <BlogPostCard
-                    title={post.data.title}
-                    description={post.data.description}
-                    slug={post.id}
-                    date={post.data.date}
-                    author={post.data.author}
-                    category={post.data.category}
-                    tags={post.data.tags}
-                    featured={true}
-                    readingTime={calculateReadingTime(post.body ?? '')}
-                    ogImage={post.data.ogImage}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* All Posts */}
-          {regularPosts.length > 0 && (
-            <section>
-              <h2 class="text-sm font-semibold uppercase tracking-wider text-dark-400 mb-6">
-                {featuredPosts.length > 0 ? 'All Articles' : 'Articles'}
-              </h2>
-              <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {regularPosts.map((post) => (
-                  <BlogPostCard
-                    title={post.data.title}
-                    description={post.data.description}
-                    slug={post.id}
-                    date={post.data.date}
-                    author={post.data.author}
-                    category={post.data.category}
-                    tags={post.data.tags}
-                    readingTime={calculateReadingTime(post.body ?? '')}
-                    ogImage={post.data.ogImage}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
+          <section>
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-dark-400 mb-6">
+              Articles
+            </h2>
+            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {posts.map((post) => (
+                <BlogPostCard
+                  title={post.data.title}
+                  description={post.data.description}
+                  slug={post.id}
+                  date={post.data.date}
+                  author={post.data.author}
+                  category={post.data.category}
+                  tags={post.data.tags}
+                  readingTime={calculateReadingTime(post.body ?? '')}
+                  ogImage={post.data.ogImage}
+                />
+              ))}
+            </div>
+          </section>
 
           {/* Categories */}
           {categories.length > 1 && (


### PR DESCRIPTION
## Business Summary

**What shipped:** The blog listing page (`/blog`) now shows every post in one uniform grid — the separate "Featured" section and its amber badge are gone. Fixed the actual cause of the stretched/cut-off hero images: it wasn't a CSS bug, it was Cloudinary cropping three specific images that didn't match the site's OG-card dimensions, discarding real content (in one case, ~40% of a screenshot's width, cutting a UI row's text off both edges). All three replaced with purpose-made illustrations. Also fixed two smaller issues found in the process: every card's image frame now matches its actual crop ratio exactly (was silently re-cropping ~3-8% off every image), and the one post with no hero image gets a fallback panel instead of rendering shorter than its neighbors.

**Quality bar:** Implementation plan reviewed via `plan-review-skill` before any code was written (3 High + 7 Medium + 5 Low findings, all applied — including two gaps the initial plan missed: dead code left behind, and an incomplete fix that would have left the bad image live in article bodies and SEO structured data). Typecheck and lint clean. Full pre-push test suite green (10,109 tests). All 16 posts' `ogImage` URLs fetch-verified live at 200 with correct 1200×630 dimensions, not just the 4 known-bad ones.

**Found along the way:** two Cloudinary assets orphaned under the *old* broken public_ids (`blog/quarantine-detection/disguised-instructions-hero`, `blog/quarantine-hardening/quarantine-audit-hero`) from a self-corrected upload mistake during image generation — unreferenced anywhere in the codebase, harmless, but flagging since deleting cloud assets isn't something I'll do without a separate go-ahead.

**Net result:** Code complete and pushed. Verifying against the Vercel preview deployment before this merges to `main`, per instruction — not merging yet.

---

## Technical detail

Tracked as **SMI-6162**. Plan: `docs/internal/implementation/blog-listing-unify-cards-fix-image-crop.md`.

**Root cause** (confirmed via direct browser/DOM inspection, not assumed): every post's OG image goes through `f_auto,q_auto,w_1200,h_630,c_fill` (1200×630, ratio 1.905:1). Most posts source a ~16:9 generated illustration, so the crop is negligible. `blog/private-registry/01-skills-list-approved` was a 1568×498 (ratio 3.15:1) product-UI screenshot — `c_fill` discarded ~40% of its width to hit the target ratio, cutting a list row's text off both edges. Two other posts (`catching-skills-that-hide-their-instructions`, `why-the-quarantine-system-needed-a-database-guard`, both `draft: true`) referenced Cloudinary assets that never existed (404 on any transform).

**Commits** (branch `fix/blog-listing-uniform-cards`, worktree `.worktrees/blog-listing-uniform-cards`):
- `09ee6c0da` — bump `docs/internal` pointer for the plan doc
- `0aebd34eb` — merge Featured into one grid; remove `featured` entirely (schema, all posts' frontmatter, badge/border JSX — confirmed no other reader in the codebase); fix `BlogPostCard`'s `aspect-video` → `aspect-[1200/630]` mismatch; add a fallback panel for the imageless post
- `883c3832b` — replace the mis-cropped private-registry hero (both posts, all occurrences: frontmatter `ogImage` + inline body image) and the two 404'ing quarantine heroes (all occurrences: frontmatter, inline body image, and embedded JSON-LD `BlogPosting.image.url`)

New Cloudinary assets (via `scripts/upload-blog-images.mjs`, generated per the `image-pipeline` skill against `docs/internal/design/brand_guidelines.md` and the site's existing hero style): `blog/private-registry/02-private-shelf-hero`, `blog/quarantine-detection/unicode-deception-hero`, `blog/quarantine-hardening/database-guard-hero`. Local sources + Cloudinary metadata committed in the `docs/internal` submodule.

**Execution**: queen-coordinated on a dedicated worktree per CLAUDE.md's default execution model — Sonnet for the component/page merge and image-generation/upload work, Haiku for the mechanical 16-file frontmatter strip. All subagent output independently verified against the actual diffs and live Cloudinary URLs before committing, not taken on the agents' own summaries.

**CI note**: `packages/doc-retrieval-mcp`'s full test suite briefly appeared to fail during pre-push — traced to a leftover `astro dev` process I'd started earlier in this same resource-capped worktree container, starving the concurrent vitest run. Killed the stray process, re-ran clean (686/686 test files passed), confirmed via a second full run on `main`'s own container that this isn't a pre-existing or code-related failure. Unrelated to this PR's diff.
