### PR TITLE
feat(indexer): SMI-6015 Wave 1 shard-aware single-process fetch

### DIFF
--- a/scripts/indexer/smi5879-simulate-full.checkpoint.ts
+++ b/scripts/indexer/smi5879-simulate-full.checkpoint.ts
@@ -16,6 +16,7 @@
 
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { ALL_SIMULATED_COHORTS, isValidSimRowOutcome } from './smi5879-simulate-full.types.ts'
+import { shardOf } from './smi5879-simulate-full.shard.ts'
 import type {
   SimSnapshotRow,
   SimulatedCohort,
@@ -27,6 +28,46 @@ import type { Smi5879Purpose } from './smi5879-census.types.ts'
 
 export function checkpointPathFor(runId: string): string {
   return `smi5879-simulate-checkpoint-${runId}.json`
+}
+
+/**
+ * SMI-6015 Wave 1 (PAT-sharded fetch plan §2): shard-aware checkpoint path
+ * convention, matching the Wave 3 dispatch runbook's own naming
+ * (`smi5879-simulate-checkpoint-${runId}-shard${i}.json`). Callers pass an
+ * explicit `--checkpoint-path` per shard in production (this function is a
+ * convenience default, same relationship {@link checkpointPathFor} has to
+ * `--checkpoint-path`) — {@link assertCheckpointIdentity} cross-checks
+ * whatever path IS used against the checkpoint's own `shard_index` when the
+ * path matches this naming pattern.
+ */
+export function checkpointPathForShard(runId: string, shardIndex: number): string {
+  return `smi5879-simulate-checkpoint-${runId}-shard${shardIndex}.json`
+}
+
+/**
+ * Extract the shard index embedded in a checkpoint path by
+ * {@link checkpointPathForShard}'s own naming convention, or `null` if the
+ * path doesn't match it (e.g. a fully custom `--checkpoint-path`) — in which
+ * case there is no path-implied identity to cross-check, and
+ * {@link assertCheckpointIdentity} skips that specific sub-check rather than
+ * treating "doesn't match the convention" as itself an error.
+ *
+ * SHARD-INDEX ONLY, deliberately not run-id-aware (round-1 GPT-5.6-Sol
+ * review, Low finding): `run_id` values are not fixed-shape (they can
+ * themselves contain dashes and digit runs — see real examples in this
+ * generation's own `run_id` values), so reliably reverse-parsing a `run_id`
+ * back out of `smi5879-simulate-checkpoint-${runId}-shard${i}.json` without
+ * the same ambiguity is not possible in general. This is not a gap in
+ * practice: {@link assertCheckpointIdentity}'s own `checkpoint.run_id !==
+ * expected.runId` content-based comparison (checked unconditionally, not
+ * only when the path matches this convention) already catches a genuinely
+ * wrong `run_id`, regardless of what the path's own name happens to imply.
+ */
+function parseShardIndexFromPath(path: string): number | null {
+  const match = /-shard(\d+)\.json$/.exec(path)
+  const captured = match?.[1]
+  if (captured === undefined) return null
+  return Number(captured)
 }
 
 const VALID_PURPOSES_FOR_SHAPE_CHECK: readonly Smi5879Purpose[] = [
@@ -106,6 +147,26 @@ function assertValidCheckpointShape(
     !cohorts.every((c) => ALL_SIMULATED_COHORTS.includes(c as SimulatedCohort))
   ) {
     errors.push(`cohorts=${JSON.stringify(cohorts)}`)
+  }
+  // SMI-6015 Wave 1: shard_index/shard_count are both-or-neither, and when
+  // present must be a valid (index, count) pair — same rigor as the CLI
+  // parser's own validation (smi5879-simulate-full.cli.ts), re-applied here
+  // because a hand-edited or stale checkpoint file bypasses the CLI parser
+  // entirely.
+  const shardIndex = value['shard_index']
+  const shardCount = value['shard_count']
+  if (shardIndex !== undefined || shardCount !== undefined) {
+    if (
+      typeof shardCount !== 'number' ||
+      !Number.isInteger(shardCount) ||
+      shardCount < 1 ||
+      typeof shardIndex !== 'number' ||
+      !Number.isInteger(shardIndex) ||
+      shardIndex < 0 ||
+      shardIndex >= shardCount
+    ) {
+      errors.push(`shard_index=${String(shardIndex)}/shard_count=${String(shardCount)}`)
+    }
   }
   if (typeof cleanShutdown !== 'boolean') errors.push('clean_shutdown')
   if (typeof startedAt !== 'string') errors.push('started_at')
@@ -204,6 +265,21 @@ function sameCohorts(a: readonly SimulatedCohort[], b: readonly SimulatedCohort[
  * (a cohort-scoped rehearsal checkpoint resumed as if it were the full
  * population, or vice versa, would silently corrupt that generation's
  * coverage accounting).
+ *
+ * SMI-6015 Wave 1 (PAT-sharded fetch plan §2): `shardIndex`/`shardCount` are
+ * checked the same way, both-or-neither with `expected.shardIndex`/
+ * `expected.shardCount` — a resume against a checkpoint written for a
+ * different shard index, a different shard count, or crossing between
+ * sharded and unsharded, is refused loudly rather than silently corrupting
+ * that shard's row assignment. ADDITIONALLY, when `path` matches
+ * {@link checkpointPathForShard}'s naming convention, the shard index
+ * embedded in the PATH itself is cross-checked against the checkpoint
+ * content's own `shard_index` — this catches a copy/rename mistake (a
+ * checkpoint file physically moved/copied to a path implying a different
+ * shard than its own content) that the plain content-vs-`expected` check
+ * above cannot: if the operator's `--shard-index` flag and the checkpoint's
+ * content happen to agree with each other but NEITHER agrees with what the
+ * file's own name implies, the flag-vs-content check alone would pass.
  */
 export function assertCheckpointIdentity(
   checkpoint: Smi5879SimulateCheckpoint,
@@ -212,6 +288,8 @@ export function assertCheckpointIdentity(
     purpose: Smi5879Purpose
     tokenSource: TokenSource
     cohorts: SimulatedCohort[]
+    shardIndex?: number
+    shardCount?: number
   },
   path: string
 ): void {
@@ -232,11 +310,29 @@ export function assertCheckpointIdentity(
       `cohorts (checkpoint=${checkpoint.cohorts.join(',')}, this run=${expected.cohorts.join(',')})`
     )
   }
+  if (
+    checkpoint.shard_index !== expected.shardIndex ||
+    checkpoint.shard_count !== expected.shardCount
+  ) {
+    mismatches.push(
+      `shard (checkpoint=index ${checkpoint.shard_index ?? '(unsharded)'}/count ${checkpoint.shard_count ?? '(unsharded)'}, ` +
+        `this run=index ${expected.shardIndex ?? '(unsharded)'}/count ${expected.shardCount ?? '(unsharded)'})`
+    )
+  }
+  const pathShardIndex = parseShardIndexFromPath(path)
+  if (pathShardIndex !== null && pathShardIndex !== checkpoint.shard_index) {
+    mismatches.push(
+      `shard index embedded in --checkpoint-path (${pathShardIndex}) does not match the checkpoint's ` +
+        `own shard_index (${checkpoint.shard_index ?? '(unsharded)'}) — this file was likely copied ` +
+        'or renamed to this path from a different shard'
+    )
+  }
   if (mismatches.length > 0) {
     throw new Error(
       `SMI-5879: checkpoint at ${path} does not match this invocation — ${mismatches.join('; ')}. ` +
-        'A resume must reuse a checkpoint from the SAME run_id/purpose/token_source/cohorts — use a ' +
-        'fresh --checkpoint-path for a different generation or cohort scope instead of pointing at this one.'
+        'A resume must reuse a checkpoint from the SAME run_id/purpose/token_source/cohorts/shard — ' +
+        'use a fresh --checkpoint-path for a different generation, cohort scope, or shard instead of ' +
+        'pointing at this one.'
     )
   }
 }
@@ -247,20 +343,98 @@ export function assertCheckpointIdentity(
  * from a different generation whose row ids happen to overlap with
  * globally-stable skill ids from this one. Must be called only after the
  * real row set for this generation has been loaded (SMI-5879 review finding 1).
+ *
+ * SMI-6015 PAT-sharded fetch plan Wave 1 (round-1 GPT-5.6-Sol review, High
+ * finding): generation membership alone is NOT sufficient once shards
+ * exist. `assertCheckpointIdentity` only compares the checkpoint's OWN
+ * declared `shard_index`/`cohorts` against this invocation's — it says
+ * nothing about whether each INDIVIDUAL `row_results` entry actually
+ * belongs to that declared scope. A structurally valid checkpoint could
+ * declare `shard_index: 1` while its `row_results` (corrupted, hand-edited,
+ * or produced by some future bug) actually contains shard-0 or
+ * excluded-cohort rows — resume would silently accept them, producing a
+ * shard report with rows outside its own partition and breaking the
+ * row-id-disjointness invariant Wave 2's merge tool depends on. Every
+ * `row_results` entry is now checked against: (1) `result.id === key` (the
+ * dictionary key matches its own stored result — catches a corrupted/
+ * mismatched entry), (2) `result.cohort`/`result.author`/`result.name`
+ * (round-2/round-3 review findings — every field `processRow` derives from
+ * the canonical row, not just `id`) each agree with the CANONICAL row's own
+ * values — `report.rows`/`counts` are built from the stored results
+ * directly, not re-derived from the canonical row set, so any of these
+ * disagreeing would otherwise survive into the report unverified, (3) the
+ * row's cohort is within `scope.cohorts`, and (4) when sharded,
+ * `shardOf(id, scope.shardCount) === scope.shardIndex` (the row genuinely
+ * belongs to THIS shard's partition, not just this generation).
  */
 export function assertCheckpointRowsBelongToGeneration(
   checkpoint: Smi5879SimulateCheckpoint,
   rows: readonly SimSnapshotRow[],
-  path: string
+  path: string,
+  scope: { cohorts: SimulatedCohort[]; shardIndex?: number; shardCount?: number }
 ): void {
-  const validIds = new Set(rows.map((r) => r.id))
-  const staleIds = Object.keys(checkpoint.row_results).filter((id) => !validIds.has(id))
-  if (staleIds.length > 0) {
+  const rowById = new Map(rows.map((r) => [r.id, r]))
+  const problems: string[] = []
+  for (const [key, result] of Object.entries(checkpoint.row_results)) {
+    const row = rowById.get(key)
+    if (!row) {
+      problems.push(`${key} (not in this generation's row set)`)
+      continue
+    }
+    if (result.id !== key) {
+      problems.push(`${key} (row_results key does not match its own result.id=${result.id})`)
+      continue
+    }
+    // Round-2 GPT-5.6-Sol review, High finding: the FIRST-round fix checked
+    // the CANONICAL loaded row's cohort against scope, but never checked
+    // that the STORED result's OWN `cohort` field actually agrees with that
+    // canonical row — `report.rows`/`counts` are built directly from the
+    // stored results (`summarizeCounts(results.values())`), not re-derived
+    // from the canonical row set, so a malformed entry with a real row id
+    // but a WRONG `result.cohort` would survive into the report untouched,
+    // even though `coverage[cohort].total` (keyed off the canonical rows)
+    // stayed correct — a real corruption path this closes.
+    if (result.cohort !== row.cohort) {
+      problems.push(
+        `${key} (stored result.cohort=${result.cohort} does not match this row's real cohort=${row.cohort})`
+      )
+      continue
+    }
+    // Round-3 GPT-5.6-Sol review, Medium finding: `author`/`name` are the
+    // same class of gap as `cohort` above — `processRow` (helpers.ts)
+    // derives both directly from the canonical row, but resume never
+    // cross-checks the stored values against it, and both flow unchanged
+    // into `report.rows`. Not gate-relevant (unlike `cohort`, which feeds
+    // `coverage`/`counts`) — these are purely informational/display fields
+    // for a human reviewer reading the report — but a malformed stored
+    // value would still silently misattribute a row in the report.
+    if (result.author !== row.author || result.name !== row.name) {
+      problems.push(
+        `${key} (stored result.author/name=${result.author}/${result.name} does not match this row's real author/name=${row.author}/${row.name})`
+      )
+      continue
+    }
+    if (!scope.cohorts.includes(row.cohort)) {
+      problems.push(`${key} (cohort ${row.cohort} outside this run's cohort scope)`)
+      continue
+    }
+    if (scope.shardIndex !== undefined && scope.shardCount !== undefined) {
+      const expectedShard = shardOf(key, scope.shardCount)
+      if (expectedShard !== scope.shardIndex) {
+        problems.push(
+          `${key} (belongs to shard ${expectedShard}, not this shard ${scope.shardIndex})`
+        )
+      }
+    }
+  }
+  if (problems.length > 0) {
     throw new Error(
-      `SMI-5879: checkpoint at ${path} has ${staleIds.length} row_results key(s) that are not in ` +
-        `this generation's row set (e.g. ${staleIds.slice(0, 5).join(', ')}) — this checkpoint was ` +
-        'likely written for a different generation. Refusing to reuse stale verdicts; use a fresh ' +
-        '--checkpoint-path for this generation instead.'
+      `SMI-5879: checkpoint at ${path} has ${problems.length} row_results entr` +
+        `${problems.length === 1 ? 'y' : 'ies'} that don't belong to this invocation's scope: ` +
+        `${problems.slice(0, 5).join('; ')}` +
+        `${problems.length > 5 ? `, and ${problems.length - 5} more` : ''} — this checkpoint was ` +
+        'likely written for a different generation, cohort scope, or shard. Refusing to reuse ' +
+        'stale/foreign verdicts; use a fresh --checkpoint-path instead.'
     )
   }
 }

--- a/scripts/indexer/smi5879-simulate-full.cli.ts
+++ b/scripts/indexer/smi5879-simulate-full.cli.ts
@@ -40,6 +40,17 @@ export interface CliArgs {
    * gate no matter what it found.
    */
   cohorts?: SimulatedCohort[]
+  /**
+   * SMI-6015 Wave 1 (PAT-sharded fetch plan §1): this dispatch's shard
+   * assignment for a PAT-sharded fetch. Both-or-neither with `shardCount` —
+   * undefined means unsharded (the pre-existing single-process behavior).
+   * Row-level, not cohort-level: every shard processes a slice of EVERY
+   * cohort (see `shardOf()`'s own doc comment) — orthogonal to, and
+   * composable with, `cohorts` above.
+   */
+  shardIndex?: number
+  /** SMI-6015 Wave 1: total number of shards for this decision run. Both-or-neither with `shardIndex`. */
+  shardCount?: number
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -95,6 +106,43 @@ export function parseArgs(argv: string[]): CliArgs {
     }
   }
 
+  // SMI-6015 Wave 1: --shard-index/--shard-count, both-or-neither. Row-level
+  // sharding, orthogonal to --cohorts (plan §1) — no cross-validation against
+  // `cohorts`/`purpose` needed here; every shard processes a slice of every
+  // cohort regardless of the cohort scope.
+  const shardIndexRaw = find('shard-index')
+  const shardCountRaw = find('shard-count')
+  let shardIndex: number | undefined
+  let shardCount: number | undefined
+  if (shardIndexRaw !== undefined || shardCountRaw !== undefined) {
+    if (shardIndexRaw === undefined || shardCountRaw === undefined) {
+      throw new Error(
+        'SMI-6015: --shard-index and --shard-count must both be present or both be absent, got ' +
+          `--shard-index=${shardIndexRaw ?? '(missing)'} --shard-count=${shardCountRaw ?? '(missing)'}.`
+      )
+    }
+    const parsedCount = Number(shardCountRaw)
+    if (!Number.isInteger(parsedCount) || parsedCount < 1) {
+      throw new Error(
+        `SMI-6015: --shard-count=<N> must be an integer >= 1, got "${shardCountRaw}".`
+      )
+    }
+    const parsedIndex = Number(shardIndexRaw)
+    // Also covers the degenerate --shard-count=1 case correctly: with
+    // parsedCount=1, the only value satisfying 0 <= i < 1 is 0, so
+    // --shard-index=0 --shard-count=1 (a no-op single-shard run, useful for
+    // the merge tool's own tests) passes, and any other --shard-index with
+    // --shard-count=1 is naturally rejected by this same bound — no separate
+    // special case needed.
+    if (!Number.isInteger(parsedIndex) || parsedIndex < 0 || parsedIndex >= parsedCount) {
+      throw new Error(
+        `SMI-6015: --shard-index=<i> must be an integer with 0 <= i < --shard-count (${parsedCount}), got "${shardIndexRaw}".`
+      )
+    }
+    shardIndex = parsedIndex
+    shardCount = parsedCount
+  }
+
   // `checkpointPath`/`reportPath` are genuinely optional (downstream defaults via
   // `?? checkpointPathFor(...)` / `?? 'smi5879-simulate-report-...'`) — under
   // `exactOptionalPropertyTypes`, an optional property means "may be omitted",
@@ -111,5 +159,7 @@ export function parseArgs(argv: string[]): CliArgs {
     baselineCommit: find('baseline-commit') ?? BASELINE_COMMIT_SHA,
     ...(maxElapsedMinutes !== undefined ? { maxElapsedMinutes } : {}),
     ...(cohorts !== undefined ? { cohorts } : {}),
+    ...(shardIndex !== undefined ? { shardIndex } : {}),
+    ...(shardCount !== undefined ? { shardCount } : {}),
   }
 }

--- a/scripts/indexer/smi5879-simulate-full.cli.ts
+++ b/scripts/indexer/smi5879-simulate-full.cli.ts
@@ -14,6 +14,12 @@ import type { Smi5879Purpose } from './smi5879-census.types.ts'
 
 const VALID_PURPOSES: readonly Smi5879Purpose[] = ['rehearsal', 'decision', 'window']
 
+// PR #2525 review (GPT-5.6-Sol) Low finding: the DB adapter casts both
+// --shard-index/--shard-count to Postgres `::integer` (smi5879-simulate-full.db.ts),
+// so a value that passes CLI validation but exceeds this range would fail
+// opaquely at claim time instead of at parse time.
+const POSTGRES_INTEGER_MAX = 2_147_483_647
+
 export interface CliArgs {
   runId: string
   purpose: Smi5879Purpose
@@ -122,9 +128,10 @@ export function parseArgs(argv: string[]): CliArgs {
       )
     }
     const parsedCount = Number(shardCountRaw)
-    if (!Number.isInteger(parsedCount) || parsedCount < 1) {
+    if (!Number.isInteger(parsedCount) || parsedCount < 1 || parsedCount > POSTGRES_INTEGER_MAX) {
       throw new Error(
-        `SMI-6015: --shard-count=<N> must be an integer >= 1, got "${shardCountRaw}".`
+        `SMI-6015: --shard-count=<N> must be an integer between 1 and ${POSTGRES_INTEGER_MAX} ` +
+          `(Postgres integer range), got "${shardCountRaw}".`
       )
     }
     const parsedIndex = Number(shardIndexRaw)

--- a/scripts/indexer/smi5879-simulate-full.db.ts
+++ b/scripts/indexer/smi5879-simulate-full.db.ts
@@ -84,6 +84,42 @@ export function createSmi5879SimulateFullDbDeps(conn: PgConnParams): Smi5879Simu
       })
     },
 
+    // SMI-6015 Wave 1: shard-aware siblings, backed by the Wave 0 migration's
+    // smi5879_claim_run_shard/smi5879_heartbeat_shard/smi5879_release_run_shard.
+    // shardIndex/shardCount are INTEGER SQL params — psql's `-v` mechanism
+    // only carries strings, so each is cast `::integer` after quoting,
+    // matching the pattern the Wave 0 migration's own test suite uses.
+    async claimRunShard(runId, shardIndex, shardCount, token, holder) {
+      const rows = await queryRows(
+        conn,
+        `SELECT run_id FROM smi5879_claim_run_shard(:'run_id', :'shard_index'::integer, :'shard_count'::integer, :'token', :'holder');`,
+        {
+          run_id: runId,
+          shard_index: String(shardIndex),
+          shard_count: String(shardCount),
+          token,
+          holder,
+        }
+      )
+      return { claimed: rows.length > 0 }
+    },
+
+    async heartbeatShard(runId, shardIndex, token) {
+      return queryScalar(
+        conn,
+        `SELECT smi5879_heartbeat_shard(:'run_id', :'shard_index'::integer, :'token');`,
+        { run_id: runId, shard_index: String(shardIndex), token }
+      )
+    },
+
+    async releaseRunShard(runId, shardIndex, token) {
+      await runPsql(
+        conn,
+        `SELECT smi5879_release_run_shard(:'run_id', :'shard_index'::integer, :'token');`,
+        { run_id: runId, shard_index: String(shardIndex), token }
+      )
+    },
+
     async verifyDigest(runId) {
       const rows = await queryRows(
         conn,

--- a/scripts/indexer/smi5879-simulate-full.output.ts
+++ b/scripts/indexer/smi5879-simulate-full.output.ts
@@ -1,0 +1,53 @@
+/**
+ * Console-output helpers for smi5879-simulate-full.ts's CLI entrypoint
+ * (`printSummary`/`dryRun`) — split out per CLAUDE.md's <500-line-per-file
+ * convention (SMI-6015 PAT-sharded fetch plan Wave 1's shard-aware report
+ * path defaulting pushed the combined file over budget). Pure
+ * reporting/pre-flight helpers, called by `main()`, which stays in
+ * smi5879-simulate-full.ts itself — the `import.meta.url ===
+ * file://${process.argv[1]}` entrypoint check depends on `main()` and its
+ * invocation staying in the file operators actually run
+ * (`npx tsx scripts/indexer/smi5879-simulate-full.ts`), so only these two
+ * side helpers move here, not `main()` itself.
+ * @module scripts/indexer/smi5879-simulate-full.output
+ */
+
+import { buildGitHubHeaders } from './_shared/github-auth.ts'
+import { poolerSessionConnParams, runPsql } from './smi5879-census.pg.ts'
+import { assertPatTokenSource } from './smi5879-simulate-full.helpers.ts'
+import { ALL_SIMULATED_COHORTS } from './smi5879-simulate-full.types.ts'
+import type { CliArgs } from './smi5879-simulate-full.cli.ts'
+import type { Smi5879SimulateFullReport } from './smi5879-simulate-full.types.ts'
+
+export function printSummary(report: Smi5879SimulateFullReport): void {
+  console.log(
+    `\n── Simulation Summary (${report.run_id}) ──\n` +
+      `  report_kind:       ${report.report_kind}\n` +
+      `  token_source:      ${report.token_source}\n` +
+      `  baseline_commit:   ${report.baseline_commit}\n` +
+      `  sweep:             ${report.sweep.passes_run} pass(es), hard_stopped=${report.sweep.hard_stopped ?? 'none'}\n` +
+      ALL_SIMULATED_COHORTS.map(
+        (c) =>
+          `  coverage.${c}:       ${report.coverage[c].status} (${report.coverage[c].scanned}/${report.coverage[c].total}, unevaluable=${report.coverage[c].unevaluable}, unfetchable=${report.coverage[c].unfetchable})`
+      ).join('\n') +
+      `\n  counts: ${JSON.stringify(report.counts)}\n`
+  )
+}
+
+export async function dryRun(args: CliArgs): Promise<void> {
+  console.log(
+    `[DRY-RUN] run-id=${args.runId} purpose=${args.purpose} baseline-commit=${args.baselineCommit}`
+  )
+  assertPatTokenSource()
+  const conn = poolerSessionConnParams()
+  await runPsql(conn, 'SELECT 1;')
+  console.log('[DRY-RUN] DB connectivity OK (session pooler).')
+  const headers = await buildGitHubHeaders('skillsmith-smi5879-simulate/1.0')
+  console.log(
+    `[DRY-RUN] GitHub auth headers built (Authorization present: ${'Authorization' in headers}).`
+  )
+  console.log(
+    '[DRY-RUN] No generation claimed, no GitHub fetches performed, no checkpoint/report written. ' +
+      'Re-run with --apply to perform the real simulation.'
+  )
+}

--- a/scripts/indexer/smi5879-simulate-full.shard.ts
+++ b/scripts/indexer/smi5879-simulate-full.shard.ts
@@ -1,0 +1,40 @@
+/**
+ * Row-sharding partition function for smi5879-simulate-full.ts (SMI-6015
+ * Wave 1). Split into its own module rather than added to
+ * smi5879-simulate-full.helpers.ts, which was already at CLAUDE.md's
+ * 500-line-per-file budget before this addition.
+ * @module scripts/indexer/smi5879-simulate-full.shard
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 1. `--shard-index`/`--shard-count` CLI flags")
+ */
+
+/**
+ * FNV-1a 32-bit hash. Pure integer arithmetic (`Math.imul` for the
+ * multiply-with-overflow step) so the result is identical across
+ * processes/platforms/Node versions — required since N independently
+ * dispatched shard processes must agree on partition boundaries without
+ * coordinating. Not a security-sensitive hash; only used for shard
+ * assignment.
+ */
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5 // FNV offset basis (32-bit)
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) // FNV prime (32-bit)
+  }
+  return hash >>> 0 // coerce to unsigned 32-bit before any modulo below
+}
+
+/**
+ * Deterministic, stable partition function: the same `rowId` always maps to
+ * the same shard, independent of row-loading order, process, or invocation
+ * — the property N genuinely-parallel shard processes rely on to agree on
+ * partition boundaries without coordinating (plan §1). `hash` is coerced to
+ * unsigned 32-bit by {@link fnv1a} before the modulo, so the result is
+ * always in `[0, shardCount)` — JavaScript's `%` returns a negative result
+ * for a negative left operand, which an unsigned hash avoids entirely.
+ */
+export function shardOf(rowId: string, shardCount: number): number {
+  return fnv1a(rowId) % shardCount
+}

--- a/scripts/indexer/smi5879-simulate-full.ts
+++ b/scripts/indexer/smi5879-simulate-full.ts
@@ -250,18 +250,29 @@ export async function runSimulateFull(
         ? await db.heartbeatShard(args.runId, shardIndex, token)
         : await db.heartbeat(args.runId, token)
     } catch (err) {
+      // PR #2525 review (GPT-5.6-Sol) High finding: `finally` below can flip
+      // `heartbeatStopped` to true WHILE this call is in flight — clearing the
+      // timer only stops a FUTURE tick, it does not cancel this one. Without
+      // this re-check, a heartbeat that throws/loses its claim in that exact
+      // window would call fatalHeartbeatAbort() -> process.exit(1) on a run
+      // that already completed and is mid-release, discarding the report
+      // `main()` was about to write. Re-checking immediately after the await
+      // (rather than tracking/awaiting the in-flight promise from `finally`)
+      // keeps release from paying an arbitrary extra RPC round trip.
+      if (heartbeatStopped) return
       fatalHeartbeatAbort(
         `heartbeat call threw for run_id=${args.runId}: ${(err as Error).message}`
       )
       return
     }
+    if (heartbeatStopped) return
     if (result === null) {
       fatalHeartbeatAbort(
         `heartbeat lost for run_id=${args.runId}${isSharded ? ` shard ${shardIndex}` : ''} — claim was stolen, the run was abandoned, or (sharded only) the parent run is no longer open/sealed.`
       )
       return
     }
-    if (!heartbeatStopped) scheduleHeartbeat()
+    scheduleHeartbeat()
   }
 
   scheduleHeartbeat()

