### PR TITLE
feat(indexer): SMI-5898 Wave 2 Step 4 — merge duplicate skills rows

### DIFF
--- a/scripts/indexer/merge-duplicate-skills.helpers.ts
+++ b/scripts/indexer/merge-duplicate-skills.helpers.ts
@@ -380,9 +380,14 @@ export function buildGroupMutationSql(group: DuplicateGroup): string {
   const survivorId = assertUuid(group.survivor.id, 'survivor id')
   const loserIds = group.losers.map((l) => assertUuid(l.id, 'loser id'))
   const loserArr = idArrayLiteral(loserIds, 'loser id')
+  // Defense-in-depth: repoUrlCanonical only ever appears inside a `--` SQL
+  // comment here, never in executable SQL, but a stray newline would still
+  // let it "break out" of the comment onto the next line of the generated
+  // script — strip any control characters before interpolating.
+  const commentSafeKey = group.repoUrlCanonical.replace(/[\r\n]/g, ' ')
 
   return `
--- Group: ${group.repoUrlCanonical}
+-- Group: ${commentSafeKey}
 -- 1. skill_categories: union insert, then drop losers' rows.
 INSERT INTO skill_categories (skill_id, category_id)
   SELECT '${survivorId}', category_id FROM skill_categories WHERE skill_id = ANY(${loserArr})

--- a/scripts/indexer/merge-duplicate-skills.helpers.ts
+++ b/scripts/indexer/merge-duplicate-skills.helpers.ts
@@ -9,20 +9,26 @@
 import { writeFileSync, mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { type PgConnParams, queryRows, queryScalar, nullable } from './smi5879-census.pg.ts'
+import {
+  GUARDRAIL_MAX_LOSERS,
+  DEPENDENT_TABLES,
+  type DuplicateGroup,
+  type SkillRow,
+  type TableMovement,
+  type ReversalManifest,
+} from './merge-duplicate-skills.types.ts'
 
-/** R4 guardrail (design doc §B.3.3) — abort if the key ever selects more than a hand-count of rows. */
-export const GUARDRAIL_MAX_LOSERS = 500
-
-/** The six tables with a real or soft reference into `skills.id`, per design doc §B.3.2. */
-export const DEPENDENT_TABLES = [
-  'skill_categories',
-  'skills_optimized',
-  'skill_transformations',
-  'outreach_suppressions',
-  'outreach_events',
-  'quarantine_approvals',
-] as const
-export type DependentTable = (typeof DEPENDENT_TABLES)[number]
+export {
+  GUARDRAIL_MAX_LOSERS,
+  DEPENDENT_TABLES,
+  type DependentTable,
+  type SkillRow,
+  type DuplicateGroup,
+  type TableMovement,
+  type QuarantineApprovalDelta,
+  type ReversalManifest,
+  type MergeCounts,
+} from './merge-duplicate-skills.types.ts'
 
 /** UUID-shaped guard for any id interpolated directly into a generated SQL script (defense-in-depth — these come from our own prior read, never external input). */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -36,61 +42,6 @@ export function assertUuid(id: string, label: string): string {
 export function idArrayLiteral(ids: string[], label: string): string {
   const quoted = ids.map((id) => `'${assertUuid(id, label)}'`)
   return `ARRAY[${quoted.join(',')}]::text[]`
-}
-
-/** A single `skills` row as read for grouping/ranking. */
-export interface SkillRow {
-  id: string
-  repo_url_canonical: string
-  repo_url: string | null
-  author: string | null
-  name: string
-  quarantined: boolean
-  last_seen_at: string | null
-  trust_tier: string | null
-  stars: number | null
-  updated_at: string | null
-}
-
-/** One duplicate group: a survivor plus its losers, ranked per the canonical survivor-selection order. */
-export interface DuplicateGroup {
-  repoUrlCanonical: string
-  survivor: SkillRow
-  losers: SkillRow[]
-}
-
-/** Per-table row-movement counts for one group, for the dry-run report. */
-export interface TableMovement {
-  table: DependentTable
-  rePointed: number
-  discarded: number
-  skippedOnConflict: number
-}
-
-export interface QuarantineApprovalDelta {
-  skillId: string
-  before: boolean
-  after: boolean
-}
-
-export interface ReversalManifest {
-  createdAt: string
-  groups: Array<{
-    repoUrlCanonical: string
-    survivorId: string
-    loserIds: string[]
-  }>
-  /** Full pre-merge row snapshots, keyed by table name. */
-  rows: Record<'skills' | DependentTable, unknown[]>
-}
-
-export interface MergeCounts {
-  groups: number
-  losersRemoved: number
-  tableMovements: TableMovement[]
-  isCompleteDeltas: QuarantineApprovalDelta[]
-  suppressionCountBefore: number
-  suppressionCountAfter: number
 }
 
 const RANKING_ORDER_SQL = `
@@ -351,17 +302,28 @@ export async function planGroup(
   return movements
 }
 
-/** `quarantine_approvals.is_complete` before-state for a skill, per design doc §B.3.2: `COUNT(DISTINCT reviewer_id) >= required_approvals`. */
-export async function isCompleteFor(conn: PgConnParams, skillId: string): Promise<boolean | null> {
-  const id = assertUuid(skillId, 'skill id')
+/**
+ * `quarantine_approvals.is_complete` over the UNION of `ids`' rows, per
+ * design doc §B.3.2: `COUNT(DISTINCT reviewer_id) >= MAX(required_approvals)`.
+ * Uniform "before"/"after" computation for both dry-run and apply: "before"
+ * is always `[survivorId]` alone (current state); "after" during dry-run is
+ * `[survivorId, ...loserIds]` (a read-only simulation of the post-re-point
+ * union, since nothing has moved yet); "after" during apply is
+ * `[survivorId]` alone AGAIN, but queried post-mutation, once every loser's
+ * rows already carry the survivor's id — the same query, different moment.
+ */
+export async function isCompleteForIds(conn: PgConnParams, ids: string[]): Promise<boolean | null> {
+  if (ids.length === 0) return null
+  const arr = idArrayLiteral(ids, 'skill id')
   const row = (
     await queryRows(
       conn,
-      `SELECT bool_or(is_complete) FROM quarantine_approvals WHERE skill_id = '${id}';`
+      `SELECT (count(DISTINCT reviewer_id) >= max(required_approvals))::text
+       FROM quarantine_approvals WHERE skill_id = ANY(${arr});`
     )
   )[0]
   if (!row) return null
-  return nullable(row[0]) === null ? null : row[0] === 't'
+  return nullable(row[0]) === null ? null : row[0] === 'true'
 }
 
 /** Count distinct suppressed skill_ids among the given ids — used for the pre/post suppression-preservation proof. */
@@ -375,8 +337,41 @@ export async function suppressedSkillCount(conn: PgConnParams, ids: string[]): P
   return Number(n ?? '0')
 }
 
-/** Build the SQL mutation block for one group's per-table merge rules, per design doc §B.3.2. */
-export function buildGroupMutationSql(group: DuplicateGroup): string {
+/**
+ * Whether ANY member of the group (survivor or any loser) currently has a
+ * suppression row — read BEFORE the merge mutates anything. Feeds the
+ * per-group in-transaction assertion in {@link buildGroupMutationSql}: a
+ * GLOBAL distinct-suppressed-id count comparison (the original design) is
+ * unsound here, because collapsing N suppressed skill_ids in one group down
+ * to 1 (the survivor) legitimately changes that count even when the
+ * invariant holds — the correct check is per-group ("did this group have
+ * suppression, and if so, does its survivor have exactly one now"), caught
+ * by GPT-5.6-Sol/NEEDLE review before --apply (2026-08-26).
+ */
+export async function groupHadSuppression(
+  conn: PgConnParams,
+  group: DuplicateGroup
+): Promise<boolean> {
+  const ids = [group.survivor.id, ...group.losers.map((l) => l.id)]
+  const arr = idArrayLiteral(ids, 'skill id')
+  const n = await queryScalar(
+    conn,
+    `SELECT count(*) FROM outreach_suppressions WHERE skill_id = ANY(${arr});`
+  )
+  return Number(n ?? '0') > 0
+}
+
+/**
+ * Build the SQL mutation block for one group's per-table merge rules, per
+ * design doc §B.3.2. `hadSuppression` (from {@link groupHadSuppression},
+ * read BEFORE any mutation) gates an in-transaction, per-group hard-abort
+ * assertion: if the group had any suppression before, its survivor must
+ * have EXACTLY ONE suppression row after — checked and enforced (via
+ * RAISE EXCEPTION, which rolls back the whole transaction) INSIDE this same
+ * script, not as a separate post-COMMIT check that can no longer prevent
+ * anything.
+ */
+export function buildGroupMutationSql(group: DuplicateGroup, hadSuppression: boolean): string {
   const survivorId = assertUuid(group.survivor.id, 'survivor id')
   const loserIds = group.losers.map((l) => assertUuid(l.id, 'loser id'))
   const loserArr = idArrayLiteral(loserIds, 'loser id')
@@ -423,6 +418,23 @@ UPDATE outreach_suppressions SET skill_id = '${survivorId}'
 WHERE id IN (SELECT id FROM adopt)
   AND NOT EXISTS (SELECT 1 FROM outreach_suppressions WHERE skill_id = '${survivorId}');
 DELETE FROM outreach_suppressions WHERE skill_id = ANY(${loserArr});
+
+-- 4b. In-transaction suppression-preservation assertion (per-group, not a
+-- global count comparison -- see groupHadSuppression's doc comment for why
+-- a global diff is unsound here). Rolls back the WHOLE transaction if this
+-- group's suppression state was lost, before COMMIT ever runs.
+${
+  hadSuppression
+    ? `DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM outreach_suppressions WHERE skill_id = '${survivorId}';
+  IF n <> 1 THEN
+    RAISE EXCEPTION 'ABORT: suppression-preservation invariant violated for survivor ${survivorId} -- expected exactly 1 suppression row, found %', n;
+  END IF;
+END $$;`
+    : ''
+}
 
 -- 5. outreach_events: re-point all, dedupe none (append-only event log).
 UPDATE outreach_events SET skill_id = '${survivorId}' WHERE skill_id = ANY(${loserArr});

--- a/scripts/indexer/merge-duplicate-skills.helpers.ts
+++ b/scripts/indexer/merge-duplicate-skills.helpers.ts
@@ -1,0 +1,437 @@
+/**
+ * SMI-5898 Wave 2 Step 4: types + per-group query/mutation helpers for
+ * `merge-duplicate-skills.ts`, split out to keep that file under the
+ * repo's 500-line standard (`scripts/check-file-length.mjs`'s convention).
+ * See that file's own header for the full design rationale (psql shell-out,
+ * atomicity, reversal-manifest scope).
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { type PgConnParams, queryRows, queryScalar, nullable } from './smi5879-census.pg.ts'
+
+/** R4 guardrail (design doc §B.3.3) — abort if the key ever selects more than a hand-count of rows. */
+export const GUARDRAIL_MAX_LOSERS = 500
+
+/** The six tables with a real or soft reference into `skills.id`, per design doc §B.3.2. */
+export const DEPENDENT_TABLES = [
+  'skill_categories',
+  'skills_optimized',
+  'skill_transformations',
+  'outreach_suppressions',
+  'outreach_events',
+  'quarantine_approvals',
+] as const
+export type DependentTable = (typeof DEPENDENT_TABLES)[number]
+
+/** UUID-shaped guard for any id interpolated directly into a generated SQL script (defense-in-depth — these come from our own prior read, never external input). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+export function assertUuid(id: string, label: string): string {
+  if (!UUID_RE.test(id))
+    throw new Error(`[merge-duplicate-skills] refusing non-UUID ${label}: "${id}"`)
+  return id
+}
+
+/** `ARRAY['id1','id2',...]::text[]` literal, validating every id is UUID-shaped first. */
+export function idArrayLiteral(ids: string[], label: string): string {
+  const quoted = ids.map((id) => `'${assertUuid(id, label)}'`)
+  return `ARRAY[${quoted.join(',')}]::text[]`
+}
+
+/** A single `skills` row as read for grouping/ranking. */
+export interface SkillRow {
+  id: string
+  repo_url_canonical: string
+  repo_url: string | null
+  author: string | null
+  name: string
+  quarantined: boolean
+  last_seen_at: string | null
+  trust_tier: string | null
+  stars: number | null
+  updated_at: string | null
+}
+
+/** One duplicate group: a survivor plus its losers, ranked per the canonical survivor-selection order. */
+export interface DuplicateGroup {
+  repoUrlCanonical: string
+  survivor: SkillRow
+  losers: SkillRow[]
+}
+
+/** Per-table row-movement counts for one group, for the dry-run report. */
+export interface TableMovement {
+  table: DependentTable
+  rePointed: number
+  discarded: number
+  skippedOnConflict: number
+}
+
+export interface QuarantineApprovalDelta {
+  skillId: string
+  before: boolean
+  after: boolean
+}
+
+export interface ReversalManifest {
+  createdAt: string
+  groups: Array<{
+    repoUrlCanonical: string
+    survivorId: string
+    loserIds: string[]
+  }>
+  /** Full pre-merge row snapshots, keyed by table name. */
+  rows: Record<'skills' | DependentTable, unknown[]>
+}
+
+export interface MergeCounts {
+  groups: number
+  losersRemoved: number
+  tableMovements: TableMovement[]
+  isCompleteDeltas: QuarantineApprovalDelta[]
+  suppressionCountBefore: number
+  suppressionCountAfter: number
+}
+
+const RANKING_ORDER_SQL = `
+  (quarantined IS TRUE),
+  last_seen_at DESC NULLS LAST,
+  (CASE trust_tier
+     WHEN 'verified' THEN 0 WHEN 'curated' THEN 1
+     WHEN 'community' THEN 2 WHEN 'experimental' THEN 3 ELSE 4 END),
+  stars DESC NULLS LAST, updated_at DESC NULLS LAST, id
+`
+
+/**
+ * Find every duplicate group under `repo_url_canonical`, with the survivor
+ * ranked first per the canonical survivor-selection order (reused verbatim
+ * from `20260726000000_skill_update_drift_detection.sql:411-426`, the same
+ * order the database already treats as canonical, so nothing else in the
+ * system changes which row it resolves to).
+ */
+export async function findDuplicateGroups(conn: PgConnParams): Promise<DuplicateGroup[]> {
+  const rows = await queryRows(
+    conn,
+    `
+    WITH dup_keys AS (
+      SELECT repo_url_canonical
+      FROM skills
+      WHERE repo_url_canonical IS NOT NULL
+      GROUP BY repo_url_canonical
+      HAVING count(*) > 1
+    ),
+    ranked AS (
+      SELECT
+        s.id, s.repo_url_canonical, s.repo_url, s.author, s.name, s.quarantined,
+        s.last_seen_at, s.trust_tier, s.stars, s.updated_at,
+        row_number() OVER (PARTITION BY s.repo_url_canonical ORDER BY ${RANKING_ORDER_SQL}) AS rn
+      FROM skills s
+      JOIN dup_keys d USING (repo_url_canonical)
+    )
+    SELECT id, repo_url_canonical, repo_url, author, name, quarantined::text,
+           last_seen_at, trust_tier, stars::text, updated_at, rn::text
+    FROM ranked ORDER BY repo_url_canonical, rn;
+    `
+  )
+
+  const byKey = new Map<string, Array<SkillRow & { rn: number }>>()
+  for (const r of rows) {
+    const row: SkillRow & { rn: number } = {
+      id: r[0],
+      repo_url_canonical: r[1],
+      repo_url: nullable(r[2]),
+      author: nullable(r[3]),
+      name: r[4],
+      // NOTE: the query casts quarantined::text explicitly, which renders as
+      // 'true'/'false' (a bare, uncast boolean column would render 't'/'f' —
+      // a real bug caught here at implementation time, since nothing else in
+      // this file happened to assert on SkillRow.quarantined's parsed value).
+      quarantined: r[5] === 'true',
+      last_seen_at: nullable(r[6]),
+      trust_tier: nullable(r[7]),
+      stars: nullable(r[8]) === null ? null : Number(r[8]),
+      updated_at: nullable(r[9]),
+      rn: Number(r[10]),
+    }
+    const list = byKey.get(row.repo_url_canonical) ?? []
+    list.push(row)
+    byKey.set(row.repo_url_canonical, list)
+  }
+
+  const groups: DuplicateGroup[] = []
+  for (const [repoUrlCanonical, members] of byKey) {
+    const survivor = members.find((m) => m.rn === 1)
+    if (!survivor)
+      throw new Error(`[merge-duplicate-skills] group ${repoUrlCanonical} has no rn=1 row — bug`)
+    const losers = members.filter((m) => m.rn !== 1)
+    groups.push({ repoUrlCanonical, survivor, losers })
+  }
+  return groups
+}
+
+/** R4 guardrail — total rows that would be removed from `skills`. Throws if it exceeds {@link GUARDRAIL_MAX_LOSERS}. */
+export function assertGuardrail(groups: DuplicateGroup[]): void {
+  const total = groups.reduce((sum, g) => sum + g.losers.length, 0)
+  if (total > GUARDRAIL_MAX_LOSERS) {
+    throw new Error(
+      `[merge-duplicate-skills] ABORT: merge would remove ${total} rows (guardrail ${GUARDRAIL_MAX_LOSERS}). Re-derive the key — this is not the expected single-repo-rename shape.`
+    )
+  }
+}
+
+export function allLoserIds(groups: DuplicateGroup[]): string[] {
+  return groups.flatMap((g) => g.losers.map((l) => l.id))
+}
+export function allSurvivorIds(groups: DuplicateGroup[]): string[] {
+  return groups.map((g) => g.survivor.id)
+}
+
+/**
+ * Snapshot every row in the six dependent tables belonging to any loser OR
+ * survivor, plus every loser's own `skills` row — the full before-image the
+ * reversal manifest needs (see `merge-duplicate-skills.ts`'s "Reversal
+ * manifest scope" header note). Uses `row_to_json` so the manifest captures
+ * every column without this script needing to enumerate each table's
+ * schema by hand.
+ */
+export async function buildReversalManifest(
+  conn: PgConnParams,
+  groups: DuplicateGroup[]
+): Promise<ReversalManifest> {
+  const loserIds = allLoserIds(groups)
+  const survivorIds = allSurvivorIds(groups)
+  const allIds = [...loserIds, ...survivorIds]
+
+  const rows: ReversalManifest['rows'] = {
+    skills: [],
+    skill_categories: [],
+    skills_optimized: [],
+    skill_transformations: [],
+    outreach_suppressions: [],
+    outreach_events: [],
+    quarantine_approvals: [],
+  }
+
+  if (loserIds.length > 0) {
+    const idArr = idArrayLiteral(loserIds, 'loser id')
+    const raw = await queryRows(
+      conn,
+      `SELECT row_to_json(t)::text FROM (SELECT * FROM skills WHERE id = ANY(${idArr})) t;`
+    )
+    rows.skills = raw.map((r) => JSON.parse(r[0]))
+  }
+
+  if (allIds.length > 0) {
+    const idArr = idArrayLiteral(allIds, 'skill id')
+    for (const table of DEPENDENT_TABLES) {
+      const raw = await queryRows(
+        conn,
+        `SELECT row_to_json(t)::text FROM (SELECT * FROM ${table} WHERE skill_id = ANY(${idArr})) t;`
+      )
+      rows[table] = raw.map((r) => JSON.parse(r[0]))
+    }
+  }
+
+  return {
+    createdAt: new Date().toISOString(),
+    groups: groups.map((g) => ({
+      repoUrlCanonical: g.repoUrlCanonical,
+      survivorId: g.survivor.id,
+      loserIds: g.losers.map((l) => l.id),
+    })),
+    rows,
+  }
+}
+
+/** Write the reversal manifest to disk. Throws (does not swallow) on any write failure — `--apply` must refuse to proceed. */
+export function writeReversalManifest(manifest: ReversalManifest, filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, JSON.stringify(manifest, null, 2), 'utf8')
+}
+
+/** Read-only per-table movement plan for one group (used by dry-run; apply computes the same numbers from the actual mutation results). */
+export async function planGroup(
+  conn: PgConnParams,
+  group: DuplicateGroup
+): Promise<TableMovement[]> {
+  const survivorId = assertUuid(group.survivor.id, 'survivor id')
+  const loserIds = group.losers.map((l) => assertUuid(l.id, 'loser id'))
+  const loserArr = idArrayLiteral(loserIds, 'loser id')
+  const movements: TableMovement[] = []
+
+  // 1. skill_categories — union insert ON CONFLICT DO NOTHING, then drop losers' rows.
+  {
+    const loserCats = await queryRows(
+      conn,
+      `SELECT category_id FROM skill_categories WHERE skill_id = ANY(${loserArr});`
+    )
+    const survivorCats = new Set(
+      (
+        await queryRows(
+          conn,
+          `SELECT category_id FROM skill_categories WHERE skill_id = '${survivorId}';`
+        )
+      ).map((r) => r[0])
+    )
+    const wouldInsert = loserCats.filter((r) => !survivorCats.has(r[0])).length
+    movements.push({
+      table: 'skill_categories',
+      rePointed: wouldInsert,
+      discarded: 0,
+      skippedOnConflict: loserCats.length - wouldInsert,
+    })
+  }
+
+  // 2 & 3. skills_optimized / skill_transformations — survivor wins; adopt only if survivor has none.
+  for (const table of ['skills_optimized', 'skill_transformations'] as const) {
+    const survivorHas =
+      (await queryScalar(conn, `SELECT 1 FROM ${table} WHERE skill_id = '${survivorId}';`)) !== null
+    const loserCount = Number(
+      (await queryScalar(
+        conn,
+        `SELECT count(*) FROM ${table} WHERE skill_id = ANY(${loserArr});`
+      )) ?? '0'
+    )
+    movements.push({
+      table,
+      rePointed: !survivorHas && loserCount > 0 ? 1 : 0,
+      discarded: !survivorHas && loserCount > 0 ? loserCount - 1 : loserCount,
+      skippedOnConflict: 0,
+    })
+  }
+
+  // 4. outreach_suppressions — sticky: re-point the earliest-suppressed row, drop the rest.
+  {
+    const survivorHas =
+      (await queryScalar(
+        conn,
+        `SELECT 1 FROM outreach_suppressions WHERE skill_id = '${survivorId}';`
+      )) !== null
+    const loserCount = Number(
+      (await queryScalar(
+        conn,
+        `SELECT count(*) FROM outreach_suppressions WHERE skill_id = ANY(${loserArr});`
+      )) ?? '0'
+    )
+    movements.push({
+      table: 'outreach_suppressions',
+      rePointed: !survivorHas && loserCount > 0 ? 1 : 0,
+      discarded: 0,
+      skippedOnConflict: survivorHas ? loserCount : Math.max(loserCount - 1, 0),
+    })
+  }
+
+  // 5. outreach_events — re-point all, dedupe none.
+  {
+    const n = Number(
+      (await queryScalar(
+        conn,
+        `SELECT count(*) FROM outreach_events WHERE skill_id = ANY(${loserArr});`
+      )) ?? '0'
+    )
+    movements.push({ table: 'outreach_events', rePointed: n, discarded: 0, skippedOnConflict: 0 })
+  }
+
+  // 6. quarantine_approvals — re-point all, is_complete recomputed separately.
+  {
+    const n = Number(
+      (await queryScalar(
+        conn,
+        `SELECT count(*) FROM quarantine_approvals WHERE skill_id = ANY(${loserArr});`
+      )) ?? '0'
+    )
+    movements.push({
+      table: 'quarantine_approvals',
+      rePointed: n,
+      discarded: 0,
+      skippedOnConflict: 0,
+    })
+  }
+
+  return movements
+}
+
+/** `quarantine_approvals.is_complete` before-state for a skill, per design doc §B.3.2: `COUNT(DISTINCT reviewer_id) >= required_approvals`. */
+export async function isCompleteFor(conn: PgConnParams, skillId: string): Promise<boolean | null> {
+  const id = assertUuid(skillId, 'skill id')
+  const row = (
+    await queryRows(
+      conn,
+      `SELECT bool_or(is_complete) FROM quarantine_approvals WHERE skill_id = '${id}';`
+    )
+  )[0]
+  if (!row) return null
+  return nullable(row[0]) === null ? null : row[0] === 't'
+}
+
+/** Count distinct suppressed skill_ids among the given ids — used for the pre/post suppression-preservation proof. */
+export async function suppressedSkillCount(conn: PgConnParams, ids: string[]): Promise<number> {
+  if (ids.length === 0) return 0
+  const arr = idArrayLiteral(ids, 'skill id')
+  const n = await queryScalar(
+    conn,
+    `SELECT count(DISTINCT skill_id) FROM outreach_suppressions WHERE skill_id = ANY(${arr});`
+  )
+  return Number(n ?? '0')
+}
+
+/** Build the SQL mutation block for one group's per-table merge rules, per design doc §B.3.2. */
+export function buildGroupMutationSql(group: DuplicateGroup): string {
+  const survivorId = assertUuid(group.survivor.id, 'survivor id')
+  const loserIds = group.losers.map((l) => assertUuid(l.id, 'loser id'))
+  const loserArr = idArrayLiteral(loserIds, 'loser id')
+
+  return `
+-- Group: ${group.repoUrlCanonical}
+-- 1. skill_categories: union insert, then drop losers' rows.
+INSERT INTO skill_categories (skill_id, category_id)
+  SELECT '${survivorId}', category_id FROM skill_categories WHERE skill_id = ANY(${loserArr})
+  ON CONFLICT DO NOTHING;
+DELETE FROM skill_categories WHERE skill_id = ANY(${loserArr});
+
+-- 2. skills_optimized: adopt the newest loser row only if survivor has none, else discard all losers.
+WITH adopt AS (
+  SELECT skill_id FROM skills_optimized WHERE skill_id = ANY(${loserArr})
+  ORDER BY updated_at DESC NULLS LAST LIMIT 1
+)
+UPDATE skills_optimized SET skill_id = '${survivorId}'
+WHERE skill_id IN (SELECT skill_id FROM adopt)
+  AND NOT EXISTS (SELECT 1 FROM skills_optimized WHERE skill_id = '${survivorId}');
+DELETE FROM skills_optimized WHERE skill_id = ANY(${loserArr});
+
+-- 3. skill_transformations: same adopt-if-empty rule.
+WITH adopt AS (
+  SELECT skill_id FROM skill_transformations WHERE skill_id = ANY(${loserArr})
+  ORDER BY transformed_at DESC NULLS LAST LIMIT 1
+)
+UPDATE skill_transformations SET skill_id = '${survivorId}'
+WHERE skill_id IN (SELECT skill_id FROM adopt)
+  AND NOT EXISTS (SELECT 1 FROM skill_transformations WHERE skill_id = '${survivorId}');
+DELETE FROM skill_transformations WHERE skill_id = ANY(${loserArr});
+
+-- 4. outreach_suppressions: sticky — re-point the earliest-suppressed loser row only if survivor isn't already suppressed.
+WITH adopt AS (
+  SELECT id FROM outreach_suppressions WHERE skill_id = ANY(${loserArr})
+  ORDER BY suppressed_at ASC LIMIT 1
+)
+UPDATE outreach_suppressions SET skill_id = '${survivorId}'
+WHERE id IN (SELECT id FROM adopt)
+  AND NOT EXISTS (SELECT 1 FROM outreach_suppressions WHERE skill_id = '${survivorId}');
+DELETE FROM outreach_suppressions WHERE skill_id = ANY(${loserArr});
+
+-- 5. outreach_events: re-point all, dedupe none (append-only event log).
+UPDATE outreach_events SET skill_id = '${survivorId}' WHERE skill_id = ANY(${loserArr});
+
+-- 6. quarantine_approvals: re-point all, then recompute is_complete.
+UPDATE quarantine_approvals SET skill_id = '${survivorId}' WHERE skill_id = ANY(${loserArr});
+UPDATE quarantine_approvals SET is_complete = sub.new_complete
+FROM (
+  SELECT (count(DISTINCT reviewer_id) >= max(required_approvals)) AS new_complete
+  FROM quarantine_approvals WHERE skill_id = '${survivorId}'
+) sub
+WHERE skill_id = '${survivorId}';
+
+-- 7. skills: remove the losers.
+DELETE FROM skills WHERE id = ANY(${loserArr});
+`
+}

--- a/scripts/indexer/merge-duplicate-skills.ts
+++ b/scripts/indexer/merge-duplicate-skills.ts
@@ -78,8 +78,9 @@ import {
   buildReversalManifest,
   writeReversalManifest,
   planGroup,
-  isCompleteFor,
+  isCompleteForIds,
   suppressedSkillCount,
+  groupHadSuppression,
   buildGroupMutationSql,
 } from './merge-duplicate-skills.helpers.ts'
 
@@ -124,12 +125,34 @@ export async function runMerge(
   writeReversalManifest(manifest, opts.manifestPath)
   console.log(`\nReversal manifest written: ${opts.manifestPath}`)
 
+  // "Before" is always the survivor's OWN current rows. "After" (prospective,
+  // computed here BEFORE any mutation) simulates the post-re-point union for
+  // dry-run — a read-only query, safe to run without touching anything.
+  // Apply overwrites isCompleteAfter with a real post-mutation read below.
   const isCompleteBefore = new Map<string, boolean | null>()
-  for (const g of groups)
-    isCompleteBefore.set(g.survivor.id, await isCompleteFor(conn, g.survivor.id))
+  const isCompleteAfter = new Map<string, boolean | null>()
+  const groupHadSuppressionMap = new Map<string, boolean>()
+  for (const g of groups) {
+    isCompleteBefore.set(g.survivor.id, await isCompleteForIds(conn, [g.survivor.id]))
+    isCompleteAfter.set(
+      g.survivor.id,
+      await isCompleteForIds(conn, [g.survivor.id, ...g.losers.map((l) => l.id)])
+    )
+    groupHadSuppressionMap.set(g.survivor.id, await groupHadSuppression(conn, g))
+  }
 
   const movements: TableMovement[] = []
-  for (const g of groups) movements.push(...(await planGroup(conn, g)))
+  console.log(`\n── Per-table movement plan ──`)
+  for (const g of groups) {
+    const groupMovements = await planGroup(conn, g)
+    movements.push(...groupMovements)
+    console.log(`  ${g.repoUrlCanonical}`)
+    for (const m of groupMovements) {
+      console.log(
+        `    ${m.table.padEnd(22)} rePointed=${m.rePointed} discarded=${m.discarded} skippedOnConflict=${m.skippedOnConflict}`
+      )
+    }
+  }
 
   if (opts.apply) {
     // Re-derive with a LIVE read and re-check the guardrail INSIDE the same
@@ -149,7 +172,9 @@ BEGIN
   END IF;
 END $$;
 `
-    const mutationBlocks = groups.map(buildGroupMutationSql).join('\n')
+    const mutationBlocks = groups
+      .map((g) => buildGroupMutationSql(g, groupHadSuppressionMap.get(g.survivor.id) ?? false))
+      .join('\n')
     const script = `
 BEGIN;
 SET LOCAL lock_timeout = '3s';
@@ -158,32 +183,35 @@ ${mutationBlocks}
 COMMIT;
 `
     await runPsql(conn, script)
-  }
 
-  const isCompleteDeltas: QuarantineApprovalDelta[] = []
-  if (opts.apply) {
+    // Real post-mutation read, replacing the pre-mutation simulation above —
+    // by now every loser's quarantine_approvals row already carries the
+    // survivor's id, so querying [survivorId] alone is the true after-state.
     for (const g of groups) {
-      const after = await isCompleteFor(conn, g.survivor.id)
-      const before = isCompleteBefore.get(g.survivor.id) ?? false
-      if ((before ?? false) !== (after ?? false)) {
-        isCompleteDeltas.push({
-          skillId: g.survivor.id,
-          before: before ?? false,
-          after: after ?? false,
-        })
-      }
+      isCompleteAfter.set(g.survivor.id, await isCompleteForIds(conn, [g.survivor.id]))
     }
   }
 
+  const isCompleteDeltas: QuarantineApprovalDelta[] = []
+  for (const g of groups) {
+    const before = isCompleteBefore.get(g.survivor.id) ?? false
+    const after = isCompleteAfter.get(g.survivor.id) ?? false
+    if ((before ?? false) !== (after ?? false)) {
+      isCompleteDeltas.push({
+        skillId: g.survivor.id,
+        before: before ?? false,
+        after: after ?? false,
+      })
+    }
+  }
+
+  // Informational only, post-commit — the authoritative, transaction-rolling-back
+  // check is the per-group in-transaction assertion buildGroupMutationSql emits
+  // (see groupHadSuppression's doc comment for why a global count comparison is
+  // unsound and was removed as the enforcement mechanism here).
   const suppressionCountAfter = opts.apply
     ? await suppressedSkillCount(conn, allSurvivorIds(groups))
     : suppressionCountBefore
-
-  if (opts.apply && suppressionCountAfter !== suppressionCountBefore) {
-    throw new Error(
-      `[merge-duplicate-skills] suppression-preservation invariant violated post-commit (before=${suppressionCountBefore}, after=${suppressionCountAfter}) — the transaction's own suppression check should have caught this; investigate immediately.`
-    )
-  }
 
   if (opts.apply) {
     await db.from('audit_logs').insert({

--- a/scripts/indexer/merge-duplicate-skills.ts
+++ b/scripts/indexer/merge-duplicate-skills.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env tsx
+/**
+ * SMI-5898 Wave 2 Step 4: merge duplicate `skills` rows sharing a
+ * `repo_url_canonical` value (case-only GitHub repo renames — the entire
+ * remaining duplicate-row gap the design doc's B.1 measurement identified).
+ * See docs/internal/implementation/smi-5898-wave5-b3-repo-url-canonical.md
+ * ("Duplicate merge") and docs/internal/implementation/smi-5898-wave5-design-proposal.md
+ * (§B.3.2 merge rules, §B.3.3 report + guardrail). Types + per-group
+ * query/mutation logic live in the sibling `merge-duplicate-skills.helpers.ts`
+ * (this file's own 500-line-standard split); this file is orchestration +
+ * the CLI entrypoint.
+ *
+ * Must complete before Step 5 (CREATE UNIQUE INDEX CONCURRENTLY on
+ * repo_url_canonical) — the index build fails on any remaining duplicate.
+ *
+ * Why a psql shell-out, not the `pg` npm client, not supabase-js: the design
+ * doc requires `--apply` to run the ENTIRE merge — `skills` DELETE plus all
+ * six dependent-table mutations — in one transaction (`SET LOCAL
+ * lock_timeout = '3s'`, R4 guardrail re-checked inside that same
+ * transaction). PostgREST/supabase-js has no cross-call transaction — each
+ * `.from(...)` call is its own implicit transaction. The `pg` npm client
+ * would give real transactions, but IS NOT AN INSTALLED DEPENDENCY and
+ * cannot become one from inside a worktree: a worktree's `node_modules` is
+ * bind-mounted READ-ONLY from the main checkout (SMI-4689/5560/5626/5650),
+ * so `npm install` inside a worktree container cannot write it — the same
+ * constraint `scripts/indexer/smi5879-census.pg.ts`'s own header documents
+ * hitting first. This script reuses that exact module's `queryRows`/
+ * `queryScalar`/`runPsql` helpers (shell out to `psql`, already on the dev
+ * image's PATH) instead — `runPsql` accepts a full multi-statement script
+ * (BEGIN ... COMMIT) in one call, giving the same atomicity guarantee
+ * without a new dependency.
+ *
+ * Safety: `--dry-run` is the DEFAULT; `--apply` performs writes (mirrors
+ * `dequarantine-false-positives.ts`'s convention). Gated by the SMI-5879
+ * run-gate (`assertRunAllowed('merge')` + `assertFreezeMarkerClear`) same as
+ * every other one-time `skills`-table writer in this family. `--apply`
+ * refuses to run if the reversal manifest cannot be written to disk FIRST.
+ * Per-group survivor/loser ids are captured via a fresh read immediately
+ * before the apply script is built and executed; the R4 guardrail is
+ * re-checked with a LIVE read INSIDE the transaction (not the JS-captured
+ * snapshot), so a group that grew between dry-run and apply cannot slip
+ * past the guardrail. The narrower case of a captured group's *membership*
+ * changing between that read and COMMIT is not separately re-validated
+ * inside the transaction — this is safe by construction of the wider
+ * workflow, not this script alone: Step 3 pauses every `skills` writer
+ * before Step 4 runs, so nothing should be touching `repo_url_canonical`
+ * during this window at all.
+ *
+ * Reversal manifest scope (plan-review finding, corrects the design doc's
+ * original "losers only" scope): captures full before-images of every
+ * LOSER row (all seven tables) AND every SURVIVOR-side row in the six
+ * dependent tables that already exists before the merge touches it — a
+ * union-insert into skill_categories doesn't modify a survivor's existing
+ * rows, but outreach_suppressions/quarantine_approvals re-point + recompute
+ * genuinely can, and capturing broadly (rather than reasoning per-table
+ * about which specific rows change) is the safer choice for something this
+ * rarely exercised.
+ *
+ * Usage (host tool — requires Docker container running for varlock, and a
+ * writer-pause already in effect per the plan's Step 3 — this script does
+ * NOT pause writers itself):
+ *   varlock run -- npx tsx scripts/indexer/merge-duplicate-skills.ts          # dry-run
+ *   varlock run -- npx tsx scripts/indexer/merge-duplicate-skills.ts --apply  # live
+ */
+
+import { createSupabaseAdminClient } from './_shared/supabase.ts'
+import { assertRunAllowed, assertFreezeMarkerClear } from './run-gate.ts'
+import { type PgConnParams, poolerSessionConnParams, runPsql } from './smi5879-census.pg.ts'
+import {
+  GUARDRAIL_MAX_LOSERS,
+  type MergeCounts,
+  type TableMovement,
+  type QuarantineApprovalDelta,
+  findDuplicateGroups,
+  assertGuardrail,
+  allLoserIds,
+  allSurvivorIds,
+  buildReversalManifest,
+  writeReversalManifest,
+  planGroup,
+  isCompleteFor,
+  suppressedSkillCount,
+  buildGroupMutationSql,
+} from './merge-duplicate-skills.helpers.ts'
+
+export type {
+  SkillRow,
+  DuplicateGroup,
+  TableMovement,
+  QuarantineApprovalDelta,
+  ReversalManifest,
+  MergeCounts,
+} from './merge-duplicate-skills.helpers.ts'
+export {
+  GUARDRAIL_MAX_LOSERS,
+  findDuplicateGroups,
+  assertGuardrail,
+  buildReversalManifest,
+  writeReversalManifest,
+} from './merge-duplicate-skills.helpers.ts'
+
+/** Full merge run: dry-run (default) or apply. Returns the counts for reporting. */
+export async function runMerge(
+  conn: PgConnParams,
+  db: ReturnType<typeof createSupabaseAdminClient>,
+  opts: { apply: boolean; manifestPath: string }
+): Promise<MergeCounts> {
+  const groups = await findDuplicateGroups(conn)
+  assertGuardrail(groups)
+
+  console.log(
+    `\n${opts.apply ? '🔧 APPLY' : '🔍 DRY-RUN'} — ${groups.length} duplicate group(s), ${groups.reduce((s, g) => s + g.losers.length, 0)} row(s) to merge\n`
+  )
+  for (const g of groups) {
+    console.log(`  ${g.repoUrlCanonical}`)
+    console.log(`    survivor: ${g.survivor.id} (${g.survivor.author}/${g.survivor.name})`)
+    for (const l of g.losers) console.log(`    loser:    ${l.id} (${l.author}/${l.name})`)
+  }
+
+  const allTouchedIds = [...allSurvivorIds(groups), ...allLoserIds(groups)]
+  const suppressionCountBefore = await suppressedSkillCount(conn, allTouchedIds)
+
+  const manifest = await buildReversalManifest(conn, groups)
+  writeReversalManifest(manifest, opts.manifestPath)
+  console.log(`\nReversal manifest written: ${opts.manifestPath}`)
+
+  const isCompleteBefore = new Map<string, boolean | null>()
+  for (const g of groups)
+    isCompleteBefore.set(g.survivor.id, await isCompleteFor(conn, g.survivor.id))
+
+  const movements: TableMovement[] = []
+  for (const g of groups) movements.push(...(await planGroup(conn, g)))
+
+  if (opts.apply) {
+    // Re-derive with a LIVE read and re-check the guardrail INSIDE the same
+    // logical operation — see the file header's atomicity note for why the
+    // per-group snapshot itself isn't independently re-validated here.
+    const liveGroups = await findDuplicateGroups(conn)
+    assertGuardrail(liveGroups)
+
+    const guardrailCheck = `
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT COALESCE(sum(c) - count(*), 0) INTO n
+  FROM (SELECT count(*) c FROM skills WHERE repo_url_canonical IS NOT NULL GROUP BY repo_url_canonical HAVING count(*) > 1) g;
+  IF n > ${GUARDRAIL_MAX_LOSERS} THEN
+    RAISE EXCEPTION 'ABORT: merge would remove % rows (guardrail ${GUARDRAIL_MAX_LOSERS})', n;
+  END IF;
+END $$;
+`
+    const mutationBlocks = groups.map(buildGroupMutationSql).join('\n')
+    const script = `
+BEGIN;
+SET LOCAL lock_timeout = '3s';
+${guardrailCheck}
+${mutationBlocks}
+COMMIT;
+`
+    await runPsql(conn, script)
+  }
+
+  const isCompleteDeltas: QuarantineApprovalDelta[] = []
+  if (opts.apply) {
+    for (const g of groups) {
+      const after = await isCompleteFor(conn, g.survivor.id)
+      const before = isCompleteBefore.get(g.survivor.id) ?? false
+      if ((before ?? false) !== (after ?? false)) {
+        isCompleteDeltas.push({
+          skillId: g.survivor.id,
+          before: before ?? false,
+          after: after ?? false,
+        })
+      }
+    }
+  }
+
+  const suppressionCountAfter = opts.apply
+    ? await suppressedSkillCount(conn, allSurvivorIds(groups))
+    : suppressionCountBefore
+
+  if (opts.apply && suppressionCountAfter !== suppressionCountBefore) {
+    throw new Error(
+      `[merge-duplicate-skills] suppression-preservation invariant violated post-commit (before=${suppressionCountBefore}, after=${suppressionCountAfter}) — the transaction's own suppression check should have caught this; investigate immediately.`
+    )
+  }
+
+  if (opts.apply) {
+    await db.from('audit_logs').insert({
+      event_type: 'skills:merge_duplicates',
+      actor: 'system',
+      resource: 'skills',
+      action: 'merge_duplicate_skills',
+      result: 'success',
+      metadata: {
+        smi: 'SMI-5898',
+        groups: groups.length,
+        losersRemoved: allLoserIds(groups).length,
+        manifestPath: opts.manifestPath,
+      },
+    })
+  }
+
+  console.log(
+    `\n── Summary ──\n` +
+      `  groups:              ${groups.length}\n` +
+      `  ${opts.apply ? 'removed' : 'would-remove'}:            ${allLoserIds(groups).length}\n` +
+      `  is_complete deltas:  ${isCompleteDeltas.length}\n` +
+      `  suppression before:  ${suppressionCountBefore}\n` +
+      `  suppression after:   ${opts.apply ? suppressionCountAfter : '(unchanged — dry-run)'}\n`
+  )
+  if (!opts.apply) console.log('Dry-run only — re-run with --apply to perform the merge.\n')
+
+  return {
+    groups: groups.length,
+    losersRemoved: allLoserIds(groups).length,
+    tableMovements: movements,
+    isCompleteDeltas,
+    suppressionCountBefore,
+    suppressionCountAfter,
+  }
+}
+
+async function main(): Promise<void> {
+  assertRunAllowed('merge')
+  const db = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(db, 'merge')
+
+  const apply = process.argv.includes('--apply')
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const manifestPath = `docs/internal/reports/smi-5898-merge-reversal-manifest-${timestamp}.json`
+
+  const conn = poolerSessionConnParams()
+  await runMerge(conn, db, { apply, manifestPath })
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/indexer/merge-duplicate-skills.types.ts
+++ b/scripts/indexer/merge-duplicate-skills.types.ts
@@ -1,0 +1,74 @@
+/**
+ * SMI-5898 Wave 2 Step 4: shared types for `merge-duplicate-skills.ts` +
+ * `.helpers.ts`, split out to keep both files under the repo's 500-line
+ * standard (`scripts/check-file-length.mjs`'s convention).
+ */
+
+/** R4 guardrail (design doc §B.3.3) — abort if the key ever selects more than a hand-count of rows. */
+export const GUARDRAIL_MAX_LOSERS = 500
+
+/** The six tables with a real or soft reference into `skills.id`, per design doc §B.3.2. */
+export const DEPENDENT_TABLES = [
+  'skill_categories',
+  'skills_optimized',
+  'skill_transformations',
+  'outreach_suppressions',
+  'outreach_events',
+  'quarantine_approvals',
+] as const
+export type DependentTable = (typeof DEPENDENT_TABLES)[number]
+
+/** A single `skills` row as read for grouping/ranking. */
+export interface SkillRow {
+  id: string
+  repo_url_canonical: string
+  repo_url: string | null
+  author: string | null
+  name: string
+  quarantined: boolean
+  last_seen_at: string | null
+  trust_tier: string | null
+  stars: number | null
+  updated_at: string | null
+}
+
+/** One duplicate group: a survivor plus its losers, ranked per the canonical survivor-selection order. */
+export interface DuplicateGroup {
+  repoUrlCanonical: string
+  survivor: SkillRow
+  losers: SkillRow[]
+}
+
+/** Per-table row-movement counts for one group, for the dry-run report. */
+export interface TableMovement {
+  table: DependentTable
+  rePointed: number
+  discarded: number
+  skippedOnConflict: number
+}
+
+export interface QuarantineApprovalDelta {
+  skillId: string
+  before: boolean
+  after: boolean
+}
+
+export interface ReversalManifest {
+  createdAt: string
+  groups: Array<{
+    repoUrlCanonical: string
+    survivorId: string
+    loserIds: string[]
+  }>
+  /** Full pre-merge row snapshots, keyed by table name. */
+  rows: Record<'skills' | DependentTable, unknown[]>
+}
+
+export interface MergeCounts {
+  groups: number
+  losersRemoved: number
+  tableMovements: TableMovement[]
+  isCompleteDeltas: QuarantineApprovalDelta[]
+  suppressionCountBefore: number
+  suppressionCountAfter: number
+}

--- a/scripts/indexer/run-gate.ts
+++ b/scripts/indexer/run-gate.ts
@@ -21,13 +21,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 /**
- * The seven run-type identifiers the gate understands. Five (`discovery`,
+ * The eight run-type identifiers the gate understands. Five (`discovery`,
  * `maintenance`, `recheck`, `dequarantine`, `purge`) mirror `parse-env.ts`'s
- * `RUN_TYPE` union exactly; `revalidate` and `repair` exist only in the
- * gate's own vocabulary, for host-only writers
- * (`revalidate-stale-quarantines.ts`, `repair-latched-name-rows.ts`),
- * deliberately kept out of `parse-env.ts`'s union so the workflow-facing
- * surface is unchanged.
+ * `RUN_TYPE` union exactly; `revalidate`, `repair`, and `merge` exist only in
+ * the gate's own vocabulary, for host-only writers
+ * (`revalidate-stale-quarantines.ts`, `repair-latched-name-rows.ts`,
+ * `merge-duplicate-skills.ts`), deliberately kept out of `parse-env.ts`'s
+ * union so the workflow-facing surface is unchanged.
  *
  * SMI-5930 (code-review finding): `repair` was added because
  * `repair-latched-name-rows.ts` is a genuine one-time WRITER against the
@@ -39,6 +39,13 @@ import type { SupabaseClient } from '@supabase/supabase-js'
  * psql/session-pooler connection instead of PostgREST doesn't change
  * whether a script needs this gate — what matters is read vs. write to
  * `skills`, not the connection mechanism.
+ *
+ * SMI-5898 Wave 2: `merge` added for the same reason as `repair` —
+ * `merge-duplicate-skills.ts` deletes/re-points rows against `skills` and
+ * six dependent tables, a genuine one-time writer, distinct in kind from
+ * `repair` (which corrects stale values on existing rows rather than
+ * deleting/re-pointing them) so it gets its own explicit vocabulary entry
+ * rather than overloading `repair`.
  */
 export const GATED_RUN_TYPES = [
   'discovery',
@@ -48,6 +55,7 @@ export const GATED_RUN_TYPES = [
   'purge',
   'revalidate',
   'repair',
+  'merge',
 ] as const
 
 export type GatedRunType = (typeof GATED_RUN_TYPES)[number]

--- a/scripts/tests/indexer/merge-duplicate-skills.test-helpers.ts
+++ b/scripts/tests/indexer/merge-duplicate-skills.test-helpers.ts
@@ -1,0 +1,149 @@
+/**
+ * SMI-5898 Wave 2 Step 4: shared setup/fixture harness for
+ * `merge-duplicate-skills.test.ts`. Reuses `scripts/indexer/smi5879-census.pg.ts`
+ * — this repo's one existing convention for "run raw multi-statement SQL
+ * against Postgres" — same pattern as
+ * `repo-url-canonical-trigger.test-helpers.ts`.
+ *
+ * Fixture schema is a minimal mirror of the real tables' column shapes
+ * (confirmed via `information_schema.columns` against prod at implementation
+ * time), not a verbatim copy of every column the shipped tables carry.
+ *
+ * Connection: reuses the SMI-5879 suite's own env var names (both suites can
+ * point at the SAME ephemeral Postgres instance safely — each test file works
+ * in its own schema, see resetSchema() below):
+ *   SMI5879_TEST_PGHOST / SMI5879_TEST_PGPORT / SMI5879_TEST_PGUSER /
+ *   SMI5879_TEST_PGPASSWORD / SMI5879_TEST_PGDATABASE
+ *
+ *   docker run -d --name smi5879-census-test-pg -e POSTGRES_PASSWORD=testpass \
+ *     -e POSTGRES_DB=postgres -p 15499:5432 postgres:15-alpine
+ *   SMI5879_TEST_PGHOST=host.docker.internal SMI5879_TEST_PGPORT=15499 \
+ *   SMI5879_TEST_PGUSER=postgres SMI5879_TEST_PGPASSWORD=testpass \
+ *   SMI5879_TEST_PGDATABASE=postgres npx vitest run scripts/tests/indexer/merge-duplicate-skills.test.ts
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  runPsql,
+  queryScalar,
+  testConnParamsFromEnv,
+  type PgConnParams,
+} from '../../indexer/smi5879-census.pg.ts'
+
+const MIGRATION_PATH = join(
+  process.cwd(),
+  'supabase/migrations/20260819000000_smi5898_repo_url_canonical.sql'
+)
+
+export const prePushNoLiveTestPg = !testConnParamsFromEnv()
+
+const CREATE_FIXTURES_SQL = `
+CREATE TABLE skills (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  repo_url TEXT,
+  author TEXT,
+  name TEXT NOT NULL DEFAULT 'test-skill',
+  quarantined BOOLEAN NOT NULL DEFAULT false,
+  last_seen_at TIMESTAMPTZ,
+  trust_tier TEXT,
+  stars INT,
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE categories (id TEXT PRIMARY KEY);
+
+CREATE TABLE skill_categories (
+  skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+  category_id TEXT NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  PRIMARY KEY (skill_id, category_id)
+);
+
+CREATE TABLE skills_optimized (
+  skill_id TEXT PRIMARY KEY REFERENCES skills(id) ON DELETE CASCADE,
+  content_hash TEXT NOT NULL DEFAULT 'h',
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE skill_transformations (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  skill_id TEXT NOT NULL UNIQUE REFERENCES skills(id) ON DELETE CASCADE,
+  transformed_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE outreach_suppressions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id TEXT NOT NULL UNIQUE,
+  suppressed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  reason TEXT NOT NULL DEFAULT 'test'
+);
+
+CREATE TABLE outreach_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id TEXT NOT NULL,
+  filed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  repo_owner TEXT NOT NULL DEFAULT 'x',
+  repo_name TEXT NOT NULL DEFAULT 'y',
+  finding_summary JSONB NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'filed',
+  dry_run BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE TABLE quarantine_approvals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id TEXT NOT NULL,
+  reviewer_id UUID NOT NULL DEFAULT gen_random_uuid(),
+  reviewer_email TEXT NOT NULL DEFAULT 'r@example.com',
+  decision TEXT NOT NULL DEFAULT 'approve',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  required_approvals INT NOT NULL DEFAULT 2,
+  is_complete BOOLEAN NOT NULL DEFAULT false
+);
+`
+
+/** Full reset, scoped to `schemaName` (vitest's file-level parallelism means a shared `public` schema would race sibling test files). Applies the REAL shipped migration for repo_url_canonical, then the fixture tables above. */
+export async function resetSchema(conn: PgConnParams, schemaName: string): Promise<PgConnParams> {
+  await runPsql(
+    conn,
+    `DROP SCHEMA IF EXISTS "${schemaName}" CASCADE; CREATE SCHEMA "${schemaName}";`
+  )
+  const scoped: PgConnParams = { ...conn, searchPath: `${schemaName},public` }
+  await runPsql(scoped, 'CREATE EXTENSION IF NOT EXISTS pgcrypto;')
+  await runPsql(scoped, CREATE_FIXTURES_SQL)
+  const migrationSql = readFileSync(MIGRATION_PATH, 'utf8')
+  await runPsql(scoped, migrationSql)
+  return scoped
+}
+
+/** Insert a skill row via INSERT (fires the trigger, populating repo_url_canonical); returns its id. */
+export async function insertSkill(
+  conn: PgConnParams,
+  fields: Partial<{
+    repoUrl: string
+    author: string
+    name: string
+    quarantined: boolean
+    lastSeenAt: string
+    trustTier: string
+    stars: number
+    updatedAt: string
+  }>
+): Promise<string> {
+  const repoUrl = fields.repoUrl ? `'${fields.repoUrl}'` : 'NULL'
+  const author = fields.author ? `'${fields.author}'` : 'NULL'
+  const name = fields.name ? `'${fields.name}'` : `'test-skill'`
+  const quarantined = fields.quarantined ? 'true' : 'false'
+  const lastSeenAt = fields.lastSeenAt ? `'${fields.lastSeenAt}'` : 'NULL'
+  const trustTier = fields.trustTier ? `'${fields.trustTier}'` : 'NULL'
+  const stars = fields.stars ?? 'NULL'
+  const updatedAt = fields.updatedAt ? `'${fields.updatedAt}'` : 'now()'
+  const id = await queryScalar(
+    conn,
+    `INSERT INTO skills (repo_url, author, name, quarantined, last_seen_at, trust_tier, stars, updated_at)
+     VALUES (${repoUrl}, ${author}, ${name}, ${quarantined}, ${lastSeenAt}, ${trustTier}, ${stars}, ${updatedAt})
+     RETURNING id::text;`
+  )
+  if (!id) throw new Error('merge-duplicate-skills test: skill insert returned no id')
+  return id
+}

--- a/scripts/tests/indexer/merge-duplicate-skills.test.ts
+++ b/scripts/tests/indexer/merge-duplicate-skills.test.ts
@@ -1,0 +1,239 @@
+/**
+ * SMI-5898 Wave 2 Step 4: tests for `merge-duplicate-skills.ts` against a
+ * real ephemeral Postgres instance (not mocked — this repo's testing bar
+ * for PL/pgSQL-adjacent logic). See `merge-duplicate-skills.test-helpers.ts`
+ * for how to stand one up.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import {
+  queryRows,
+  testConnParamsFromEnv,
+  type PgConnParams,
+} from '../../indexer/smi5879-census.pg.ts'
+import {
+  resetSchema,
+  insertSkill,
+  prePushNoLiveTestPg,
+} from './merge-duplicate-skills.test-helpers.ts'
+import {
+  findDuplicateGroups,
+  assertGuardrail,
+  buildReversalManifest,
+  planGroup,
+  GUARDRAIL_MAX_LOSERS,
+} from '../../indexer/merge-duplicate-skills.helpers.ts'
+import { runMerge } from '../../indexer/merge-duplicate-skills.ts'
+
+describe.skipIf(prePushNoLiveTestPg)('merge-duplicate-skills (live Postgres)', () => {
+  let conn: PgConnParams
+
+  beforeAll(async () => {
+    const base = testConnParamsFromEnv()
+    if (!base) throw new Error('unreachable — describe.skipIf guards this')
+    conn = await resetSchema(base, 'merge_duplicate_skills_test')
+  })
+
+  it('findDuplicateGroups groups by repo_url_canonical and ranks the most-recently-seen row as survivor', async () => {
+    const loserId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/Owner/Repo/tree/main/skill-a',
+      author: 'owner',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+    const survivorId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/owner/repo/tree/main/skill-a',
+      author: 'owner',
+      lastSeenAt: '2026-06-01T00:00:00Z',
+    })
+
+    const groups = await findDuplicateGroups(conn)
+    const group = groups.find(
+      (g) => g.survivor.id === survivorId || g.losers.some((l) => l.id === survivorId)
+    )
+    expect(group).toBeDefined()
+    expect(group!.survivor.id).toBe(survivorId)
+    expect(group!.losers.map((l) => l.id)).toEqual([loserId])
+  })
+
+  it('a quarantined row never wins even with a later last_seen_at', async () => {
+    const cleanId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/quarantest/repo/tree/main/x',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+      quarantined: false,
+    })
+    const quarantinedId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/quarantest/repo/tree/main/x'.toLowerCase(),
+      lastSeenAt: '2026-06-01T00:00:00Z',
+      quarantined: true,
+    })
+
+    const groups = await findDuplicateGroups(conn)
+    const group = groups.find((g) =>
+      [g.survivor.id, ...g.losers.map((l) => l.id)].includes(cleanId)
+    )
+    expect(group!.survivor.id).toBe(cleanId)
+    expect(group!.losers.map((l) => l.id)).toContain(quarantinedId)
+  })
+
+  it('assertGuardrail throws when total losers exceed the guardrail', () => {
+    // +2 items so slice(1) (the losers) is GUARDRAIL_MAX_LOSERS + 1 — genuinely over, not exactly at the line.
+    const bogus = Array.from({ length: GUARDRAIL_MAX_LOSERS + 2 }, (_, i) => ({
+      id: `loser-${i}`,
+      author: null,
+      name: 'x',
+      quarantined: false,
+      last_seen_at: null,
+      trust_tier: null,
+      stars: null,
+      updated_at: null,
+      repo_url: null,
+      repo_url_canonical: 'x',
+    }))
+    expect(() =>
+      assertGuardrail([{ repoUrlCanonical: 'x', survivor: bogus[0], losers: bogus.slice(1) }])
+    ).toThrow(/guardrail/)
+  })
+
+  it('assertGuardrail does not throw at or under the guardrail', () => {
+    const bogus = Array.from({ length: GUARDRAIL_MAX_LOSERS }, (_, i) => ({
+      id: `loser-${i}`,
+      author: null,
+      name: 'x',
+      quarantined: false,
+      last_seen_at: null,
+      trust_tier: null,
+      stars: null,
+      updated_at: null,
+      repo_url: null,
+      repo_url_canonical: 'x',
+    }))
+    expect(() =>
+      assertGuardrail([{ repoUrlCanonical: 'x', survivor: bogus[0], losers: bogus.slice(1) }])
+    ).not.toThrow()
+  })
+
+  it('end-to-end --apply: merges categories, adopts an empty-survivor cache row, preserves suppression, recomputes is_complete, and deletes the loser', async () => {
+    const survivorId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/e2e/Repo/tree/main/x',
+      lastSeenAt: '2026-06-01T00:00:00Z',
+    })
+    const loserId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/e2e/repo/tree/main/x',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+
+    await queryRows(conn, `INSERT INTO categories (id) VALUES ('cat-a'), ('cat-b');`)
+    await queryRows(
+      conn,
+      `INSERT INTO skill_categories (skill_id, category_id) VALUES ('${loserId}', 'cat-a'), ('${loserId}', 'cat-b');`
+    )
+    // Loser has a skills_optimized row, survivor has none — should be adopted.
+    await queryRows(conn, `INSERT INTO skills_optimized (skill_id) VALUES ('${loserId}');`)
+    // Loser is suppressed; survivor is not — suppression must survive onto the survivor.
+    await queryRows(
+      conn,
+      `INSERT INTO outreach_suppressions (skill_id, suppressed_at) VALUES ('${loserId}', '2026-01-01T00:00:00Z');`
+    )
+    // Two approvals on the loser from distinct reviewers, required_approvals=2 — should complete after re-point.
+    await queryRows(
+      conn,
+      `INSERT INTO quarantine_approvals (skill_id, reviewer_id, required_approvals, is_complete)
+       VALUES ('${loserId}', gen_random_uuid(), 2, false), ('${loserId}', gen_random_uuid(), 2, false);`
+    )
+
+    const db = {
+      from: () => ({ insert: async () => ({ data: null, error: null }) }),
+    } as unknown as Parameters<typeof runMerge>[1]
+
+    const dryRun = await runMerge(conn, db, {
+      apply: false,
+      manifestPath: '/tmp/smi5898-merge-test-dry.json',
+    })
+    expect(dryRun.groups).toBeGreaterThanOrEqual(1)
+
+    const result = await runMerge(conn, db, {
+      apply: true,
+      manifestPath: '/tmp/smi5898-merge-test-apply.json',
+    })
+    expect(result.losersRemoved).toBeGreaterThanOrEqual(1)
+    expect(result.suppressionCountBefore).toBe(result.suppressionCountAfter)
+
+    const loserGone = await queryRows(conn, `SELECT 1 FROM skills WHERE id = '${loserId}';`)
+    expect(loserGone).toEqual([])
+
+    const survivorCats = await queryRows(
+      conn,
+      `SELECT category_id FROM skill_categories WHERE skill_id = '${survivorId}' ORDER BY category_id;`
+    )
+    expect(survivorCats.map((r) => r[0])).toEqual(['cat-a', 'cat-b'])
+
+    const survivorOptimized = await queryRows(
+      conn,
+      `SELECT 1 FROM skills_optimized WHERE skill_id = '${survivorId}';`
+    )
+    expect(survivorOptimized).toHaveLength(1)
+
+    const survivorSuppressed = await queryRows(
+      conn,
+      `SELECT 1 FROM outreach_suppressions WHERE skill_id = '${survivorId}';`
+    )
+    expect(survivorSuppressed).toHaveLength(1)
+
+    // No ::text cast — a bare boolean column renders 't'/'f' in psql's unaligned
+    // output, unlike an explicit ::text cast (which renders 'true'/'false').
+    const survivorComplete = await queryRows(
+      conn,
+      `SELECT is_complete FROM quarantine_approvals WHERE skill_id = '${survivorId}' LIMIT 1;`
+    )
+    expect(survivorComplete[0][0]).toBe('t')
+  })
+
+  it('planGroup reports skill_categories rows already on the survivor as skippedOnConflict, not rePointed', async () => {
+    const survivorId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/plangroup/Repo/tree/main/y',
+      lastSeenAt: '2026-06-01T00:00:00Z',
+    })
+    const loserId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/plangroup/repo/tree/main/y',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+    await queryRows(
+      conn,
+      `INSERT INTO categories (id) VALUES ('cat-shared') ON CONFLICT DO NOTHING;`
+    )
+    await queryRows(
+      conn,
+      `INSERT INTO skill_categories (skill_id, category_id) VALUES ('${survivorId}', 'cat-shared'), ('${loserId}', 'cat-shared');`
+    )
+
+    const groups = await findDuplicateGroups(conn)
+    const group = groups.find((g) => g.survivor.id === survivorId)!
+    const movements = await planGroup(conn, group)
+    const catMovement = movements.find((m) => m.table === 'skill_categories')!
+    expect(catMovement.rePointed).toBe(0)
+    expect(catMovement.skippedOnConflict).toBe(1)
+  })
+
+  it('buildReversalManifest captures full before-images of loser rows and touched dependent-table rows', async () => {
+    const survivorId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/manifest/Repo/tree/main/z',
+      lastSeenAt: '2026-06-01T00:00:00Z',
+    })
+    const loserId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/manifest/repo/tree/main/z',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+    await queryRows(conn, `INSERT INTO outreach_events (skill_id) VALUES ('${loserId}');`)
+
+    const groups = await findDuplicateGroups(conn)
+    const group = groups.find((g) => g.survivor.id === survivorId)!
+    const manifest = await buildReversalManifest(conn, [group])
+
+    expect(manifest.rows.skills).toHaveLength(1)
+    expect((manifest.rows.skills[0] as { id: string }).id).toBe(loserId)
+    expect(manifest.rows.outreach_events.length).toBeGreaterThanOrEqual(1)
+    expect(manifest.groups).toEqual([
+      { repoUrlCanonical: group.repoUrlCanonical, survivorId, loserIds: [loserId] },
+    ])
+  })
+})

--- a/scripts/tests/indexer/merge-duplicate-skills.test.ts
+++ b/scripts/tests/indexer/merge-duplicate-skills.test.ts
@@ -158,6 +158,14 @@ describe.skipIf(prePushNoLiveTestPg)('merge-duplicate-skills (live Postgres)', (
       manifestPath: '/tmp/smi5898-merge-test-dry.json',
     })
     expect(dryRun.groups).toBeGreaterThanOrEqual(1)
+    // Prospective delta: dry-run must compute this WITHOUT applying anything —
+    // the GPT-5.6-Sol/NEEDLE finding this fixes (dry-run previously always
+    // returned an empty array here, regardless of the true prospective delta).
+    const dryRunDelta = dryRun.isCompleteDeltas.find((d) => d.skillId === survivorId)
+    expect(dryRunDelta).toEqual({ skillId: survivorId, before: false, after: true })
+    // And dry-run must not have mutated anything — the loser is still there.
+    const loserStillThere = await queryRows(conn, `SELECT 1 FROM skills WHERE id = '${loserId}';`)
+    expect(loserStillThere).toHaveLength(1)
 
     const result = await runMerge(conn, db, {
       apply: true,
@@ -230,6 +238,50 @@ describe.skipIf(prePushNoLiveTestPg)('merge-duplicate-skills (live Postgres)', (
     const catMovement = movements.find((m) => m.table === 'skill_categories')!
     expect(catMovement.rePointed).toBe(0)
     expect(catMovement.skippedOnConflict).toBe(1)
+  })
+
+  it('--apply survives BOTH survivor and loser being independently suppressed — the exact GPT-5.6-Sol/NEEDLE finding: a global distinct-suppressed-id count comparison is unsound here (2 suppressed skill_ids collapsing to 1 is correct, not a violation)', async () => {
+    const survivorId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/multisuppress/Repo/tree/main/w',
+      lastSeenAt: '2026-06-01T00:00:00Z',
+    })
+    const loserId = await insertSkill(conn, {
+      repoUrl: 'https://github.com/multisuppress/repo/tree/main/w',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+    // BOTH the survivor and the loser are independently suppressed —
+    // pre-merge this group has 2 distinct suppressed skill_ids.
+    await queryRows(
+      conn,
+      `INSERT INTO outreach_suppressions (skill_id, suppressed_at) VALUES
+         ('${survivorId}', '2026-02-01T00:00:00Z'),
+         ('${loserId}', '2026-01-01T00:00:00Z');`
+    )
+
+    const db = {
+      from: () => ({ insert: async () => ({ data: null, error: null }) }),
+    } as unknown as Parameters<typeof runMerge>[1]
+
+    // Must NOT throw — the fixed per-group check only requires exactly one
+    // suppression row survive for THIS group, not that the global count stay
+    // identical (it legitimately drops from 2 to 1 here).
+    await expect(
+      runMerge(conn, db, {
+        apply: true,
+        manifestPath: '/tmp/smi5898-merge-test-multisuppress.json',
+      })
+    ).resolves.toBeDefined()
+
+    const survivorSuppressions = await queryRows(
+      conn,
+      `SELECT 1 FROM outreach_suppressions WHERE skill_id = '${survivorId}';`
+    )
+    expect(survivorSuppressions).toHaveLength(1)
+    const loserSuppressions = await queryRows(
+      conn,
+      `SELECT 1 FROM outreach_suppressions WHERE skill_id = '${loserId}';`
+    )
+    expect(loserSuppressions).toEqual([])
   })
 
   it('buildReversalManifest captures full before-images of loser rows and touched dependent-table rows', async () => {

--- a/scripts/tests/indexer/merge-duplicate-skills.test.ts
+++ b/scripts/tests/indexer/merge-duplicate-skills.test.ts
@@ -141,8 +141,16 @@ describe.skipIf(prePushNoLiveTestPg)('merge-duplicate-skills (live Postgres)', (
        VALUES ('${loserId}', gen_random_uuid(), 2, false), ('${loserId}', gen_random_uuid(), 2, false);`
     )
 
+    // Spy, not a bare stub returning success unconditionally — asserted below
+    // so a broken audit_logs call shape would actually fail this test.
+    const auditInserts: Array<Record<string, unknown>> = []
     const db = {
-      from: () => ({ insert: async () => ({ data: null, error: null }) }),
+      from: (table: string) => ({
+        insert: async (row: Record<string, unknown>) => {
+          if (table === 'audit_logs') auditInserts.push(row)
+          return { data: null, error: null }
+        },
+      }),
     } as unknown as Parameters<typeof runMerge>[1]
 
     const dryRun = await runMerge(conn, db, {
@@ -157,6 +165,16 @@ describe.skipIf(prePushNoLiveTestPg)('merge-duplicate-skills (live Postgres)', (
     })
     expect(result.losersRemoved).toBeGreaterThanOrEqual(1)
     expect(result.suppressionCountBefore).toBe(result.suppressionCountAfter)
+    expect(auditInserts).toHaveLength(1)
+    expect(auditInserts[0]).toMatchObject({
+      event_type: 'skills:merge_duplicates',
+      resource: 'skills',
+      action: 'merge_duplicate_skills',
+      result: 'success',
+    })
+    expect((auditInserts[0].metadata as { losersRemoved: number }).losersRemoved).toBe(
+      result.losersRemoved
+    )
 
     const loserGone = await queryRows(conn, `SELECT 1 FROM skills WHERE id = '${loserId}';`)
     expect(loserGone).toEqual([])

--- a/scripts/tests/indexer/run-gate-callsites.test.ts
+++ b/scripts/tests/indexer/run-gate-callsites.test.ts
@@ -82,6 +82,7 @@ import {
 
 const PINNED_SHAPE1 = [
   'dequarantine-false-positives.ts',
+  'merge-duplicate-skills.ts',
   'purge-dead-quarantines.ts',
   'repair-latched-name-rows.ts',
   'revalidate-stale-quarantines.ts',
@@ -100,6 +101,7 @@ const PINNED_SHAPE4_UNGATED_GUARD = [
 
 const PINNED_SHEBANG_FILES = [
   'dequarantine-false-positives.ts',
+  'merge-duplicate-skills.ts',
   'purge-dead-quarantines.ts',
   'recheck.ts',
   'repair-latched-name-rows.ts',


### PR DESCRIPTION
## Business Summary

**What shipped:** A script that merges the 36 duplicate registry rows created by one GitHub repository's case-only rename (`gabrielwithappy/agentOS` → `agentos`) into 36 clean rows — the last data cleanup step before SMI-5898's fix can go fully live. It defaults to a safe preview mode (`--dry-run`) and only touches real data with an explicit `--apply` flag.

**Quality bar:** 27 tests run against a real database (not mocked), including a full end-to-end run verifying every rule. A `--dry-run` against the actual production data confirmed the expected 36 rows, then went through an independent second review — which caught a real bug: a safety check meant to guarantee no skill's "do not contact" preference gets lost was only checked *after* the database change had already happened, too late to undo anything if it ever failed. Fixed and re-reviewed a third time by an independent pass specifically checking the fix itself, which found no remaining issues.

**Net result:** Script written, tested, reviewed, dry-run verified against production, and the one real bug that surfaced along the way is fixed and re-confirmed. Nothing has touched production data yet — the registry's live indexer writers are still paused from an earlier step, and the actual merge (`--apply`) is held for explicit sign-off before it runs, per this repo's convention for the first genuinely destructive step in a data-cleanup change.

---

## Technical detail

Adds `scripts/indexer/merge-duplicate-skills.ts` (+ `.helpers.ts`, `.types.ts`, tests) implementing design doc §B.3.2's per-table merge rules: union-insert for `skill_categories`, adopt-if-empty for `skills_optimized`/`skill_transformations`, sticky re-point for `outreach_suppressions`, append-all for `outreach_events`, re-point + `is_complete` recompute for `quarantine_approvals`. Writes a full reversal manifest before any mutation; `--apply` refuses to run if that write fails.

Runs the entire `--apply` transaction via a single `psql` shell-out (`scripts/indexer/smi5879-census.pg.ts`'s `runPsql`), not the `pg` npm client or supabase-js — `pg` isn't an installed dependency and can't become one from inside a worktree (`node_modules` is read-only there), and PostgREST/supabase-js can't express the single-transaction atomicity the design doc requires across `skills` + six dependent tables.

Adds `'merge'` to `scripts/indexer/run-gate.ts`'s `GATED_RUN_TYPES` (the SMI-5879 freeze gate), and updates `run-gate-callsites.test.ts`'s pinned census sets accordingly.

**Suppression-preservation fix** (commit `6e26fe3a4`): the original invariant check compared a global count of distinct suppressed skill IDs before vs. after, computed *after* the transaction had already committed. Both properties were wrong — the check ran too late to prevent anything, and the comparison itself was mathematically unsound whenever a group had more than one suppressed member (correctly collapsing 2 suppressed IDs into 1 survivor legitimately changes that count). Fixed with a per-group assertion emitted inside the same SQL script, before `COMMIT`, so a real violation now genuinely rolls back the transaction instead of alarming after the fact. Also fixed: dry-run now computes the true prospective `is_complete` delta instead of always reporting zero, and per-table row-movement counts are now actually printed.

Code review report + addendum: `docs/internal/code_review/2026-08-25-smi5898-wave2-step4-merge-script-review.md`.