### PR TITLE
docs(blog): SMI-6173 cross-machine skill inventory live-test walkthrough

### DIFF
--- a/packages/website/src/content/blog/cross-machine-inventory-live-test.md
+++ b/packages/website/src/content/blog/cross-machine-inventory-live-test.md
@@ -11,9 +11,9 @@ draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/cross-machine-inventory-live-test/skill-inventory-list"
 ---
 
-If you use more than one machine — a laptop and a desktop, a work machine and a personal one — you've probably had this moment: you reach for a skill you know you have, and it isn't there. It's on the *other* computer.
+If you use more than one machine, say a laptop and a desktop, or a work machine and a personal one, you've probably had this moment: you reach for a skill you know you have, and it isn't there. It's on the *other* computer.
 
-Skillsmith's installed-skill inventory fixes that. Push from any machine, and a read-only dashboard shows you what's installed everywhere — plus which skills have a newer version waiting. Here's what that actually looks like, end to end.
+Skillsmith's installed-skill inventory fixes that. Push from any machine, and a read-only dashboard shows you what's installed everywhere, plus which skills have a newer version waiting. Here's what that actually looks like, end to end.
 
 ## Turn it on
 
@@ -21,7 +21,7 @@ Cross-machine inventory is opt-in and off by default. One toggle, under **Accoun
 
 ![Cross-machine skill inventory toggle, switched on](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/cross-machine-inventory-live-test/telemetry-toggle)
 
-The page tells you exactly what gets shared before you flip it: a random device ID that's never linked to your name, an optional label you set yourself, your OS and CLI version, and — per skill — the harness, skill ID, version, and content hash. What never leaves your machine: your real hostname, file contents, file paths, or skill source code.
+The page tells you exactly what gets shared before you flip it: a random device ID that's never linked to your name, an optional label you set yourself, your OS and CLI version, and (per skill) the harness, skill ID, version, and content hash. What never leaves your machine: your real hostname, file contents, file paths, or skill source code.
 
 ## Push from a machine
 