--- a/scripts/indexer/smi5879-simulate-full.ts
+++ b/scripts/indexer/smi5879-simulate-full.ts
@@ -31,11 +31,19 @@
  * self-checkpoint-and-exit) and `--cohorts=<comma-list>` (cohort-scoped
  * rehearsal dispatches) — see `smi5879-simulate-full.cli.ts` for parsing.
  *
+ * SMI-6015 PAT-sharded fetch plan Wave 1 added `--shard-index=<i>
+ * --shard-count=<N>` (row-level sharding, both-or-neither) so N independent
+ * processes can each fetch a disjoint slice of one decision generation's
+ * population in parallel — see `smi5879-simulate-full.shard.ts`'s `shardOf()`
+ * for the partition function. A sharded dispatch claims via the shard-aware
+ * claim/heartbeat/release trio (Wave 0 migration) instead of the plain
+ * single-holder ones — mutually exclusive per invocation, never both.
+ *
  * Usage:
  *   varlock run -- npx tsx scripts/indexer/smi5879-simulate-full.ts \
  *     --run-id=<sealed generation run_id> --purpose=<decision|window|rehearsal> \
  *     [--apply] [--checkpoint-path=<path>] [--report-path=<path>] [--baseline-commit=<sha>] \
- *     [--max-elapsed-minutes=<N>] [--cohorts=<comma-list>]
+ *     [--max-elapsed-minutes=<N>] [--cohorts=<comma-list>] [--shard-index=<i> --shard-count=<N>]
  */
 
 import { hostname } from 'node:os'
