### PR TITLE
fix(website): correct private registry walkthrough content drift

### DIFF
--- a/packages/website/src/content/blog/private-registry-walkthrough.md
+++ b/packages/website/src/content/blog/private-registry-walkthrough.md
@@ -31,13 +31,20 @@ Publishing goes through the `private_registry_publish` MCP tool: your skill ID (
 ```json
 {
   "success": true,
+  "dataSource": "live",
   "skill": {
     "skillId": "your-team/skill-name",
     "version": "0.1.0",
+    "description": "Formats commit messages to match our team's changelog conventions.",
+    "deprecated": false,
+    "publishedAt": "2026-08-23T14:32:07.000Z",
+    "publishedBy": "4e2f6a8c-9d31-4b7a-8e5f-1c6a9d2f7b30",
+    "registryUrl": null,
     "approvalStatus": "pending",
     "approvalMode": "review"
   },
-  "message": "Submitted your-team/skill-name@0.1.0 for review — an admin must approve it before teammates can install it."
+  "skillNamespace": "your-team",
+  "message": "Submitted your-team/skill-name@0.1.0 for review — an admin must approve it before teammates can install it. Review confirms who published this and what version/description was submitted; it does not include a full content read by the approver."
 }
 ```
 
@@ -57,7 +64,7 @@ Once a teammate approves it, the skill moves into the "Skills" section with an "
 
 ## Install it with the CLI
 
-For installing, reach for your terminal, not the MCP tool:
+For installing, the CLI is the simplest path:
 
 ```
 skillsmith registry install your-team/skill-name

--- a/packages/website/src/pages/docs/tutorials/private-registry.astro
+++ b/packages/website/src/pages/docs/tutorials/private-registry.astro
@@ -89,9 +89,10 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <p>
     Every team gets one fixed registry namespace. Ask the <code>private_registry_manage</code> MCP
-    tool for it with <code>action: "namespace"</code>, or open the private registry dashboard under
-    your account settings, which shows it at the top of the page as a short prefix, something like
-    <code>your-team/</code>. Every skill ID you publish has to start with that exact prefix, checked
+    tool for it with <code>action: "namespace"</code>, or open the private registry dashboard, which
+    lives on your account's Registry page (left sidebar, under Tools), and shows the namespace at the
+    top of the page as a short prefix, something like <code>your-team/</code>. Every skill ID you
+    publish has to start with that exact prefix, checked
     at the database level on every publish, so there's no accidentally landing in someone else's
     namespace.
   </p>
@@ -107,13 +108,20 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <pre><code>{`{
   "success": true,
+  "dataSource": "live",
   "skill": {
     "skillId": "your-team/skill-name",
     "version": "0.1.0",
+    "description": "Formats commit messages to match our team's changelog conventions.",
+    "deprecated": false,
+    "publishedAt": "2026-08-23T14:32:07.000Z",
+    "publishedBy": "4e2f6a8c-9d31-4b7a-8e5f-1c6a9d2f7b30",
+    "registryUrl": null,
     "approvalStatus": "pending",
     "approvalMode": "review"
   },
-  "message": "Submitted your-team/skill-name@0.1.0 for review — an admin must approve it before teammates can install it."
+  "skillNamespace": "your-team",
+  "message": "Submitted your-team/skill-name@0.1.0 for review — an admin must approve it before teammates can install it. Review confirms who published this and what version/description was submitted; it does not include a full content read by the approver."
 }`}</code></pre>
 
   <p>
@@ -125,13 +133,14 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
   <h2 id="step-3-review">Step 3: A teammate reviews it</h2>
 
   <p>
-    The submission shows up in the "Pending Submissions" section of the private registry dashboard
-    (under your account's Team tools), with the skill ID, version, description, and two buttons:
-    Approve and Reject. Only team admins and owners can act on either button, and critically,
+    The submission shows up in the "Pending Submissions" section of that same dashboard, with the
+    skill ID, version, description, and two buttons: Approve and Reject. Only team admins and owners
+    can act on either button, and critically,
     <strong>the person who published a submission cannot approve or reject it themselves</strong>,
-    even if they hold an admin role. This is enforced at the database level, not just hidden in the
-    interface, so it can't be worked around by calling the underlying tool directly either. A
-    different admin has to make the call.
+    even if they hold an admin role. This is enforced at the database level, so it can't be worked
+    around by calling the underlying tool directly either. Even the interface's own Approve and
+    Reject buttons don't stop you from clicking them on your own submission; they simply fail with an
+    error if you try. A different admin has to make the call.
   </p>
 
   <p>


### PR DESCRIPTION
## Business Summary

**What shipped:** The private-registry walkthrough (blog post + docs tutorial) now matches the shipped product. Two same-day changes that landed right around the walkthrough's original launch — a nav consolidation and an MCP-install fix — were never reflected in the content, so the published guide was giving readers directions that no longer worked. Fixed: the install guidance no longer wrongly warns off the MCP tool, the example JSON response matches what the tool actually returns, the navigation instructions point to where the page really lives, and the self-approval explanation no longer implies the interface visually blocks it (it doesn't — it's enforced server-side and fails with an error if you try).

**Quality bar:** Sonnet implementation, Sonnet governance review, and an independent GPT-5.6-Sol cross-provider review (via NEEDLE) — all against the real code, not just each other's word. Site build and Prettier formatting both verified clean in a Docker container.

**Found along the way:** the cross-provider review caught one issue the first pass missed — the JSON example's `publishedBy` field looked like an email address, but the real field is a UUID (`auth.uid()`). Fixed in the same commit.

**Net result:** Fully shipped, no follow-up blocking. One optional UI enhancement noted in the code review report (docs/internal/code_review/2026-08-25-private-registry-walkthrough-content-fix.md) — making the self-approval block visually disabled in the dashboard, not just server-enforced — flagged as a separate possible follow-up, not filed as a blocking issue.

---

## Technical detail

- `packages/website/src/content/blog/private-registry-walkthrough.md` — corrected CLI/MCP install wording, expanded the JSON response example to the real field set, fixed the `publishedBy` example value
- `packages/website/src/pages/docs/tutorials/private-registry.astro` — corrected navigation wording (left-sidebar "Tools" group, not the removed tab row), same JSON example fix, softened the self-approval "not just hidden in the interface" claim to match real behavior
- `docs/internal` submodule pointer bump — adds the code review report at `docs/internal/code_review/2026-08-25-private-registry-walkthrough-content-fix.md`
- Verified: `npm run --workspace packages/website build` and `npx prettier --check` both pass in the worktree's own Docker container
- Linear: SMI-6163 tracks this fix