@@ -31,7 +31,7 @@ With the toggle on, one command:
 skillsmith inventory push
 ```
 
-That's it. The CLI walks every harness it knows about — Claude Code, Cursor, Copilot, Windsurf, and more — finds what's actually installed, and uploads the metadata.
+That's it. The CLI walks every harness it knows about (Claude Code, Cursor, Copilot, Windsurf, and more), finds what's actually installed, and uploads the metadata.
 
 ## See it on the dashboard
 
@@ -39,12 +39,12 @@ Head to **Account → Skill Inventory**, and the machine that just pushed shows 
 
 ![Skill inventory dashboard showing a synced device with several skills flagged as having updates available](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/cross-machine-inventory-live-test/skill-inventory-list)
 
-This is the part that actually surprised me running it live: Skillsmith doesn't just list what's installed — it cross-references every skill's content hash against the registry's latest version, in real time. Anything that's drifted gets a clear **Update available** badge, right next to the exact command to fix it. No separate "check for updates" step; the dashboard already did it the moment the push landed.
+This is the part that actually surprised me running it live: Skillsmith cross-references every skill's content hash against the registry's latest version, in real time. Anything that's drifted gets a clear **Update available** badge, right next to the exact command to fix it. There's no separate "check for updates" step; the dashboard already did it the moment the push landed.
 
-Push from a second machine, and the same view becomes a real cross-machine comparison — which skills you have everywhere, which ones are only on one box, and which ones are quietly out of date on both.
+Push from a second machine, and the same view becomes a real cross-machine comparison: which skills you have everywhere, which ones are only on one box, and which ones are quietly out of date on both.
 
 ## Why this matters beyond "don't lose track of your skills"
 
-The obvious win is personal: never wonder again whether the skill you want is on this laptop. But the same mechanism is the foundation for something bigger we're building next — using this exact inventory pipeline as the on-ramp for **team private registries**. A team member's machine already knows what's installed; the natural next step is letting a team admin pull those skills straight into the team's shared, curated registry, instead of everyone re-discovering and re-installing the same things independently.
+The obvious win is personal: never wonder again whether the skill you want is on this laptop. But the same mechanism is the foundation for something bigger we're building next: using this exact inventory pipeline as the on-ramp for **team private registries**. A team member's machine already knows what's installed; the natural next step is letting a team admin pull those skills straight into the team's shared, curated registry, instead of everyone re-discovering and re-installing the same things independently.
 
 Read-only visibility today, a real team workflow next. Turn it on, run the push, and see your own machines show up.

--- a/packages/website/src/content/blog/cross-machine-inventory-live-test.md
+++ b/packages/website/src/content/blog/cross-machine-inventory-live-test.md
@@ -6,7 +6,7 @@ date: 2026-08-21
 updated: 2026-08-21
 category: "Guides"
 tags: ["cross-machine-inventory", "skill-management", "cli", "mcp", "developer-productivity", "skill-updates"]
-draft: true
+draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/cross-machine-inventory-live-test/skill-inventory-list"
 ---
 

--- a/packages/website/src/content/blog/cross-machine-inventory-live-test.md
+++ b/packages/website/src/content/blog/cross-machine-inventory-live-test.md
@@ -1,0 +1,50 @@
+---
+title: "Your Skills, Across Every Machine You Use"
+description: "A walkthrough of Skillsmith's cross-machine skill inventory: push what's installed on one machine, see it on the dashboard, and know at a glance which skills have updates waiting."
+author: "Ryan Smith"
+date: 2026-08-21
+updated: 2026-08-21
+category: "Guides"
+tags: ["cross-machine-inventory", "skill-management", "cli", "mcp", "developer-productivity", "skill-updates"]
+featured: false
+draft: false
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/cross-machine-inventory-live-test/skill-inventory-list"
+---
+
+If you use more than one machine — a laptop and a desktop, a work machine and a personal one — you've probably had this moment: you reach for a skill you know you have, and it isn't there. It's on the *other* computer.
+
+Skillsmith's installed-skill inventory fixes that. Push from any machine, and a read-only dashboard shows you what's installed everywhere — plus which skills have a newer version waiting. Here's what that actually looks like, end to end.
+
+## Turn it on
+
+Cross-machine inventory is opt-in and off by default. One toggle, under **Account → Telemetry**:
+
+![Cross-machine skill inventory toggle, switched on](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/cross-machine-inventory-live-test/telemetry-toggle)
+
+The page tells you exactly what gets shared before you flip it: a random device ID that's never linked to your name, an optional label you set yourself, your OS and CLI version, and — per skill — the harness, skill ID, version, and content hash. What never leaves your machine: your real hostname, file contents, file paths, or skill source code.
+
+## Push from a machine
+
+With the toggle on, one command:
+
+```bash
+skillsmith inventory push
+```
+
+That's it. The CLI walks every harness it knows about — Claude Code, Cursor, Copilot, Windsurf, and more — finds what's actually installed, and uploads the metadata.
+
+## See it on the dashboard
+
+Head to **Account → Skill Inventory**, and the machine that just pushed shows up immediately:
+
+![Skill inventory dashboard showing a synced device with several skills flagged as having updates available](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/cross-machine-inventory-live-test/skill-inventory-list)
+
+This is the part that actually surprised me running it live: Skillsmith doesn't just list what's installed — it cross-references every skill's content hash against the registry's latest version, in real time. Anything that's drifted gets a clear **Update available** badge, right next to the exact command to fix it. No separate "check for updates" step; the dashboard already did it the moment the push landed.
+
+Push from a second machine, and the same view becomes a real cross-machine comparison — which skills you have everywhere, which ones are only on one box, and which ones are quietly out of date on both.
+
+## Why this matters beyond "don't lose track of your skills"
+
+The obvious win is personal: never wonder again whether the skill you want is on this laptop. But the same mechanism is the foundation for something bigger we're building next — using this exact inventory pipeline as the on-ramp for **team private registries**. A team member's machine already knows what's installed; the natural next step is letting a team admin pull those skills straight into the team's shared, curated registry, instead of everyone re-discovering and re-installing the same things independently.
+
+Read-only visibility today, a real team workflow next. Turn it on, run the push, and see your own machines show up.

--- a/packages/website/src/content/blog/cross-machine-inventory-live-test.md
+++ b/packages/website/src/content/blog/cross-machine-inventory-live-test.md
@@ -6,8 +6,7 @@ date: 2026-08-21
 updated: 2026-08-21
 category: "Guides"
 tags: ["cross-machine-inventory", "skill-management", "cli", "mcp", "developer-productivity", "skill-updates"]
-featured: false
-draft: false
+draft: true
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/cross-machine-inventory-live-test/skill-inventory-list"
 ---
 


### PR DESCRIPTION
## Business Summary

**What shipped:** A new blog post walking through Skillsmith's cross-machine skill inventory feature end-to-end — turning it on, pushing from a machine, and seeing the dashboard flag out-of-date skills in real time. Written from an actual live test run, with real screenshots.

**Quality bar:** Content already through a plain-language style pass (a follow-up commit removed em dashes and indirect phrasing). Both images independently verified live on Cloudinary (200, correct dimensions). Rebased cleanly onto current main — no drift, no conflicts.

**Net result:** Set to `draft: true`, so merging this does **not** publish it — it stays off the live `/blog` listing until reviewed and flipped to `draft: false` in a follow-up. This matches the original author's own note that it wasn't yet approved for prod.

---

## Technical detail

Tracked as SMI-6173. This branch existed locally with 2 real commits and no PR ever opened — found during end-of-session cleanup, rebased onto main (was 4 days stale), and given one small fix: `draft: false` → `draft: true`, plus dropping the now-dead `featured` frontmatter field (removed from the schema entirely by SMI-6162).

Single file changed: `packages/website/src/content/blog/cross-machine-inventory-live-test.md`.

[skip-impl-check]