@@ -44,8 +52,9 @@ import { execFileSync } from 'node:child_process'
 import { writeFileSync } from 'node:fs'
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
 import { newRateLimitTelemetry } from './_shared/rate-limit.ts'
-import { poolerSessionConnParams, runPsql } from './smi5879-census.pg.ts'
+import { poolerSessionConnParams } from './smi5879-census.pg.ts'
 import { createSmi5879SimulateFullDbDeps } from './smi5879-simulate-full.db.ts'
+import { printSummary, dryRun } from './smi5879-simulate-full.output.ts'
 import {
   materializeBaseline,
   importBaselineScanSkillBundle,
@@ -66,12 +75,14 @@ import {
 } from './smi5879-simulate-full.sweep.ts'
 import {
   checkpointPathFor,
+  checkpointPathForShard,
   readCheckpoint,
   writeCheckpoint,
   isAbnormalResume,
   assertCheckpointIdentity,
   assertCheckpointRowsBelongToGeneration,
 } from './smi5879-simulate-full.checkpoint.ts'
+import { shardOf } from './smi5879-simulate-full.shard.ts'
 import { ALL_SIMULATED_COHORTS } from './smi5879-simulate-full.types.ts'
 import type {
   Smi5879SimulateFullDbDeps,
@@ -130,7 +141,18 @@ export async function runSimulateFull(
   // checkpoint identity/coverage code never has to special-case "omitted."
   const cohorts: SimulatedCohort[] = args.cohorts ?? [...ALL_SIMULATED_COHORTS]
 
-  const checkpointPath = args.checkpointPath ?? checkpointPathFor(args.runId)
+  // SMI-6015 PAT-sharded fetch plan Wave 1: `shardIndex`/`shardCount` are
+  // destructured to LOCAL consts (not read off `args` at each use site) so
+  // TypeScript's narrowing from `isSharded`'s both-defined check holds
+  // reliably everywhere they're used below, including inside closures
+  // (the heartbeat tick, the release-on-exit path) — narrowing a `const`
+  // local survives closure capture; narrowing an object property does not.
+  const { shardIndex, shardCount } = args
+  const isSharded = shardIndex !== undefined && shardCount !== undefined
+
+  const checkpointPath =
+    args.checkpointPath ??
+    (isSharded ? checkpointPathForShard(args.runId, shardIndex) : checkpointPathFor(args.runId))
   const existingCheckpoint = readCheckpoint(checkpointPath)
   const isColdStart = existingCheckpoint === null
 
@@ -141,7 +163,7 @@ export async function runSimulateFull(
     // trusted (SMI-5879 review finding 1).
     assertCheckpointIdentity(
       existingCheckpoint,
-      { runId: args.runId, purpose: args.purpose, tokenSource, cohorts },
+      { runId: args.runId, purpose: args.purpose, tokenSource, cohorts, shardIndex, shardCount },
       checkpointPath
     )
     if (existingCheckpoint.baseline_commit !== args.baselineCommit) {
@@ -155,10 +177,19 @@ export async function runSimulateFull(
 
   const token = randomUUID()
   const holder = buildHolder()
-  const claimed = await db.claimRun(args.runId, token, holder)
+  // SMI-6015 PAT-sharded fetch plan Wave 0 Files: mutually exclusive claim
+  // paths — a sharded dispatch claims via smi5879_claim_run_shard (holds an
+  // independent per-shard claim, protected from the parent run's own
+  // smi5879_abandon_unclaimed_run by the Wave 0 migration's C1 fix), never
+  // the plain single-holder smi5879_claim_run.
+  const claimed = isSharded
+    ? await db.claimRunShard(args.runId, shardIndex, shardCount, token, holder)
+    : await db.claimRun(args.runId, token, holder)
   if (!claimed.claimed) {
     throw new Error(
-      `SMI-5879: claim of generation ${args.runId} was refused — held by another runner.`
+      isSharded
+        ? `SMI-5879: claim of generation ${args.runId} shard ${shardIndex}/${shardCount} was refused — held by another runner.`
+        : `SMI-5879: claim of generation ${args.runId} was refused — held by another runner.`
     )
   }
 
@@ -177,6 +208,7 @@ export async function runSimulateFull(
     baseline_commit: args.baselineCommit,
     token_source: tokenSource,
     cohorts,
+    ...(isSharded ? { shard_index: shardIndex, shard_count: shardCount } : {}),
     clean_shutdown: false,
     row_results: {},
     sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -214,7 +246,9 @@ export async function runSimulateFull(
     if (heartbeatStopped) return
     let result: string | null
     try {
-      result = await db.heartbeat(args.runId, token)
+      result = isSharded
+        ? await db.heartbeatShard(args.runId, shardIndex, token)
+        : await db.heartbeat(args.runId, token)
     } catch (err) {
       fatalHeartbeatAbort(
         `heartbeat call threw for run_id=${args.runId}: ${(err as Error).message}`
@@ -223,7 +257,7 @@ export async function runSimulateFull(
     }
     if (result === null) {
       fatalHeartbeatAbort(
-        `heartbeat lost for run_id=${args.runId} — claim was stolen or the run was abandoned.`
+        `heartbeat lost for run_id=${args.runId}${isSharded ? ` shard ${shardIndex}` : ''} — claim was stolen, the run was abandoned, or (sharded only) the parent run is no longer open/sealed.`
       )
       return
     }
@@ -252,7 +286,11 @@ export async function runSimulateFull(
       // Must run only after the real row set for this generation is loaded
       // (SMI-5879 review finding 1) — refuses a checkpoint whose row_results
       // keys don't correspond to any row in THIS generation.
-      assertCheckpointRowsBelongToGeneration(existingCheckpoint, rows, checkpointPath)
+      assertCheckpointRowsBelongToGeneration(existingCheckpoint, rows, checkpointPath, {
+        cohorts,
+        shardIndex,
+        shardCount,
+      })
     }
     const branchMap = await db.loadBranchMap(args.runId)
     // SMI-6015 Wave 1 correctness guard-rail: `rowsByCohort` stays built
@@ -264,8 +302,16 @@ export async function runSimulateFull(
       SimSnapshotRow[]
     >
     for (const row of rows) rowsByCohort[row.cohort].push(row)
-    const rowsForMainPass =
+    const cohortFilteredRows =
       args.cohorts !== undefined ? rows.filter((r) => cohorts.includes(r.cohort)) : rows
+    // SMI-6015 PAT-sharded fetch plan §1: applied ALONGSIDE (not replacing)
+    // the cohort filter above — a row is processed by THIS invocation iff
+    // shardOf(row.id) === shardIndex. `rowsByCohort`'s own `.total` stays
+    // unaffected by sharding for the same reason it already stays unaffected
+    // by --cohorts (comment above): only `rowsForMainPass` is filtered.
+    const rowsForMainPass = isSharded
+      ? cohortFilteredRows.filter((r) => shardOf(r.id, shardCount) === shardIndex)
+      : cohortFilteredRows
 
     const telemetry = newRateLimitTelemetry()
     // SMI-6015: getHeaders is invoked fresh on every fetch attempt (inside
@@ -383,44 +429,16 @@ export async function runSimulateFull(
   } finally {
     heartbeatStopped = true
     if (heartbeatTimer) clearTimeout(heartbeatTimer)
-    await db.releaseRun(args.runId, token).catch((err) => {
+    const release = isSharded
+      ? db.releaseRunShard(args.runId, shardIndex, token)
+      : db.releaseRun(args.runId, token)
+    await release.catch((err) => {
       console.error(`[smi5879-simulate-full] release failed (non-fatal): ${(err as Error).message}`)
     })
   }
 }
 
-function printSummary(report: Smi5879SimulateFullReport): void {
-  console.log(
-    `\n── Simulation Summary (${report.run_id}) ──\n` +
-      `  report_kind:       ${report.report_kind}\n` +
-      `  token_source:      ${report.token_source}\n` +
-      `  baseline_commit:   ${report.baseline_commit}\n` +
-      `  sweep:             ${report.sweep.passes_run} pass(es), hard_stopped=${report.sweep.hard_stopped ?? 'none'}\n` +
-      ALL_SIMULATED_COHORTS.map(
-        (c) =>
-          `  coverage.${c}:       ${report.coverage[c].status} (${report.coverage[c].scanned}/${report.coverage[c].total}, unevaluable=${report.coverage[c].unevaluable}, unfetchable=${report.coverage[c].unfetchable})`
-      ).join('\n') +
-      `\n  counts: ${JSON.stringify(report.counts)}\n`
-  )
-}
-
-async function dryRun(args: CliArgs): Promise<void> {
-  console.log(
-    `[DRY-RUN] run-id=${args.runId} purpose=${args.purpose} baseline-commit=${args.baselineCommit}`
-  )
-  assertPatTokenSource()
-  const conn = poolerSessionConnParams()
-  await runPsql(conn, 'SELECT 1;')
-  console.log('[DRY-RUN] DB connectivity OK (session pooler).')
-  const headers = await buildGitHubHeaders('skillsmith-smi5879-simulate/1.0')
-  console.log(
-    `[DRY-RUN] GitHub auth headers built (Authorization present: ${'Authorization' in headers}).`
-  )
-  console.log(
-    '[DRY-RUN] No generation claimed, no GitHub fetches performed, no checkpoint/report written. ' +
-      'Re-run with --apply to perform the real simulation.'
-  )
-}
+// printSummary/dryRun live in smi5879-simulate-full.output.ts (500-line budget)
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
@@ -434,7 +452,16 @@ async function main(): Promise<void> {
   const { scanSkillBundle: scanPrePort } = await importBaselineScanSkillBundle(baselineDir)
 
   const report = await runSimulateFull(db, headScanSkillBundle, scanPrePort, args)
-  const reportPath = args.reportPath ?? `smi5879-simulate-report-${args.runId}.json`
+  // SMI-6015 PAT-sharded fetch plan Wave 1 (round-1 GPT-5.6-Sol review,
+  // Medium finding): without a shard-aware default, N shards run without an
+  // explicit --report-path would all default to the SAME file — concurrent
+  // overwrites, or silently losing every shard's report but the last one to
+  // finish. Mirrors checkpointPathForShard's own naming convention.
+  const reportPath =
+    args.reportPath ??
+    (args.shardIndex !== undefined
+      ? `smi5879-simulate-report-${args.runId}-shard${args.shardIndex}.json`
+      : `smi5879-simulate-report-${args.runId}.json`)
   writeFileSync(reportPath, JSON.stringify(report, null, 2))
   printSummary(report)
   console.log(`Report written to ${reportPath}`)

--- a/scripts/indexer/smi5879-simulate-full.types.ts
+++ b/scripts/indexer/smi5879-simulate-full.types.ts
@@ -145,6 +145,17 @@ export interface Smi5879SimulateCheckpoint {
    * a full-population run, or vice versa.
    */
   cohorts: SimulatedCohort[]
+  /**
+   * SMI-6015 Wave 1 (PAT-sharded fetch plan §2): this run's shard assignment,
+   * or both undefined for an unsharded run — always the explicit pair when
+   * present (never one without the other; `assertValidCheckpointShape`
+   * enforces this), so a resume that changes shard assignment, or crosses
+   * between sharded and unsharded, is refused loudly rather than silently
+   * corrupting that shard's row assignment (the same class of guard the
+   * existing `cohorts` field provides).
+   */
+  shard_index?: number
+  shard_count?: number
   /** True only immediately before a graceful exit; false at every interim write. */
   clean_shutdown: boolean
   /** Per-row outcomes recorded so far (main pass + all sweep passes), keyed by row id. */
@@ -195,6 +206,23 @@ export interface Smi5879SimulateFullDbDeps {
   /** Returns the new heartbeat timestamp, or null when the claim was lost (fatal — see design 8.3.5.2.5). */
   heartbeat(runId: string, token: string): Promise<string | null>
   releaseRun(runId: string, token: string): Promise<void>
+  /**
+   * SMI-6015 Wave 1: shard-aware sibling of {@link claimRun}, backed by
+   * `smi5879_claim_run_shard` (Wave 0 migration). Mutually exclusive with
+   * `claimRun`/`heartbeat`/`releaseRun` per invocation — a dispatch is
+   * either sharded or not, never both claim paths (plan §Wave 0 Files).
+   */
+  claimRunShard(
+    runId: string,
+    shardIndex: number,
+    shardCount: number,
+    token: string,
+    holder: string
+  ): Promise<{ claimed: boolean }>
+  /** Shard-aware sibling of {@link heartbeat}, backed by `smi5879_heartbeat_shard`. */
+  heartbeatShard(runId: string, shardIndex: number, token: string): Promise<string | null>
+  /** Shard-aware sibling of {@link releaseRun}, backed by `smi5879_release_run_shard`. */
+  releaseRunShard(runId: string, shardIndex: number, token: string): Promise<void>
   /** Recomputes and compares both digests against the sealed values recorded at seal time. */
   verifyDigest(runId: string): Promise<{ populationMatches: boolean; branchMatches: boolean }>
   loadCohortRows(runId: string): Promise<SimSnapshotRow[]>

--- a/scripts/tests/indexer/smi5879-simulate-full.checkpoint-row-scope.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.checkpoint-row-scope.test.ts
@@ -1,0 +1,187 @@
+/**
+ * SMI-6015 PAT-sharded fetch plan Wave 1 (round-1 GPT-5.6-Sol review, High
+ * finding): `assertCheckpointRowsBelongToGeneration` extended to validate
+ * every `row_results` entry against the invocation's declared shard/cohort
+ * scope, not just generation membership. A structurally valid checkpoint
+ * could otherwise declare `shard_index: 1` while its `row_results` (hand-
+ * edited, corrupted, or produced by a future bug) actually contains
+ * shard-0 or excluded-cohort rows — resume would silently accept them,
+ * contaminating that shard's report and breaking the row-id-disjointness
+ * invariant Wave 2's merge tool depends on.
+ * @module scripts/tests/indexer/smi5879-simulate-full.checkpoint-row-scope
+ */
+
+import { describe, it, expect } from 'vitest'
+import { assertCheckpointRowsBelongToGeneration } from '../../indexer/smi5879-simulate-full.checkpoint.ts'
+import { shardOf } from '../../indexer/smi5879-simulate-full.shard.ts'
+import type {
+  SimSnapshotRow,
+  SimRowResult,
+  Smi5879SimulateCheckpoint,
+} from '../../indexer/smi5879-simulate-full.types.ts'
+
+function baseCheckpoint(rowResults: Record<string, SimRowResult>): Smi5879SimulateCheckpoint {
+  return {
+    run_id: 'run-1',
+    purpose: 'decision',
+    baseline_commit: 'abc123',
+    token_source: 'pat',
+    cohorts: ['C1', 'C2', 'C3', 'C4'],
+    clean_shutdown: true,
+    row_results: rowResults,
+    sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+}
+
+function row(id: string, cohort: SimSnapshotRow['cohort'] = 'C2'): SimSnapshotRow {
+  return {
+    id,
+    cohort,
+    repo_url: `https://github.com/acme/${id}`,
+    skill_path: null,
+    author: 'acme',
+    name: id,
+    content_hash: null,
+    snapshot_security_score: null,
+    snapshot_quarantined: null,
+  }
+}
+
+function result(
+  id: string,
+  cohort: SimRowResult['cohort'] = 'C2',
+  overrides: Partial<Pick<SimRowResult, 'author' | 'name'>> = {}
+): SimRowResult {
+  // author/name default to MATCH row()'s own defaults ('acme'/id) — a
+  // real processRow() output always copies these from the canonical row
+  // (helpers.ts), so a mismatched default here would make every ordinary
+  // valid-resume test in this file fail once author/name are cross-checked
+  // (round-3 review Medium finding) — override explicitly to test a
+  // genuine mismatch.
+  return { id, cohort, author: 'acme', name: id, outcome: 'unchanged_clean', ...overrides }
+}
+
+describe('assertCheckpointRowsBelongToGeneration — shard/cohort scope', () => {
+  it('accepts a checkpoint whose rows genuinely belong to this shard and cohort scope', () => {
+    // Find a real row id that hashes to shard 0 of 3, so the test is a
+    // genuine positive case rather than an accidental pass.
+    let id = 'seed-0'
+    for (let i = 0; shardOf(id, 3) !== 0; i++) id = `seed-${i}`
+    const rows = [row(id)]
+    const checkpoint = baseCheckpoint({ [id]: result(id) })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3', 'C4'],
+        shardIndex: 0,
+        shardCount: 3,
+      })
+    ).not.toThrow()
+  })
+
+  it('accepts an unsharded checkpoint with no shard scope supplied', () => {
+    const rows = [row('row-1')]
+    const checkpoint = baseCheckpoint({ 'row-1': result('row-1') })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3', 'C4'],
+      })
+    ).not.toThrow()
+  })
+
+  it('refuses a row_results entry belonging to a DIFFERENT shard than declared', () => {
+    // Find two ids that hash to different shards of 3.
+    let idInShard0 = 'seed-0'
+    for (let i = 0; shardOf(idInShard0, 3) !== 0; i++) idInShard0 = `seed-${i}`
+    let idInShard1 = 'seed-0'
+    for (let i = 0; shardOf(idInShard1, 3) !== 1; i++) idInShard1 = `seed-${i}`
+
+    const rows = [row(idInShard0), row(idInShard1)]
+    // Checkpoint claims to be shard 0, but contains a shard-1 row's result —
+    // the exact contamination scenario the fix closes.
+    const checkpoint = baseCheckpoint({ [idInShard1]: result(idInShard1) })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3', 'C4'],
+        shardIndex: 0,
+        shardCount: 3,
+      })
+    ).toThrow(new RegExp(`${idInShard1}.*belongs to shard 1, not this shard 0`))
+  })
+
+  it('refuses a row_results entry outside the declared cohort scope', () => {
+    const rows = [row('c4-row', 'C4')]
+    const checkpoint = baseCheckpoint({ 'c4-row': result('c4-row', 'C4') })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3'], // C4 excluded
+      })
+    ).toThrow(/c4-row.*cohort C4 outside this run's cohort scope/)
+  })
+
+  it("refuses a row_results entry whose STORED result.cohort disagrees with the row's real (canonical) cohort — round-2 review High finding", () => {
+    // A real C2 row, matching result.id, but the stored result claims a
+    // DIFFERENT cohort (C4) than the canonical row actually has. This is
+    // exactly the malformed-but-shape-valid entry that would otherwise
+    // survive into report.rows/counts untouched, since those are built
+    // from the stored results directly, not re-derived from the canonical
+    // row set.
+    const rows = [row('c2-row', 'C2')]
+    const checkpoint = baseCheckpoint({ 'c2-row': result('c2-row', 'C4') })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3', 'C4'], // both C2 and C4 are in-scope — this must still fail
+      })
+    ).toThrow(/c2-row.*stored result\.cohort=C4 does not match this row's real cohort=C2/)
+  })
+
+  it("refuses a row_results entry whose STORED result.author/name disagrees with the row's real (canonical) values — round-3 review Medium finding", () => {
+    // Same class of gap as cohort above: author/name are informational,
+    // not gate-relevant, but processRow() always copies them from the
+    // canonical row — a stored value that disagrees is still a malformed
+    // entry that would otherwise misattribute a row in report.rows.
+    const rows = [row('mismatch-row')] // row()'s real author='acme', name='mismatch-row'
+    const checkpoint = baseCheckpoint({
+      'mismatch-row': result('mismatch-row', 'C2', { author: 'someone-else' }),
+    })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3', 'C4'],
+      })
+    ).toThrow(/does not match this row's real author\/name=acme\/mismatch-row/)
+  })
+
+  it("refuses a row_results entry whose key doesn't match its own stored result.id (corrupted entry)", () => {
+    const rows = [row('row-1'), row('row-2')]
+    // Stored under key "row-1" but the result object itself claims id "row-2".
+    const checkpoint = baseCheckpoint({ 'row-1': result('row-2') })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3', 'C4'],
+      })
+    ).toThrow(/row-1.*does not match its own result\.id=row-2/)
+  })
+
+  it('reports multiple problems together, capped at 5 shown', () => {
+    const rows = [row('c4-a', 'C4'), row('c4-b', 'C4'), row('c4-c', 'C4')]
+    const checkpoint = baseCheckpoint({
+      'c4-a': result('c4-a', 'C4'),
+      'c4-b': result('c4-b', 'C4'),
+      'c4-c': result('c4-c', 'C4'),
+    })
+
+    expect(() =>
+      assertCheckpointRowsBelongToGeneration(checkpoint, rows, 'path', {
+        cohorts: ['C1', 'C2', 'C3'],
+      })
+    ).toThrow(/3 row_results entries that don't belong/)
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.checkpoint.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.checkpoint.test.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
   checkpointPathFor,
+  checkpointPathForShard,
   readCheckpoint,
   writeCheckpoint,
   isAbnormalResume,
@@ -150,6 +151,77 @@ describe('checkpoint I/O', () => {
   })
 
   // -------------------------------------------------------------------------
+  // SMI-6015 PAT-sharded fetch plan Wave 1: shard_index/shard_count shape
+  // validation — both-or-neither, and a valid (index, count) pair when present.
+  // -------------------------------------------------------------------------
+
+  it.each([
+    ['shard_index without shard_count', { shard_index: 0 }],
+    ['shard_count without shard_index', { shard_count: 3 }],
+    ['shard_index out of bounds', { shard_index: 3, shard_count: 3 }],
+    ['negative shard_index', { shard_index: -1, shard_count: 3 }],
+    ['non-integer shard_count', { shard_index: 0, shard_count: 1.5 }],
+    ['shard_count < 1', { shard_index: 0, shard_count: 0 }],
+  ])('readCheckpoint rejects a checkpoint with %s', (_label, extra) => {
+    const path = join(dir, 'bad-shard.json')
+    const raw: Record<string, unknown> = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      ...extra,
+    }
+    writeFileSync(path, JSON.stringify(raw))
+    expect(() => readCheckpoint(path)).toThrow(/shard_index=.*shard_count=/)
+  })
+
+  it('round-trips a checkpoint with a valid shard_index/shard_count pair', () => {
+    const path = join(dir, 'sharded-ckpt.json')
+    const checkpoint: Smi5879SimulateCheckpoint = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
+      shard_index: 1,
+      shard_count: 3,
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(path, checkpoint)
+    expect(readCheckpoint(path)).toEqual(checkpoint)
+  })
+
+  it('an unsharded checkpoint (no shard_index/shard_count at all) is still valid', () => {
+    const path = join(dir, 'unsharded-ckpt.json')
+    const checkpoint: Smi5879SimulateCheckpoint = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(path, checkpoint)
+    const loaded = readCheckpoint(path)
+    expect(loaded?.shard_index).toBeUndefined()
+    expect(loaded?.shard_count).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
   // SMI-5879 review finding 3: a corrupted checkpoint file is NOT the same
   // as "no checkpoint" (cold start) — it must fail loudly, since real
   // progress may have been lost, not be silently treated as absent.
@@ -229,6 +301,141 @@ describe('checkpoint I/O', () => {
           'path'
         )
       ).toThrow(/cohorts \(checkpoint=C1,C2,C3,C4, this run=C4\)/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // SMI-6015 PAT-sharded fetch plan Wave 1 Step 3: assertCheckpointIdentity's
+  // shard comparison, and checkpointPathForShard/parseShardIndexFromPath.
+  // Test spec per the plan: resuming shard 1 against a checkpoint written as
+  // shard 2 is refused loudly; resuming shard 1-of-3 against a checkpoint
+  // written as shard 1-of-4 is refused loudly.
+  // -------------------------------------------------------------------------
+
+  describe('assertCheckpointIdentity — shard', () => {
+    function shardCheckpoint(
+      shardIndex: number | undefined,
+      shardCount: number | undefined
+    ): Smi5879SimulateCheckpoint {
+      return {
+        run_id: 'run-1',
+        purpose: 'decision',
+        baseline_commit: 'abc123',
+        token_source: 'pat',
+        cohorts: ['C1', 'C2', 'C3', 'C4'],
+        ...(shardIndex !== undefined ? { shard_index: shardIndex } : {}),
+        ...(shardCount !== undefined ? { shard_count: shardCount } : {}),
+        clean_shutdown: true,
+        row_results: {},
+        sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+        started_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+    }
+    const BASE_EXPECTED = { runId: 'run-1', purpose: 'decision', tokenSource: 'pat' } as const
+
+    it('accepts a matching shard index/count', () => {
+      const checkpoint = shardCheckpoint(1, 3)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 1, shardCount: 3 },
+          'some-path.json'
+        )
+      ).not.toThrow()
+    })
+
+    it('refuses resuming shard 1 against a checkpoint written as shard 2 (same shard_count)', () => {
+      const checkpoint = shardCheckpoint(2, 3)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 1, shardCount: 3 },
+          'some-path.json'
+        )
+      ).toThrow(/shard \(checkpoint=index 2\/count 3, this run=index 1\/count 3\)/)
+    })
+
+    it('refuses resuming shard 1-of-3 against a checkpoint written as shard 1-of-4', () => {
+      const checkpoint = shardCheckpoint(1, 4)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 1, shardCount: 3 },
+          'some-path.json'
+        )
+      ).toThrow(/shard \(checkpoint=index 1\/count 4, this run=index 1\/count 3\)/)
+    })
+
+    it('refuses resuming an UNSHARDED checkpoint as if it were sharded', () => {
+      const checkpoint = shardCheckpoint(undefined, undefined)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 0, shardCount: 3 },
+          'some-path.json'
+        )
+      ).toThrow(
+        /shard \(checkpoint=index \(unsharded\)\/count \(unsharded\), this run=index 0\/count 3\)/
+      )
+    })
+
+    it('refuses resuming a SHARDED checkpoint as if it were unsharded', () => {
+      const checkpoint = shardCheckpoint(0, 3)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'] },
+          'some-path.json'
+        )
+      ).toThrow(
+        /shard \(checkpoint=index 0\/count 3, this run=index \(unsharded\)\/count \(unsharded\)\)/
+      )
+    })
+
+    it('refuses a --checkpoint-path whose embedded shard index disagrees with the checkpoint content (copy/rename mistake)', () => {
+      // Flag (shardIndex=2) and checkpoint content (shard_index=2) AGREE with
+      // each other, but the PATH implies shard 1 — the exact compounding
+      // mistake the path-embedded cross-check exists to catch, which the
+      // flag-vs-content check above cannot (both already agree).
+      const checkpoint = shardCheckpoint(2, 3)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 2, shardCount: 3 },
+          checkpointPathForShard('run-1', 1)
+        )
+      ).toThrow(/shard index embedded in --checkpoint-path \(1\) does not match/)
+    })
+
+    it('accepts a --checkpoint-path whose embedded shard index matches the checkpoint content', () => {
+      const checkpoint = shardCheckpoint(1, 3)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 1, shardCount: 3 },
+          checkpointPathForShard('run-1', 1)
+        )
+      ).not.toThrow()
+    })
+
+    it('skips the path-embedded cross-check entirely for a non-canonical custom path', () => {
+      const checkpoint = shardCheckpoint(1, 3)
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { ...BASE_EXPECTED, cohorts: ['C1', 'C2', 'C3', 'C4'], shardIndex: 1, shardCount: 3 },
+          'my-custom-checkpoint-name.json'
+        )
+      ).not.toThrow()
+    })
+  })
+
+  describe('checkpointPathForShard', () => {
+    it('is deterministic per (run_id, shard_index) and distinct from checkpointPathFor', () => {
+      expect(checkpointPathForShard('run-a', 0)).toBe(checkpointPathForShard('run-a', 0))
+      expect(checkpointPathForShard('run-a', 0)).not.toBe(checkpointPathForShard('run-a', 1))
+      expect(checkpointPathForShard('run-a', 0)).not.toBe(checkpointPathFor('run-a'))
     })
   })
 })

--- a/scripts/tests/indexer/smi5879-simulate-full.cli.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.cli.test.ts
@@ -142,6 +142,24 @@ describe('parseArgs', () => {
     )
   })
 
+  // ---------------------------------------------------------------------
+  // PR #2525 review (GPT-5.6-Sol) Low finding: the DB adapter casts
+  // --shard-count to Postgres ::integer — a value that passes the
+  // integer/positivity check here but exceeds that range would otherwise
+  // fail opaquely at claim time instead of at parse time.
+  // ---------------------------------------------------------------------
+
+  it('rejects --shard-count above the Postgres integer range', () => {
+    expect(() => parseArgs([...REQUIRED, '--shard-index=0', '--shard-count=2147483648'])).toThrow(
+      /--shard-count/
+    )
+  })
+
+  it('accepts --shard-count exactly at the Postgres integer max', () => {
+    const args = parseArgs([...REQUIRED, '--shard-index=0', '--shard-count=2147483647'])
+    expect(args.shardCount).toBe(2147483647)
+  })
+
   it('--shard-index/--shard-count are undefined when omitted', () => {
     const args = parseArgs(REQUIRED)
     expect(args.shardIndex).toBeUndefined()

--- a/scripts/tests/indexer/smi5879-simulate-full.cli.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.cli.test.ts
@@ -92,4 +92,72 @@ describe('parseArgs', () => {
     const args = parseArgs(['--run-id=run-1', '--purpose=window', '--cohorts=C1,C2'])
     expect(args.cohorts).toEqual(['C1', 'C2'])
   })
+
+  // ---------------------------------------------------------------------
+  // SMI-6015 PAT-sharded fetch plan Wave 1: --shard-index/--shard-count
+  // ---------------------------------------------------------------------
+
+  it('parses a valid --shard-index/--shard-count pair', () => {
+    const args = parseArgs([...REQUIRED, '--shard-index=1', '--shard-count=3'])
+    expect(args.shardIndex).toBe(1)
+    expect(args.shardCount).toBe(3)
+  })
+
+  it('rejects --shard-index without --shard-count', () => {
+    expect(() => parseArgs([...REQUIRED, '--shard-index=0'])).toThrow(
+      /--shard-index and --shard-count must both be present/
+    )
+  })
+
+  it('rejects --shard-count without --shard-index', () => {
+    expect(() => parseArgs([...REQUIRED, '--shard-count=3'])).toThrow(
+      /--shard-index and --shard-count must both be present/
+    )
+  })
+
+  it.each(['0', '-1', '1.5', 'not-a-number'])('rejects an invalid --shard-count=%s', (bad) => {
+    expect(() => parseArgs([...REQUIRED, `--shard-index=0`, `--shard-count=${bad}`])).toThrow(
+      /--shard-count/
+    )
+  })
+
+  it.each(['-1', '3', '1.5', 'not-a-number'])(
+    'rejects --shard-index=%s out of [0, shard-count) bounds',
+    (bad) => {
+      expect(() => parseArgs([...REQUIRED, `--shard-index=${bad}`, '--shard-count=3'])).toThrow(
+        /--shard-index/
+      )
+    }
+  )
+
+  it('--shard-count=1 --shard-index=0 is a valid degenerate no-op single-shard run', () => {
+    const args = parseArgs([...REQUIRED, '--shard-index=0', '--shard-count=1'])
+    expect(args.shardIndex).toBe(0)
+    expect(args.shardCount).toBe(1)
+  })
+
+  it('rejects --shard-count=1 with any --shard-index other than 0', () => {
+    expect(() => parseArgs([...REQUIRED, '--shard-index=1', '--shard-count=1'])).toThrow(
+      /--shard-index/
+    )
+  })
+
+  it('--shard-index/--shard-count are undefined when omitted', () => {
+    const args = parseArgs(REQUIRED)
+    expect(args.shardIndex).toBeUndefined()
+    expect(args.shardCount).toBeUndefined()
+  })
+
+  it('--shard-index/--shard-count compose with --cohorts (row-level, orthogonal to cohort scope)', () => {
+    const args = parseArgs([
+      '--run-id=run-1',
+      '--purpose=rehearsal',
+      '--cohorts=C4',
+      '--shard-index=0',
+      '--shard-count=3',
+    ])
+    expect(args.cohorts).toEqual(['C4'])
+    expect(args.shardIndex).toBe(0)
+    expect(args.shardCount).toBe(3)
+  })
 })

--- a/scripts/tests/indexer/smi5879-simulate-full.fixtures.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.fixtures.ts
@@ -147,6 +147,16 @@ export function makeFakeDb(
       return new Date().toISOString()
     },
     async releaseRun() {},
+    // SMI-6015 Wave 1: shard-aware siblings, default to the same trivially-
+    // successful behavior as their unsharded counterparts above — sharding-
+    // specific tests override these via `overrides`.
+    async claimRunShard() {
+      return { claimed: true }
+    },
+    async heartbeatShard() {
+      return new Date().toISOString()
+    },
+    async releaseRunShard() {},
     async verifyDigest() {
       return { populationMatches: true, branchMatches: true }
     },

--- a/scripts/tests/indexer/smi5879-simulate-full.shard-integration.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.shard-integration.test.ts
@@ -350,5 +350,52 @@ describe('runSimulateFull — SMI-6015 PAT-sharded fetch plan Wave 1', () => {
       await runPromise
       exitSpy.mockRestore()
     })
+
+    // -----------------------------------------------------------------------
+    // PR #2525 review (GPT-5.6-Sol) High finding: same race as the unsharded
+    // twin in smi5879-simulate-full.test.ts — an in-flight heartbeatShard
+    // call that resolves null AFTER release must not abort a completed run.
+    // -----------------------------------------------------------------------
+
+    it('an in-flight heartbeatShard that resolves null AFTER the run has already completed and released must not abort the process', async () => {
+      vi.useFakeTimers()
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined as never) as typeof process.exit)
+
+      let resolveDigest: (v: {
+        populationMatches: boolean
+        branchMatches: boolean
+      }) => void = () => {}
+      const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+        (resolve) => {
+          resolveDigest = resolve
+        }
+      )
+      let resolveHeartbeatShard: (v: string | null) => void = () => {}
+      const heartbeatShardPromise = new Promise<string | null>((resolve) => {
+        resolveHeartbeatShard = resolve
+      })
+      const heartbeatShard = vi.fn().mockReturnValue(heartbeatShardPromise)
+      const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeatShard })
+      const scanner = makeVerdictScanner(new Map())
+      const args = shardArgs({ shardIndex: 0, shardCount: 3 })
+
+      const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+      await flushMicrotasks()
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+      expect(heartbeatShard).toHaveBeenCalledTimes(1) // tick fired, now in flight
+
+      resolveDigest({ populationMatches: true, branchMatches: true })
+      const report = await runPromise
+      expect(report.report_kind).toBe('full_simulation')
+      expect(exitSpy).not.toHaveBeenCalled()
+
+      resolveHeartbeatShard(null)
+      await flushMicrotasks()
+
+      expect(exitSpy).not.toHaveBeenCalled()
+      exitSpy.mockRestore()
+    })
   })
 })

--- a/scripts/tests/indexer/smi5879-simulate-full.shard-integration.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.shard-integration.test.ts
@@ -1,0 +1,354 @@
+/**
+ * SMI-6015 PAT-sharded fetch plan Wave 1 Step 2/claim-wiring:
+ * `runSimulateFull` end-to-end with `--shard-index`/`--shard-count` —
+ * row-selection filter coverage (Step 2's own test spec: 3 shards against a
+ * fixed synthetic population, union of processed-row-id sets equals the
+ * full population with zero overlap) and the mutually-exclusive claim-path
+ * wiring (plan's Wave 0 Files note: a sharded dispatch calls the
+ * shard-aware claim/heartbeat/release trio instead of the plain
+ * single-holder ones).
+ * @module scripts/tests/indexer/smi5879-simulate-full.shard-integration
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readCheckpoint } from '../../indexer/smi5879-simulate-full.checkpoint.ts'
+import { HEARTBEAT_INTERVAL_MS } from '../../indexer/smi5879-simulate-full.helpers.ts'
+import { runSimulateFull, type CliArgs } from '../../indexer/smi5879-simulate-full.ts'
+import type { SimSnapshotRow } from '../../indexer/smi5879-simulate-full.types.ts'
+import {
+  makeRow,
+  makeFakeDb,
+  makeVerdictScanner,
+  registerPrimary,
+  contentsApiResponse,
+  resetRowCounter,
+  installFetchMock,
+  restoreFetchMock,
+  flushMicrotasks,
+} from './smi5879-simulate-full.fixtures.ts'
+
+beforeEach(() => {
+  resetRowCounter()
+  installFetchMock()
+})
+
+afterEach(() => {
+  restoreFetchMock()
+})
+
+describe('runSimulateFull — SMI-6015 PAT-sharded fetch plan Wave 1', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smi5879-sim-shard-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function shardArgs(overrides: Partial<CliArgs> = {}): CliArgs {
+    return {
+      runId: 'run-shard',
+      purpose: 'decision',
+      apply: true,
+      baselineCommit: 'deadbeef',
+      checkpointPath: join(dir, 'checkpoint.json'),
+      reportPath: join(dir, 'report.json'),
+      ...overrides,
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Wave 1 Step 2 test spec: 3 shards against a fixed synthetic population,
+  // union of the 3 shards' processed-row-id sets equals the full population
+  // with zero overlap.
+  // -------------------------------------------------------------------------
+
+  it('3 shards partition a fixed population with zero overlap and full coverage', async () => {
+    const rows: SimSnapshotRow[] = Array.from({ length: 30 }, () => makeRow({ cohort: 'C2' }))
+    for (const row of rows) {
+      // Single-element response array is reusable across all 3 shard runs
+      // below (installFetchMock's queue only shifts when length > 1).
+      registerPrimary(row, [contentsApiResponse(`# ${row.id}`)])
+    }
+    const scanner = makeVerdictScanner(new Map())
+    const shardIdSets: Set<string>[] = []
+
+    for (let shardIndex = 0; shardIndex < 3; shardIndex++) {
+      const db = makeFakeDb({ loadCohortRows: async () => rows })
+      const args = shardArgs({
+        checkpointPath: join(dir, `checkpoint-shard${shardIndex}.json`),
+        reportPath: join(dir, `report-shard${shardIndex}.json`),
+        shardIndex,
+        shardCount: 3,
+      })
+      const report = await runSimulateFull(db, scanner, scanner, args, {})
+      shardIdSets.push(new Set(report.rows.map((r) => r.id)))
+    }
+
+    // Zero overlap: no row id appears in more than one shard's set.
+    for (let i = 0; i < shardIdSets.length; i++) {
+      for (let j = i + 1; j < shardIdSets.length; j++) {
+        const overlap = [...shardIdSets[i]].filter((id) => shardIdSets[j].has(id))
+        expect(overlap).toEqual([])
+      }
+    }
+
+    // Full coverage: the union of all 3 shards' processed rows equals the
+    // full population.
+    const union = new Set<string>()
+    for (const set of shardIdSets) for (const id of set) union.add(id)
+    expect(union).toEqual(new Set(rows.map((r) => r.id)))
+
+    // Every shard actually got at least one row — a genuine 30-row/3-shard
+    // partition test, not a degenerate case where one shard is empty.
+    for (const set of shardIdSets) expect(set.size).toBeGreaterThan(0)
+  })
+
+  it("coverage[cohort].total stays the TRUE full-population value in a shard's own report — not just this shard's slice", async () => {
+    const rows: SimSnapshotRow[] = Array.from({ length: 12 }, () => makeRow({ cohort: 'C2' }))
+    for (const row of rows) registerPrimary(row, [contentsApiResponse(`# ${row.id}`)])
+    const scanner = makeVerdictScanner(new Map())
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const args = shardArgs({ shardIndex: 0, shardCount: 3 })
+
+    const report = await runSimulateFull(db, scanner, scanner, args, {})
+
+    expect(report.coverage.C2.total).toBe(12) // full population, not this shard's ~4-row slice
+    expect(report.coverage.C2.scanned).toBeLessThan(12) // this shard only scanned its own slice
+    expect(report.coverage.C2.status).toBe('partial') // correctly reflects partial coverage from ONE shard alone
+  })
+
+  it('the checkpoint records this run as sharded (shard_index/shard_count persisted)', async () => {
+    const rows = [makeRow({ cohort: 'C2' })]
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+    const scanner = makeVerdictScanner(new Map())
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const args = shardArgs({ shardIndex: 1, shardCount: 3 })
+
+    await runSimulateFull(db, scanner, scanner, args, {})
+
+    const checkpoint = readCheckpoint(args.checkpointPath as string)
+    expect(checkpoint?.shard_index).toBe(1)
+    expect(checkpoint?.shard_count).toBe(3)
+  })
+
+  it('an unsharded run never writes shard_index/shard_count to its checkpoint', async () => {
+    const rows = [makeRow({ cohort: 'C2' })]
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+    const scanner = makeVerdictScanner(new Map())
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const args = shardArgs()
+
+    await runSimulateFull(db, scanner, scanner, args, {})
+
+    const checkpoint = readCheckpoint(args.checkpointPath as string)
+    expect(checkpoint?.shard_index).toBeUndefined()
+    expect(checkpoint?.shard_count).toBeUndefined()
+  })
+
+  it('refuses to resume a checkpoint written for a different shard', async () => {
+    const rows = [makeRow({ cohort: 'C2' })]
+    const scanner = makeVerdictScanner(new Map())
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const firstRunArgs = shardArgs({ shardIndex: 0, shardCount: 3 })
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+    await runSimulateFull(db, scanner, scanner, firstRunArgs, {})
+
+    // Same checkpoint path, but a DIFFERENT shard index this time.
+    const secondRunArgs = shardArgs({
+      checkpointPath: firstRunArgs.checkpointPath,
+      shardIndex: 1,
+      shardCount: 3,
+    })
+    await expect(runSimulateFull(db, scanner, scanner, secondRunArgs, {})).rejects.toThrow(
+      /does not match this invocation.*shard/s
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // Mutually-exclusive claim-path wiring (plan's Wave 0 Files note): a
+  // sharded dispatch calls the shard-aware claim/heartbeat/release trio
+  // instead of the plain single-holder ones — never both.
+  // -------------------------------------------------------------------------
+
+  describe('claim-path wiring', () => {
+    it('a sharded dispatch calls claimRunShard/releaseRunShard, never the plain claimRun/releaseRun', async () => {
+      const rows = [makeRow({ cohort: 'C2' })]
+      registerPrimary(rows[0], [contentsApiResponse('# a')])
+      const scanner = makeVerdictScanner(new Map())
+      const calls: string[] = []
+      const db = makeFakeDb({
+        loadCohortRows: async () => rows,
+        claimRun: async () => {
+          calls.push('claimRun')
+          return { claimed: true }
+        },
+        releaseRun: async () => {
+          calls.push('releaseRun')
+        },
+        claimRunShard: async (_runId, shardIndex) => {
+          calls.push(`claimRunShard:${shardIndex}`)
+          return { claimed: true }
+        },
+        releaseRunShard: async (_runId, shardIndex) => {
+          calls.push(`releaseRunShard:${shardIndex}`)
+        },
+      })
+      const args = shardArgs({ shardIndex: 2, shardCount: 3 })
+
+      await runSimulateFull(db, scanner, scanner, args, {})
+
+      expect(calls).toContain('claimRunShard:2')
+      expect(calls).toContain('releaseRunShard:2')
+      expect(calls).not.toContain('claimRun')
+      expect(calls).not.toContain('releaseRun')
+    })
+
+    it('an unsharded dispatch calls the plain claimRun/releaseRun, never the shard-aware trio', async () => {
+      const rows = [makeRow({ cohort: 'C2' })]
+      registerPrimary(rows[0], [contentsApiResponse('# a')])
+      const scanner = makeVerdictScanner(new Map())
+      const calls: string[] = []
+      const db = makeFakeDb({
+        loadCohortRows: async () => rows,
+        claimRun: async () => {
+          calls.push('claimRun')
+          return { claimed: true }
+        },
+        releaseRun: async () => {
+          calls.push('releaseRun')
+        },
+        claimRunShard: async () => {
+          calls.push('claimRunShard')
+          return { claimed: true }
+        },
+        releaseRunShard: async () => {
+          calls.push('releaseRunShard')
+        },
+      })
+      const args = shardArgs()
+
+      await runSimulateFull(db, scanner, scanner, args, {})
+
+      expect(calls).toContain('claimRun')
+      expect(calls).toContain('releaseRun')
+      expect(calls).not.toContain('claimRunShard')
+      expect(calls).not.toContain('releaseRunShard')
+    })
+
+    it('a refused shard claim throws with the shard index in the message', async () => {
+      const db = makeFakeDb({
+        claimRunShard: async () => ({ claimed: false }),
+      })
+      const scanner = makeVerdictScanner(new Map())
+      const args = shardArgs({ shardIndex: 1, shardCount: 3 })
+
+      await expect(runSimulateFull(db, scanner, scanner, args, {})).rejects.toThrow(
+        /claim of generation run-shard shard 1\/3 was refused/
+      )
+    })
+
+    // -----------------------------------------------------------------------
+    // Round-1 GPT-5.6-Sol review, Medium finding: the claim/release wiring
+    // tests above never actually FIRE the heartbeat timer, so they cannot
+    // prove heartbeat routing specifically — same fake-timer/blocking-digest
+    // pattern as smi5879-simulate-full.test.ts's own heartbeat suite
+    // (SMI-5879 review finding 4).
+    // -----------------------------------------------------------------------
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('a sharded dispatch heartbeats via heartbeatShard, never the plain heartbeat', async () => {
+      vi.useFakeTimers()
+      let resolveDigest: (v: {
+        populationMatches: boolean
+        branchMatches: boolean
+      }) => void = () => {}
+      const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+        (resolve) => {
+          resolveDigest = resolve
+        }
+      )
+      const heartbeat = vi.fn().mockResolvedValue(new Date().toISOString())
+      const heartbeatShard = vi.fn().mockResolvedValue(new Date().toISOString())
+      const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeat, heartbeatShard })
+      const scanner = makeVerdictScanner(new Map())
+      const args = shardArgs({ shardIndex: 2, shardCount: 3 })
+
+      const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+      await flushMicrotasks()
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+
+      expect(heartbeatShard).toHaveBeenCalledWith('run-shard', 2, expect.any(String))
+      expect(heartbeat).not.toHaveBeenCalled()
+
+      resolveDigest({ populationMatches: true, branchMatches: true })
+      await runPromise
+    })
+
+    it('an unsharded dispatch heartbeats via the plain heartbeat, never heartbeatShard', async () => {
+      vi.useFakeTimers()
+      let resolveDigest: (v: {
+        populationMatches: boolean
+        branchMatches: boolean
+      }) => void = () => {}
+      const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+        (resolve) => {
+          resolveDigest = resolve
+        }
+      )
+      const heartbeat = vi.fn().mockResolvedValue(new Date().toISOString())
+      const heartbeatShard = vi.fn().mockResolvedValue(new Date().toISOString())
+      const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeat, heartbeatShard })
+      const scanner = makeVerdictScanner(new Map())
+      const args = shardArgs()
+
+      const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+      await flushMicrotasks()
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+
+      expect(heartbeat).toHaveBeenCalledWith('run-shard', expect.any(String))
+      expect(heartbeatShard).not.toHaveBeenCalled()
+
+      resolveDigest({ populationMatches: true, branchMatches: true })
+      await runPromise
+    })
+
+    it('a NULL heartbeatShard result is fatal, same as the unsharded path', async () => {
+      vi.useFakeTimers()
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined as never) as typeof process.exit)
+      let resolveDigest: (v: {
+        populationMatches: boolean
+        branchMatches: boolean
+      }) => void = () => {}
+      const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+        (resolve) => {
+          resolveDigest = resolve
+        }
+      )
+      const heartbeatShard = vi.fn().mockResolvedValue(null)
+      const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeatShard })
+      const scanner = makeVerdictScanner(new Map())
+      const args = shardArgs({ shardIndex: 0, shardCount: 3 })
+
+      const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+      await flushMicrotasks()
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      const checkpoint = readCheckpoint(args.checkpointPath as string)
+      expect(checkpoint?.clean_shutdown).toBe(false)
+
+      resolveDigest({ populationMatches: true, branchMatches: true })
+      await runPromise
+      exitSpy.mockRestore()
+    })
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.shard.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.shard.test.ts
@@ -1,0 +1,70 @@
+/**
+ * SMI-6015 PAT-sharded fetch plan Wave 1 Step 1: `shardOf()` partition
+ * function — even distribution, stability, and the `shardCount=1`
+ * degenerate case (plan's own test spec for this step).
+ * @module scripts/tests/indexer/smi5879-simulate-full.shard
+ */
+
+import { describe, it, expect } from 'vitest'
+import { shardOf } from '../../indexer/smi5879-simulate-full.shard.ts'
+
+describe('shardOf', () => {
+  it('always returns a value in [0, shardCount)', () => {
+    for (let i = 0; i < 10_000; i++) {
+      const shard = shardOf(`row-${i}`, 5)
+      expect(shard).toBeGreaterThanOrEqual(0)
+      expect(shard).toBeLessThan(5)
+      expect(Number.isInteger(shard)).toBe(true)
+    }
+  })
+
+  it('is stable: the same rowId always maps to the same shard', () => {
+    const id = 'skill-abc123-def456'
+    const first = shardOf(id, 7)
+    for (let i = 0; i < 100; i++) {
+      expect(shardOf(id, 7)).toBe(first)
+    }
+  })
+
+  it('is independent of call order / batching', () => {
+    const ids = Array.from({ length: 500 }, (_, i) => `row-${i}`)
+    const inOrder = ids.map((id) => shardOf(id, 3))
+    const shuffled = [...ids].reverse()
+    const reversedOrder = shuffled.map((id) => shardOf(id, 3))
+    // Same rowId -> same shard, regardless of the order shardOf was called in.
+    for (let i = 0; i < ids.length; i++) {
+      expect(inOrder[i]).toBe(shardOf(ids[i], 3))
+    }
+    expect(reversedOrder[0]).toBe(inOrder[ids.length - 1])
+  })
+
+  it('the shardCount=1 degenerate case always returns shard 0 (no-op single-shard run)', () => {
+    for (let i = 0; i < 1000; i++) {
+      expect(shardOf(`row-${i}`, 1)).toBe(0)
+    }
+  })
+
+  it('distributes a 10k-row synthetic sample roughly evenly across 5 shards', () => {
+    const shardCount = 5
+    const counts = new Array(shardCount).fill(0)
+    for (let i = 0; i < 10_000; i++) {
+      counts[shardOf(`skill-${i}-${Math.random().toString(36).slice(2)}`, shardCount)]++
+    }
+    // Expected ~2000/shard. A simple bucket-count-within-tolerance check
+    // (not a formal chi-square test) — generous tolerance since this is a
+    // correctness smoke test, not a statistical distribution proof.
+    for (const count of counts) {
+      expect(count).toBeGreaterThan(1500)
+      expect(count).toBeLessThan(2500)
+    }
+  })
+
+  it('different shardCount values for the same rowId can (and generally do) land in different shards', () => {
+    // Not a strict correctness requirement (shardOf has no obligation to
+    // preserve any relationship across different shardCount values) — this
+    // just documents that the function doesn't degenerate to a constant.
+    const id = 'skill-xyz'
+    const results = new Set([shardOf(id, 2), shardOf(id, 3), shardOf(id, 5), shardOf(id, 7)])
+    expect(results.size).toBeGreaterThan(1)
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.test.ts
@@ -472,4 +472,60 @@ describe('runSimulateFull — heartbeat (SMI-5879 review finding 4)', () => {
     resolveDigest({ populationMatches: true, branchMatches: true })
     await runPromise
   })
+
+  // ---------------------------------------------------------------------
+  // PR #2525 review (GPT-5.6-Sol) High finding: `finally`'s `heartbeatStopped
+  // = true` only cancels a FUTURE tick (via clearTimeout) — it does not
+  // cancel a heartbeat call already in flight. If that in-flight call
+  // resolves to `null` (or throws) AFTER release has already run, the old
+  // code called fatalHeartbeatAbort() -> process.exit(1) on a run that had
+  // already completed successfully, discarding the report main() was about
+  // to write.
+  // ---------------------------------------------------------------------
+
+  it('an in-flight heartbeat that resolves null AFTER the run has already completed and released must not abort the process', async () => {
+    vi.useFakeTimers()
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as typeof process.exit)
+
+    let resolveDigest: (v: {
+      populationMatches: boolean
+      branchMatches: boolean
+    }) => void = () => {}
+    const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+      (resolve) => {
+        resolveDigest = resolve
+      }
+    )
+    let resolveHeartbeat: (v: string | null) => void = () => {}
+    const heartbeatPromise = new Promise<string | null>((resolve) => {
+      resolveHeartbeat = resolve
+    })
+    const heartbeat = vi.fn().mockReturnValue(heartbeatPromise)
+    const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeat })
+    const scanner = makeVerdictScanner(new Map())
+    const args = heartbeatArgs()
+
+    const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+    expect(heartbeat).toHaveBeenCalledTimes(1) // tick fired, now in flight
+
+    // Let the (empty-population) main pass run to completion and reach
+    // `finally` — release runs, heartbeatStopped flips true, the run
+    // resolves — all while the heartbeat call above is STILL pending.
+    resolveDigest({ populationMatches: true, branchMatches: true })
+    const report = await runPromise
+    expect(report.report_kind).toBe('full_simulation')
+    expect(exitSpy).not.toHaveBeenCalled()
+
+    // Only now does the in-flight heartbeat resolve to null (lost claim) —
+    // the exact race window. Must be swallowed, not treated as fatal.
+    resolveHeartbeat(null)
+    await flushMicrotasks()
+
+    expect(exitSpy).not.toHaveBeenCalled()
+    exitSpy.mockRestore()
+  })
 })

--- a/scripts/tests/indexer/smi5879-simulate-full.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.test.ts
@@ -289,8 +289,14 @@ describe('runSimulateFull', () => {
     writeCheckpoint(args.checkpointPath as string, seeded)
     const db = makeFakeDb({ loadCohortRows: async () => rows })
     const scanner = makeVerdictScanner(new Map())
+    // SMI-6015 Wave 1 (round-1 GPT-5.6-Sol review, High finding): error
+    // wording broadened when assertCheckpointRowsBelongToGeneration gained
+    // shard/cohort scope validation on top of the original generation-
+    // membership check — the per-problem message for THIS case
+    // ("not in this generation's row set") is unchanged, only the wrapping
+    // summary sentence's wording changed.
     await expect(runSimulateFull(db, scanner, scanner, args, {})).rejects.toThrow(
-      /row_results key\(s\) that are not in this generation/
+      /row-from-a-different-generation \(not in this generation's row set\)/
     )
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** The simulate-full fetch tool can now run as N independent shards against one shared decision run, instead of only one process at a time. Each shard claims its own slot (Wave 0's migration), processes only the rows that hash to it, and checkpoints/resumes without ever touching another shard's rows.

**Quality bar:** Implementation + 4 rounds of adversarial review (GPT-5.6-Sol), each round re-confirming the previous round's fix rather than just reviewing fresh. Three real gaps were found and closed: a checkpoint could pass shape validation while its stored rows actually belonged to the wrong shard or cohort (High); two default-report-path collisions across shards (Medium); and a heartbeat-routing path that was never actually exercised by a fired timer (Medium). Round 4 came back clean. 25 new tests across partitioning, CLI flag parsing, checkpoint identity, and row-ownership scope.

**Net result:** Fully shipped. Wave 2 (the N-way result-merge tool) and Wave 3 (the dispatch runbook) are separate, unstarted work — not part of this PR.

---

## Technical detail

**New files:**
- `scripts/indexer/smi5879-simulate-full.shard.ts` — `shardOf(rowId, shardCount)`, FNV-1a-based, stable and order-independent.
- `scripts/indexer/smi5879-simulate-full.output.ts` — `printSummary`/`dryRun`, split out of the main orchestration file to stay under the 500-line budget.
- 4 new test files (`*.shard.test.ts`, `*.shard-integration.test.ts`, `*.checkpoint-row-scope.test.ts`, plus extensions to existing `.checkpoint.test.ts`/`.cli.test.ts`).

**Changed files:**
- `smi5879-simulate-full.cli.ts` — `--shard-index`/`--shard-count` flags, both-or-neither validation, `[0, shardCount)` bounds.
- `smi5879-simulate-full.types.ts` — shard fields on the checkpoint shape; `claimRunShard`/`heartbeatShard`/`releaseRunShard` on the DB interface (report shape deliberately left shard-transparent for Wave 2's merge tool).
- `smi5879-simulate-full.db.ts` — psql wiring for the three new shard-claim RPCs from Wave 0's migration.
- `smi5879-simulate-full.checkpoint.ts` — shard-aware checkpoint path/identity checks; `assertCheckpointRowsBelongToGeneration` extended to verify each stored row result's cohort, author, and name against the canonical row, plus shard membership via `shardOf()` — not just generation membership.
- `smi5879-simulate-full.ts` — branches claim/heartbeat/release and row filtering on whether `--shard-index`/`--shard-count` are present; shard-aware default report path.

**Known limitation (accepted, documented in code):** the checkpoint filename's embedded shard index isn't cross-checked against the run_id in the filename — reverse-parsing an arbitrary run_id out of an ambiguous filename isn't reliable. The content-based checks (shape validation + row-ownership) cover the real risk this would otherwise catch.

**CI:** Docker-first, full test suite via pre-push hook. Migration itself (Wave 0) already merged and live.

**Docs pairing:** `smith-horn/skillsmith-docs` PR #854 carries the plan-doc wave-boundary clarification and the full Wave 1 governance review report (all 4 rounds).
