### PR TITLE
feat(indexer): SMI-6015 Wave 2 N-way shard-merge tool

### DIFF
--- a/scripts/indexer/smi5879-merge-shards.merge-rules.ts
+++ b/scripts/indexer/smi5879-merge-shards.merge-rules.ts
@@ -1,0 +1,416 @@
+/**
+ * Pure merge rules and invariant assertions for `smi5879-merge-shards.ts`.
+ * Split into its own module per CLAUDE.md's <500-line-per-file convention,
+ * the same way `smi5879-simulate-full.ts` already splits its own
+ * `.cli.ts`/`.checkpoint.ts`/`.sweep.ts`/`.output.ts` siblings: this file
+ * owns every row of the plan's merge-rule table plus every invariant that
+ * table names, while `smi5879-merge-shards.ts` owns argument parsing, the
+ * injected DB round trip, orchestration order, and the atomic write.
+ * @module scripts/indexer/smi5879-merge-shards.merge-rules
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)")
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.3.5.2.4/§8.4/§8.5
+ *
+ * THE SAFETY PROPERTY THIS FILE ENFORCES
+ * --------------------------------------
+ * N shard processes each produce a `report_kind: 'full_simulation'` report
+ * covering a disjoint slice of ONE sealed decision generation's population.
+ * `smi5879-gate-check.ts` accepts exactly one such report per decision
+ * `run_id` and derives a MERGE-GATE decision from it (G-1's R set, G-2's
+ * coverage, G-3's two-sided counts, G-5's +32 delta bound). The merged report
+ * assembled here is therefore the single artifact standing between N
+ * independent, days-long, partially-observable fetch processes and a security
+ * gate deciding whether a scanner port may ship.
+ *
+ * The property that must hold is NOT "the arithmetic balances" — a merge that
+ * silently drops one shard's rows balances perfectly against its own dropped
+ * coverage numbers, and a same-cohort id substituted for a genuinely-lost row
+ * keeps every count intact. The property is EXACT SET EQUALITY between the
+ * merged `rows` id set and the authoritative sealed population's id set: zero
+ * missing, zero extra, zero duplicate, with each row's canonical fields
+ * agreeing. That check — and the digest-verified population load it depends
+ * on — lives in the `.population.ts` sibling; this file holds everything the
+ * merge does with the shard reports themselves.
+ *
+ * Everything here is defense in depth around that property, following
+ * the "never trust the label alone" rule `evaluateG2` applies to a report's
+ * own `coverage[cohort].status` (`smi5879-gate-check.gates.ts`): every derived
+ * field is RECOMPUTED here and cross-checked against what the shard reports
+ * claimed, and any disagreement throws rather than silently picking a winner.
+ */
+
+import {
+  ALL_SIMULATED_COHORTS,
+  SIM_ROW_OUTCOMES,
+  EMPTY_OUTCOME_COUNTS,
+} from './smi5879-simulate-full.types.ts'
+import type {
+  CohortCoverage,
+  CoverageByCohort,
+  SimRowOutcome,
+  SimRowResult,
+  Smi5879SimulateFullReport,
+  SweepHardStopReason,
+} from './smi5879-simulate-full.types.ts'
+
+/** One shard report plus the path it was read from — the path appears verbatim in every error. */
+export interface ShardReportInput {
+  path: string
+  report: Smi5879SimulateFullReport
+}
+
+/**
+ * Scalar fields that must be byte-identical across all N shard reports. A
+ * mismatch in any of them means the reports do not describe one run of one
+ * generation against one baseline, so no merge of them is meaningful — the
+ * plan calls for a loud failure here specifically because "pick the first
+ * one" would produce a report that looks well-formed and gates cleanly while
+ * describing a run that never happened.
+ */
+const IDENTITY_FIELDS = [
+  'report_kind',
+  'run_id',
+  'purpose',
+  'status',
+  'token_source',
+  'baseline_commit',
+] as const
+
+export type ShardIdentity = Pick<Smi5879SimulateFullReport, (typeof IDENTITY_FIELDS)[number]>
+
+/**
+ * How many offending ids to name before truncating — matches G-1/G-2R's own
+ * `slice(0, 10)` precedent. Exported alongside {@link formatIds} so the
+ * `.population.ts` sibling formats its own id lists identically rather than
+ * growing a second, subtly-different truncation convention.
+ */
+export const MAX_IDS_IN_ERROR = 10
+
+export function formatIds(ids: readonly string[]): string {
+  return `${ids.slice(0, MAX_IDS_IN_ERROR).join(', ')}${ids.length > MAX_IDS_IN_ERROR ? ', ...' : ''}`
+}
+
+/**
+ * `loadSimulatorReport` (`smi5879-gate-check.io.ts`) validates every numeric
+ * field with a bare `typeof n !== 'number'` — which `NaN`, `Infinity`, `-1`
+ * and `1.5` all pass. Adequate for the gate, which only compares those
+ * numbers; NOT adequate for a merge, where one `NaN` addend silently poisons
+ * an entire summed cohort (`NaN <= total` is `false`, so even the bound
+ * checks below would report a confusing failure rather than the real cause)
+ * and a fractional/negative count would survive into the merged artifact
+ * unremarked. Every number consumed from a shard report passes through here.
+ */
+function assertNonNegativeInteger(value: number, label: string, path: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `SMI-6015: shard report at ${path} has ${label}=${String(value)}, which is not a ` +
+        'non-negative integer. Merging would propagate a nonsensical (NaN/negative/fractional) ' +
+        'count into the gate-eligible merged report — refusing to merge a malformed shard report.'
+    )
+  }
+}
+
+/** Validate every numeric field of one shard report up front, before any arithmetic touches it. */
+export function assertShardReportNumericSanity(input: ShardReportInput): void {
+  assertNonNegativeInteger(input.report.sweep.passes_run, 'sweep.passes_run', input.path)
+  for (const cohort of ALL_SIMULATED_COHORTS) {
+    const c = input.report.coverage[cohort]
+    assertNonNegativeInteger(c.total, `coverage.${cohort}.total`, input.path)
+    assertNonNegativeInteger(c.scanned, `coverage.${cohort}.scanned`, input.path)
+    assertNonNegativeInteger(c.unevaluable, `coverage.${cohort}.unevaluable`, input.path)
+    assertNonNegativeInteger(c.unfetchable, `coverage.${cohort}.unfetchable`, input.path)
+  }
+  for (const outcome of SIM_ROW_OUTCOMES) {
+    assertNonNegativeInteger(input.report.counts[outcome], `counts.${outcome}`, input.path)
+  }
+}
+
+/**
+ * Plan merge-rule table, row 1: the {@link IDENTITY_FIELDS} must be identical
+ * across all N shard reports — "fail loudly (not silently pick one) on any
+ * mismatch". Every mismatching field is collected and reported at once (the
+ * `assertCheckpointIdentity` precedent, `smi5879-simulate-full.checkpoint.ts`)
+ * so one run tells the operator everything that is wrong.
+ */
+export function assertIdenticalIdentityFields(inputs: readonly ShardReportInput[]): ShardIdentity {
+  const first = inputs[0]
+  if (first === undefined) {
+    throw new Error('SMI-6015: cannot merge zero shard reports — at least one is required.')
+  }
+  const mismatches: string[] = []
+  for (const field of IDENTITY_FIELDS) {
+    for (const input of inputs.slice(1)) {
+      if (input.report[field] !== first.report[field]) {
+        mismatches.push(
+          `${field} (${first.path}="${first.report[field]}", ${input.path}="${input.report[field]}")`
+        )
+      }
+    }
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      'SMI-6015: shard reports disagree on field(s) that must be identical across every shard of ' +
+        `one run — ${mismatches.join('; ')}. These reports do not describe one run of one ` +
+        'generation against one baseline commit; refusing to merge them into a single ' +
+        "gate-eligible report rather than silently adopting one shard's value."
+    )
+  }
+  return {
+    report_kind: first.report.report_kind,
+    run_id: first.report.run_id,
+    purpose: first.report.purpose,
+    status: first.report.status,
+    token_source: first.report.token_source,
+    baseline_commit: first.report.baseline_commit,
+  }
+}
+
+/**
+ * Plan merge-rule table, `rows` row: CONCATENATED across all N shards, with
+ * row-id disjointness enforced — every `row.id` must appear in exactly one
+ * shard's `rows` array.
+ *
+ * Disjointness is NECESSARY BUT NOT SUFFICIENT (plan §3, round-1 review
+ * Critical finding #2): it proves no row was double-counted and says nothing
+ * about rows no shard reported at all. `assertMergedRowsMatchPopulation`
+ * (`.population.ts`) closes that hole; this check exists so an overlap is
+ * diagnosed AS an overlap (naming both shard files) instead of surfacing later
+ * as a confusing "extra row" against the population.
+ *
+ * Concatenation order is the operator's `--reports` order, deliberately not
+ * re-sorted: no downstream consumer indexes `rows` positionally (G-1's
+ * `computeR`, G-3's direction counts, G-5's per-row bound and
+ * `validateSimulatorReportConsistency` all filter or tally), so a canonical
+ * order would buy byte-stability across operators without buying correctness.
+ */
+export function mergeRows(inputs: readonly ShardReportInput[]): SimRowResult[] {
+  const merged: SimRowResult[] = []
+  const seenAt = new Map<string, string>()
+  const duplicates: string[] = []
+  for (const input of inputs) {
+    for (const row of input.report.rows) {
+      const priorPath = seenAt.get(row.id)
+      if (priorPath !== undefined) {
+        duplicates.push(`${row.id} (in both ${priorPath} and ${input.path})`)
+        continue
+      }
+      seenAt.set(row.id, input.path)
+      merged.push(row)
+    }
+  }
+  if (duplicates.length > 0) {
+    throw new Error(
+      `SMI-6015: ${duplicates.length} row id(s) appear in more than one shard report, so the ` +
+        'shards did not process disjoint slices of the population: ' +
+        `${duplicates.slice(0, MAX_IDS_IN_ERROR).join('; ')}` +
+        `${duplicates.length > MAX_IDS_IN_ERROR ? `, and ${duplicates.length - MAX_IDS_IN_ERROR} more` : ''}. ` +
+        'Merging would double-count these rows in coverage and counts. Check that each shard ran ' +
+        'with the correct --shard-index/--shard-count pair.'
+    )
+  }
+  return merged
+}
+
+/**
+ * Plan merge-rule table, `coverage` rows.
+ *
+ * - `total`: must be IDENTICAL across all N shard reports — every shard
+ *   reports the TRUE full-population total for every cohort (plan §1: the
+ *   shard filter is applied AFTER `loadCohortRows`, never to it).
+ * - `scanned`/`unevaluable`/`unfetchable`: SUMMED. `scanned` already CONTAINS
+ *   `unevaluable`/`unfetchable`/`bundle_absent` as SUBSETS, so they are never
+ *   added to it as separate addends (round-1 review High finding #3).
+ * - `status`: RECOMPUTED, never copied from any shard — `'full'` iff
+ *   `scanned === total && unevaluable === 0` over the MERGED sums, mirroring
+ *   `evaluateG2`'s own independent recheck of exactly those two facts.
+ *
+ * On top of the plan's bound checks, each summed value is independently
+ * re-derived from `mergedRows` and compared: a shard whose `coverage`
+ * disagrees with its own `rows` would otherwise carry that disagreement into
+ * the merged artifact, where `validateSimulatorReportConsistency`
+ * (`smi5879-gate-check.io.ts`) would reject it much later with no indication
+ * of WHICH shard introduced it. This also guarantees by construction that the
+ * merged report satisfies that same validator.
+ */
+export function mergeCoverage(
+  inputs: readonly ShardReportInput[],
+  mergedRows: readonly SimRowResult[]
+): CoverageByCohort {
+  const first = inputs[0]
+  if (first === undefined) {
+    throw new Error('SMI-6015: cannot merge coverage from zero shard reports.')
+  }
+  const coverage = {} as CoverageByCohort
+  for (const cohort of ALL_SIMULATED_COHORTS) {
+    const total = first.report.coverage[cohort].total
+    for (const input of inputs.slice(1)) {
+      const otherTotal = input.report.coverage[cohort].total
+      if (otherTotal !== total) {
+        throw new Error(
+          `SMI-6015: shard reports disagree on coverage.${cohort}.total ` +
+            `(${first.path}=${total}, ${input.path}=${otherTotal}). Every shard must report the ` +
+            'TRUE full-population total for every cohort — a disagreement means the shards ran ' +
+            'against different populations, or one filtered its row load instead of filtering ' +
+            'after it. Refusing to merge.'
+        )
+      }
+    }
+
+    let scanned = 0
+    let unevaluable = 0
+    let unfetchable = 0
+    for (const input of inputs) {
+      const c = input.report.coverage[cohort]
+      scanned += c.scanned
+      unevaluable += c.unevaluable
+      unfetchable += c.unfetchable
+    }
+
+    const cohortRows = mergedRows.filter((r) => r.cohort === cohort)
+    const summed = { scanned, unevaluable, unfetchable }
+    const recomputed = {
+      scanned: cohortRows.length,
+      unevaluable: cohortRows.filter((r) => r.outcome === 'unevaluable').length,
+      unfetchable: cohortRows.filter((r) => r.outcome === 'unfetchable').length,
+    }
+    for (const key of ['scanned', 'unevaluable', 'unfetchable'] as const) {
+      if (summed[key] !== recomputed[key]) {
+        throw new Error(
+          `SMI-6015: summed coverage.${cohort}.${key}=${summed[key]} across the shard reports does ` +
+            `not equal the ${recomputed[key]} matching row(s) actually present in the merged rows. ` +
+            "At least one shard's coverage disagrees with its own rows array — that report is " +
+            'internally inconsistent and must not be merged into a gate-eligible artifact.'
+        )
+      }
+    }
+
+    if (scanned > total) {
+      throw new Error(
+        `SMI-6015: merged coverage.${cohort}.scanned=${scanned} exceeds coverage.${cohort}.total=` +
+          `${total} — the shards collectively reported more rows than the cohort contains.`
+      )
+    }
+    if (unevaluable > scanned || unfetchable > scanned) {
+      throw new Error(
+        `SMI-6015: merged coverage.${cohort} subset count(s) exceed scanned=${scanned} ` +
+          `(unevaluable=${unevaluable}, unfetchable=${unfetchable}). Both are SUBSETS of scanned, ` +
+          'never addends to it.'
+      )
+    }
+
+    const status: CohortCoverage['status'] =
+      scanned === total && unevaluable === 0 ? 'full' : 'partial'
+    coverage[cohort] = { status, scanned, total, unevaluable, unfetchable }
+  }
+  return coverage
+}
+
+/**
+ * Plan merge-rule table, `counts` row: RECOMPUTED from the merged `rows`
+ * array directly, NOT summed from the shard reports' own `counts` fields —
+ * defense in depth, the same principle as the coverage recheck above.
+ *
+ * The tally is deliberately re-implemented here rather than importing
+ * `summarizeCounts` from `smi5879-simulate-full.sweep.ts`: that function is
+ * the PRODUCER of the numbers this tool exists to verify, and a verifier
+ * running the producer's own arithmetic cannot detect a fault in it. The
+ * closed outcome VOCABULARY is still shared (`SIM_ROW_OUTCOMES`/
+ * `EMPTY_OUTCOME_COUNTS`, whose module doc names them the single source of
+ * truth) — a vocabulary that drifted between producer and verifier would
+ * itself be a bug, whereas independently-derived arithmetic is the point.
+ */
+export function recomputeCounts(rows: readonly SimRowResult[]): Record<SimRowOutcome, number> {
+  const counts: Record<SimRowOutcome, number> = { ...EMPTY_OUTCOME_COUNTS }
+  for (const row of rows) counts[row.outcome] += 1
+  return counts
+}
+
+/** Plan merge-rule table, `counts` row invariant: `sum(counts) === rows.length`. */
+export function assertCountsBalance(
+  counts: Record<SimRowOutcome, number>,
+  rows: readonly SimRowResult[]
+): void {
+  const sum = SIM_ROW_OUTCOMES.reduce((acc, outcome) => acc + counts[outcome], 0)
+  if (sum !== rows.length) {
+    throw new Error(
+      `SMI-6015: recomputed counts sum to ${sum} across all outcome buckets but the merged rows ` +
+        `array holds ${rows.length} row(s). An outcome outside the closed SimRowOutcome ` +
+        'vocabulary would produce exactly this — refusing to write an unbalanced merged report.'
+    )
+  }
+}
+
+/**
+ * Plan merge-rule table, `sweep` rows.
+ *
+ * - `passes_run`: `max()` across shards. Reported only, no gating semantics.
+ * - `hard_stopped`: non-null if ANY shard's is non-null. This feeds G-2's hard
+ *   gate directly (`smi5879-gate-check.gates.ts`: a non-null `hard_stopped` is
+ *   an immediate INCONCLUSIVE), so silently nulling out one shard's
+ *   non-convergence would let the gate pass on data that never finished.
+ *
+ * Two or more shards reporting DIFFERENT non-null reasons is itself a
+ * hard-fail (round-1 review Medium finding), not an arbitrary pick — a
+ * silently-chosen reason under disagreement is a diagnosability regression at
+ * the exact moment an operator most needs to know what happened. Because
+ * disagreement throws, the surviving selection only ever chooses among
+ * IDENTICAL values, which makes the result deterministic regardless of the
+ * order `--reports` was given in.
+ */
+export function mergeSweep(
+  inputs: readonly ShardReportInput[]
+): Smi5879SimulateFullReport['sweep'] {
+  let passesRun = 0
+  for (const input of inputs) passesRun = Math.max(passesRun, input.report.sweep.passes_run)
+
+  const stopped = inputs.filter((i) => i.report.sweep.hard_stopped !== null)
+  const distinctReasons = new Set<SweepHardStopReason>(
+    stopped.map((i) => i.report.sweep.hard_stopped)
+  )
+  if (distinctReasons.size > 1) {
+    throw new Error(
+      'SMI-6015: shard reports disagree on sweep.hard_stopped — ' +
+        `${stopped.map((i) => `${i.path}="${String(i.report.sweep.hard_stopped)}"`).join(', ')}. ` +
+        'Picking one arbitrarily would discard the other reason(s) at the exact point an operator ' +
+        'needs them; resolve why the shards terminated differently before merging.'
+    )
+  }
+  return { passes_run: passesRun, hard_stopped: stopped[0]?.report.sweep.hard_stopped ?? null }
+}
+
+/**
+ * Assemble the merged report from already-verified parts. `coverage`, `rows`
+ * and `counts` are three independently-writable views over the same
+ * underlying data (`smi5879-gate-check.io.ts`'s finding #7), which is why
+ * each is recomputed and cross-checked by the functions above before reaching
+ * this assembler rather than trusted from the shard reports.
+ *
+ * `estimated_completion_at` is `null` — a merge is a post-hoc step over
+ * already-finished shards, never a live estimate. `generated_at` is this
+ * tool's own timestamp, injected by the caller so the merge stays a pure
+ * function of its inputs and is therefore testable.
+ */
+export function assembleMergedReport(
+  identity: ShardIdentity,
+  coverage: CoverageByCohort,
+  rows: SimRowResult[],
+  counts: Record<SimRowOutcome, number>,
+  sweep: Smi5879SimulateFullReport['sweep'],
+  generatedAt: string
+): Smi5879SimulateFullReport {
+  return {
+    report_kind: 'full_simulation',
+    run_id: identity.run_id,
+    purpose: identity.purpose,
+    status: identity.status,
+    token_source: identity.token_source,
+    baseline_commit: identity.baseline_commit,
+    coverage,
+    estimated_completion_at: null,
+    sweep,
+    rows,
+    counts,
+    generated_at: generatedAt,
+  }
+}

--- a/scripts/indexer/smi5879-merge-shards.merge-rules.ts
+++ b/scripts/indexer/smi5879-merge-shards.merge-rules.ts
@@ -212,6 +212,9 @@ export function mergeRows(inputs: readonly ShardReportInput[]): SimRowResult[] {
   return merged
 }
 
+// `assertRowOutcomeCoherence` lives in the `.outcome-coherence.ts` sibling
+// (500-line budget — this file was at 499/500 with it inline).
+
 /**
  * Plan merge-rule table, `coverage` rows.
  *

--- a/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
+++ b/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
@@ -10,7 +10,7 @@
  *
  * WHY THIS CHECK EXISTS
  * ----------------------
- * Wave 2 adversarial review finding: none of `.merge-rules.ts`'s checks —
+ * Wave 2 adversarial review, round 1: none of `.merge-rules.ts`'s checks —
  * id disjointness, population set-equality, per-cohort/author/name
  * agreement — verify that a row's `outcome` LABEL is actually consistent
  * with its own `prePortQuarantine`/`postPortQuarantine` fields. A row with
@@ -22,9 +22,31 @@
  * omit or include the wrong rows, while every coverage/count number this
  * tool checks still balances perfectly, because `counts` is recomputed
  * from the SAME (already-wrong) `outcome` field the label itself carries.
+ *
+ * Round 2 (confirmation round on round 1's fix) found a gap IN that fix: it
+ * only checked the four verdict-delta outcomes, so a genuinely
+ * `newly_quarantined` row mislabeled `unfetchable` (or `unevaluable`/
+ * `content_drifted`) while STILL carrying `prePortQuarantine=false,
+ * postPortQuarantine=true` would skip this check entirely (those three
+ * outcomes are not in `VERDICT_DELTA_OUTCOMES`) AND skip G-5's
+ * `checkDeltaBound` (which only looks at `SCORED_OUTCOMES`) AND be excluded
+ * from G-1's review set — with coverage/counts still balancing, because
+ * `unfetchable`/`unevaluable`/`content_drifted` are non-blocking, "we
+ * couldn't fully evaluate this row" buckets, not verdicts. Confirmed against
+ * `processRow` (`smi5879-simulate-full.helpers.ts`): every one of that
+ * function's `unfetchable`/`unevaluable`/`content_drifted` return sites
+ * constructs its result as `{ ...base, outcome: '...', reason: '...' }` —
+ * NONE of them ever attach `prePortQuarantine`/`postPortQuarantine` (or the
+ * risk-score fields) at all. Only `SCORED_OUTCOMES`
+ * (`smi5879-gate-check.helpers.ts` — `bundle_absent` plus the four
+ * verdict-delta outcomes) legitimately carry those fields. `assertRowOutcomeFieldPresence`
+ * below closes this: a row outside `SCORED_OUTCOMES` carrying quarantine
+ * fields at all is now itself a hard-fail, which catches the round-2 attack
+ * regardless of which non-scored outcome the mislabeling used.
  */
 
 import type { SimRowOutcome, SimRowResult } from './smi5879-simulate-full.types.ts'
+import { SCORED_OUTCOMES } from './smi5879-gate-check.helpers.ts'
 import { MAX_IDS_IN_ERROR } from './smi5879-merge-shards.merge-rules.ts'
 
 /**
@@ -49,7 +71,11 @@ const VERDICT_DELTA_OUTCOMES: readonly SimRowOutcome[] = [
  * own function cannot detect a fault IN that function) — and reimplementing
  * avoids pulling `smi5879-simulate-full.helpers.ts`'s network/fetch/
  * rate-limit dependency graph into a tool that must stay a pure local
- * aggregation step.
+ * aggregation step. `SCORED_OUTCOMES` below is imported, not reimplemented,
+ * for the opposite reason: it is not producer arithmetic to be independently
+ * re-derived, it is the closed classification G-5's own `checkDeltaBound`
+ * already depends on — reusing it means this check and G-5 can never drift
+ * apart on which outcomes are "scored."
  */
 function expectedVerdictDeltaOutcome(
   prePortQuarantine: boolean,
@@ -59,6 +85,45 @@ function expectedVerdictDeltaOutcome(
   if (prePortQuarantine && !postPortQuarantine) return 'newly_cleared'
   if (!prePortQuarantine && !postPortQuarantine) return 'unchanged_clean'
   return 'unchanged_quarantined'
+}
+
+/**
+ * Round-2 fix: assert `prePortQuarantine`/`postPortQuarantine` are present
+ * if and only if `outcome` is in `SCORED_OUTCOMES`. Closes the class of
+ * attack independent of which non-scored outcome is used — a row cannot
+ * carry quarantine fields while claiming to be `unfetchable`/`unevaluable`/
+ * `content_drifted` (fields present where the real producer never puts
+ * them), and cannot omit them while claiming a scored outcome (already
+ * covered for the verdict-delta subset by {@link assertRowOutcomeCoherence}
+ * below, extended here to `bundle_absent` too).
+ */
+export function assertRowOutcomeFieldPresence(rows: readonly SimRowResult[]): void {
+  const violations: string[] = []
+  for (const row of rows) {
+    const isScored = (SCORED_OUTCOMES as readonly SimRowOutcome[]).includes(row.outcome)
+    const hasFields = row.prePortQuarantine !== undefined || row.postPortQuarantine !== undefined
+    if (isScored && !hasFields) {
+      violations.push(
+        `${row.id} (outcome=${row.outcome} is a scored outcome, but has neither field)`
+      )
+    } else if (!isScored && hasFields) {
+      violations.push(
+        `${row.id} (outcome=${row.outcome} is NOT a scored outcome, but carries ` +
+          `prePortQuarantine=${row.prePortQuarantine}/postPortQuarantine=${row.postPortQuarantine} — ` +
+          'the real simulator never attaches these fields to this outcome)'
+      )
+    }
+  }
+  if (violations.length > 0) {
+    throw new Error(
+      `SMI-6015: ${violations.length} row(s) have quarantine-field presence inconsistent with their ` +
+        `outcome: ${violations.slice(0, MAX_IDS_IN_ERROR).join('; ')}` +
+        `${violations.length > MAX_IDS_IN_ERROR ? ', ...' : ''}. A row outside SCORED_OUTCOMES that ` +
+        'still carries these fields could otherwise masquerade as a non-blocking, non-reviewed ' +
+        "outcome while smuggling a real quarantine verdict's fields past G-1's review set and G-5's " +
+        'delta-bound check. Refusing to merge.'
+    )
+  }
 }
 
 /**

--- a/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
+++ b/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
@@ -1,0 +1,99 @@
+/**
+ * Row-outcome-label coherence check for `smi5879-merge-shards.ts`. Split
+ * into its own module per CLAUDE.md's <500-line-per-file convention —
+ * `.merge-rules.ts` was at 499/500 lines once this check was added, too
+ * tight a margin to leave in place.
+ * @module scripts/indexer/smi5879-merge-shards.outcome-coherence
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)")
+ *
+ * WHY THIS CHECK EXISTS
+ * ----------------------
+ * Wave 2 adversarial review finding: none of `.merge-rules.ts`'s checks —
+ * id disjointness, population set-equality, per-cohort/author/name
+ * agreement — verify that a row's `outcome` LABEL is actually consistent
+ * with its own `prePortQuarantine`/`postPortQuarantine` fields. A row with
+ * a genuine population id (so it passes every check in `.merge-rules.ts`
+ * and `.population.ts`) but a wrong `outcome` — e.g. `unchanged_clean` on a
+ * row whose quarantine booleans say `unchanged_quarantined` — would make
+ * G-1's review set `R` (`computeR`, `smi5879-gate-check.helpers.ts`,
+ * filters on `outcome === 'newly_quarantined' | 'newly_cleared'`) silently
+ * omit or include the wrong rows, while every coverage/count number this
+ * tool checks still balances perfectly, because `counts` is recomputed
+ * from the SAME (already-wrong) `outcome` field the label itself carries.
+ */
+
+import type { SimRowOutcome, SimRowResult } from './smi5879-simulate-full.types.ts'
+import { MAX_IDS_IN_ERROR } from './smi5879-merge-shards.merge-rules.ts'
+
+/**
+ * The four "verdict-delta" outcomes — the only ones `classifyVerdictDelta`
+ * (`smi5879-simulate-full.helpers.ts`) ever produces. `bundle_absent` also
+ * carries `prePortQuarantine`/`postPortQuarantine` but is NOT one of these:
+ * its outcome label is deliberately overridden past whatever those booleans
+ * would classify to (`processRow`'s `isBundleAbsent` branch), so checking it
+ * here would flag a correct row as a false positive.
+ */
+const VERDICT_DELTA_OUTCOMES: readonly SimRowOutcome[] = [
+  'newly_quarantined',
+  'newly_cleared',
+  'unchanged_clean',
+  'unchanged_quarantined',
+]
+
+/**
+ * `classifyVerdictDelta`'s own four-branch logic is deliberately
+ * REIMPLEMENTED here rather than imported (same rationale as
+ * `.merge-rules.ts`'s `recomputeCounts`: a verifier calling the producer's
+ * own function cannot detect a fault IN that function) — and reimplementing
+ * avoids pulling `smi5879-simulate-full.helpers.ts`'s network/fetch/
+ * rate-limit dependency graph into a tool that must stay a pure local
+ * aggregation step.
+ */
+function expectedVerdictDeltaOutcome(
+  prePortQuarantine: boolean,
+  postPortQuarantine: boolean
+): SimRowOutcome {
+  if (!prePortQuarantine && postPortQuarantine) return 'newly_quarantined'
+  if (prePortQuarantine && !postPortQuarantine) return 'newly_cleared'
+  if (!prePortQuarantine && !postPortQuarantine) return 'unchanged_clean'
+  return 'unchanged_quarantined'
+}
+
+/**
+ * Assert every merged row whose `outcome` is a verdict-delta outcome
+ * actually agrees with its own `prePortQuarantine`/`postPortQuarantine`
+ * fields. Applied to the merged rows (after `mergeRows`, before population
+ * verification) — a cheap, purely local structural check, same tier as
+ * `.merge-rules.ts`'s numeric-sanity check.
+ */
+export function assertRowOutcomeCoherence(rows: readonly SimRowResult[]): void {
+  const mismatches: string[] = []
+  for (const row of rows) {
+    if (!VERDICT_DELTA_OUTCOMES.includes(row.outcome)) continue
+    if (row.prePortQuarantine === undefined || row.postPortQuarantine === undefined) {
+      mismatches.push(
+        `${row.id} (outcome=${row.outcome} but prePortQuarantine/postPortQuarantine is missing)`
+      )
+      continue
+    }
+    const expected = expectedVerdictDeltaOutcome(row.prePortQuarantine, row.postPortQuarantine)
+    if (expected !== row.outcome) {
+      mismatches.push(
+        `${row.id} (outcome=${row.outcome}, but prePortQuarantine=${row.prePortQuarantine}/` +
+          `postPortQuarantine=${row.postPortQuarantine} implies ${expected})`
+      )
+    }
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `SMI-6015: ${mismatches.length} row(s) have an outcome label that disagrees with their own ` +
+        `prePortQuarantine/postPortQuarantine fields: ${mismatches.slice(0, MAX_IDS_IN_ERROR).join('; ')}` +
+        `${mismatches.length > MAX_IDS_IN_ERROR ? ', ...' : ''}. G-1's review set and G-3's counts ` +
+        'are derived directly from the outcome label — a row whose label disagrees with its own ' +
+        'quarantine fields would corrupt both without any coverage/count arithmetic ever detecting it. ' +
+        'Refusing to merge a shard report containing an internally-inconsistent row.'
+    )
+  }
+}

--- a/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
+++ b/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
@@ -88,59 +88,77 @@ function expectedVerdictDeltaOutcome(
 }
 
 /**
- * Round-2 fix: assert `prePortQuarantine`/`postPortQuarantine` are present
- * if and only if `outcome` is in `SCORED_OUTCOMES`. Closes the class of
- * attack independent of which non-scored outcome is used — a row cannot
- * carry quarantine fields while claiming to be `unfetchable`/`unevaluable`/
- * `content_drifted` (fields present where the real producer never puts
- * them), and cannot omit them while claiming a scored outcome (already
- * covered for the verdict-delta subset by {@link assertRowOutcomeCoherence}
- * below, extended here to `bundle_absent` too).
+ * The four fields `processRow` (`smi5879-simulate-full.helpers.ts`) ONLY
+ * ever sets as one unit — both of its scored construction sites (the
+ * `bundle_absent` branch and the final `classifyVerdictDelta` branch) set
+ * all four in the SAME object literal, from the SAME `preVerdict`/
+ * `postVerdict` pair, never independently. Round-4 confirmation review:
+ * the round-3 fix checked only the quarantine pair — a row could have a
+ * fully-coherent quarantine pair but a partially-present (or wrongly
+ * present/absent) risk-score pair, a shape the real producer can never
+ * emit, unchecked by round 3.
+ */
+const SCORED_FIELD_PAIRS = [
+  ['prePortQuarantine', 'postPortQuarantine'],
+  ['prePortRiskScore', 'postPortRiskScore'],
+] as const
+
+/**
+ * Round-2 fix: assert `prePortQuarantine`/`postPortQuarantine` (round 4:
+ * and `prePortRiskScore`/`postPortRiskScore`) are present if and only if
+ * `outcome` is in `SCORED_OUTCOMES`. Closes the class of attack independent
+ * of which non-scored outcome is used — a row cannot carry these fields
+ * while claiming to be `unfetchable`/`unevaluable`/`content_drifted`
+ * (fields present where the real producer never puts them), and cannot
+ * omit them while claiming a scored outcome (already covered for the
+ * verdict-delta subset by {@link assertRowOutcomeCoherence} below,
+ * extended here to `bundle_absent` too).
  *
- * Round-3 confirmation review found a gap IN this fix: the original
- * `hasFields` test used OR, so a row with EXACTLY ONE of the two fields
- * present (the other omitted) was treated as "has fields" and passed —
- * `assertRowOutcomeCoherence` below rescues this shape for the four
- * verdict-delta outcomes (its own missing-field check uses OR the other
- * way, catching "at least one absent"), but it deliberately does NOT cover
- * `bundle_absent`, so a `bundle_absent` row with only one field present
- * slipped through both checks entirely. `prePortQuarantine`/
- * `postPortQuarantine` are ALWAYS set together in the same object literal
- * by every real producer site (`processRow`, `smi5879-simulate-full.helpers.ts`)
- * — never independently — so "exactly one present" is now its own,
- * outcome-independent violation, checked before the scored/unscored
- * comparison even runs.
+ * Round-3 confirmation review found a gap IN the original (quarantine-only)
+ * fix: its `hasFields` test used OR, so a row with EXACTLY ONE of a pair's
+ * two fields present (the other omitted) was treated as "has fields" and
+ * passed — `assertRowOutcomeCoherence` below rescues this shape for the
+ * four verdict-delta outcomes (its own missing-field check uses OR the
+ * other way, catching "at least one absent"), but it deliberately does NOT
+ * cover `bundle_absent`, so a `bundle_absent` row with only one field
+ * present slipped through both checks entirely. Every field pair in
+ * {@link SCORED_FIELD_PAIRS} is now checked "both present together, or
+ * both absent together" as its own outcome-independent violation, before
+ * the scored/unscored comparison even runs — round 4 generalized this from
+ * the quarantine pair alone to every pair the real producer sets as a unit.
  */
 export function assertRowOutcomeFieldPresence(rows: readonly SimRowResult[]): void {
   const violations: string[] = []
   for (const row of rows) {
     const isScored = (SCORED_OUTCOMES as readonly SimRowOutcome[]).includes(row.outcome)
-    const preDefined = row.prePortQuarantine !== undefined
-    const postDefined = row.postPortQuarantine !== undefined
-    if (preDefined !== postDefined) {
-      violations.push(
-        `${row.id} (outcome=${row.outcome} has exactly one of prePortQuarantine/` +
-          'postPortQuarantine present — the real simulator always sets both together, never ' +
-          'independently)'
-      )
-      continue
-    }
-    const hasBoth = preDefined && postDefined
-    if (isScored && !hasBoth) {
-      violations.push(
-        `${row.id} (outcome=${row.outcome} is a scored outcome, but has neither field)`
-      )
-    } else if (!isScored && hasBoth) {
-      violations.push(
-        `${row.id} (outcome=${row.outcome} is NOT a scored outcome, but carries ` +
-          `prePortQuarantine=${row.prePortQuarantine}/postPortQuarantine=${row.postPortQuarantine} — ` +
-          'the real simulator never attaches these fields to this outcome)'
-      )
+    for (const [preField, postField] of SCORED_FIELD_PAIRS) {
+      const preDefined = row[preField] !== undefined
+      const postDefined = row[postField] !== undefined
+      if (preDefined !== postDefined) {
+        violations.push(
+          `${row.id} (outcome=${row.outcome} has exactly one of ${preField}/${postField} present ` +
+            '— the real simulator always sets both together, never independently)'
+        )
+        continue
+      }
+      const hasBoth = preDefined && postDefined
+      if (isScored && !hasBoth) {
+        violations.push(
+          `${row.id} (outcome=${row.outcome} is a scored outcome, but has neither ${preField} nor ` +
+            `${postField})`
+        )
+      } else if (!isScored && hasBoth) {
+        violations.push(
+          `${row.id} (outcome=${row.outcome} is NOT a scored outcome, but carries ` +
+            `${preField}=${row[preField]}/${postField}=${row[postField]} — the real simulator never ` +
+            'attaches these fields to this outcome)'
+        )
+      }
     }
   }
   if (violations.length > 0) {
     throw new Error(
-      `SMI-6015: ${violations.length} row(s) have quarantine-field presence inconsistent with their ` +
+      `SMI-6015: ${violations.length} row(s) have scored-field presence inconsistent with their ` +
         `outcome: ${violations.slice(0, MAX_IDS_IN_ERROR).join('; ')}` +
         `${violations.length > MAX_IDS_IN_ERROR ? ', ...' : ''}. A row outside SCORED_OUTCOMES that ` +
         'still carries these fields could otherwise masquerade as a non-blocking, non-reviewed ' +

--- a/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
+++ b/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
@@ -96,17 +96,41 @@ function expectedVerdictDeltaOutcome(
  * them), and cannot omit them while claiming a scored outcome (already
  * covered for the verdict-delta subset by {@link assertRowOutcomeCoherence}
  * below, extended here to `bundle_absent` too).
+ *
+ * Round-3 confirmation review found a gap IN this fix: the original
+ * `hasFields` test used OR, so a row with EXACTLY ONE of the two fields
+ * present (the other omitted) was treated as "has fields" and passed —
+ * `assertRowOutcomeCoherence` below rescues this shape for the four
+ * verdict-delta outcomes (its own missing-field check uses OR the other
+ * way, catching "at least one absent"), but it deliberately does NOT cover
+ * `bundle_absent`, so a `bundle_absent` row with only one field present
+ * slipped through both checks entirely. `prePortQuarantine`/
+ * `postPortQuarantine` are ALWAYS set together in the same object literal
+ * by every real producer site (`processRow`, `smi5879-simulate-full.helpers.ts`)
+ * — never independently — so "exactly one present" is now its own,
+ * outcome-independent violation, checked before the scored/unscored
+ * comparison even runs.
  */
 export function assertRowOutcomeFieldPresence(rows: readonly SimRowResult[]): void {
   const violations: string[] = []
   for (const row of rows) {
     const isScored = (SCORED_OUTCOMES as readonly SimRowOutcome[]).includes(row.outcome)
-    const hasFields = row.prePortQuarantine !== undefined || row.postPortQuarantine !== undefined
-    if (isScored && !hasFields) {
+    const preDefined = row.prePortQuarantine !== undefined
+    const postDefined = row.postPortQuarantine !== undefined
+    if (preDefined !== postDefined) {
+      violations.push(
+        `${row.id} (outcome=${row.outcome} has exactly one of prePortQuarantine/` +
+          'postPortQuarantine present — the real simulator always sets both together, never ' +
+          'independently)'
+      )
+      continue
+    }
+    const hasBoth = preDefined && postDefined
+    if (isScored && !hasBoth) {
       violations.push(
         `${row.id} (outcome=${row.outcome} is a scored outcome, but has neither field)`
       )
-    } else if (!isScored && hasFields) {
+    } else if (!isScored && hasBoth) {
       violations.push(
         `${row.id} (outcome=${row.outcome} is NOT a scored outcome, but carries ` +
           `prePortQuarantine=${row.prePortQuarantine}/postPortQuarantine=${row.postPortQuarantine} — ` +
@@ -121,7 +145,8 @@ export function assertRowOutcomeFieldPresence(rows: readonly SimRowResult[]): vo
         `${violations.length > MAX_IDS_IN_ERROR ? ', ...' : ''}. A row outside SCORED_OUTCOMES that ` +
         'still carries these fields could otherwise masquerade as a non-blocking, non-reviewed ' +
         "outcome while smuggling a real quarantine verdict's fields past G-1's review set and G-5's " +
-        'delta-bound check. Refusing to merge.'
+        'delta-bound check; a row with only one field present is malformed regardless of outcome. ' +
+        'Refusing to merge.'
     )
   }
 }

--- a/scripts/indexer/smi5879-merge-shards.population.ts
+++ b/scripts/indexer/smi5879-merge-shards.population.ts
@@ -1,0 +1,266 @@
+/**
+ * Authoritative-population binding for `smi5879-merge-shards.ts`: the
+ * digest-verified load of the sealed generation's row set, the artifact
+ * binding that ties the shard reports to that generation, and the EXACT SET
+ * EQUALITY check that is this tool's whole reason for touching a database at
+ * all. Split into its own module per CLAUDE.md's <500-line-per-file
+ * convention, and along the same seam `smi5879-gate-check.ts` uses when it
+ * keeps `bindGeneration` in `smi5879-gate-check.binding.ts` rather than
+ * inline: "prove these artifacts describe this generation" is a separable
+ * concern from "combine these artifacts".
+ * @module scripts/indexer/smi5879-merge-shards.population
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)")
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.3.5.2.4/§8.5
+ *
+ * WHY ROW-DISJOINTNESS IS NOT ENOUGH
+ * ----------------------------------
+ * `mergeRows` (`.merge-rules.ts`) proves no row was reported twice. It cannot
+ * prove that every row was reported at all, and neither can any amount of
+ * internal arithmetic: a merged report missing rows balances perfectly
+ * against its own reduced coverage numbers, and a same-cohort id substituted
+ * for a genuinely-dropped row keeps every count intact. Only comparison
+ * against the authoritative population catches those, and only if that
+ * population is itself proven un-drifted first — hence the strict ordering in
+ * {@link loadVerifiedPopulation}: exists -> sealed -> digests re-verify ->
+ * only THEN read the rows.
+ */
+
+import { ALL_SIMULATED_COHORTS } from './smi5879-simulate-full.types.ts'
+import { MAX_IDS_IN_ERROR, formatIds } from './smi5879-merge-shards.merge-rules.ts'
+import type { Smi5879Purpose, Smi5879RunStatus } from './smi5879-census.types.ts'
+import type {
+  CoverageByCohort,
+  SimRowResult,
+  SimSnapshotRow,
+  Smi5879SimulateFullDbDeps,
+} from './smi5879-simulate-full.types.ts'
+
+/**
+ * The DB surface the merge tool needs, expressed as a structural SUBSET of
+ * `Smi5879SimulateFullDbDeps` rather than as a new interface — so the EXISTING
+ * production adapter (`createSmi5879SimulateFullDbDeps`, which already wraps
+ * `smi5879_population_digest()`/`smi5879_branch_digest()` and the cohort row
+ * load) satisfies it with no new implementation, and so a test injects a fake
+ * exactly the way `runSimulateFull`'s own tests already do. This is the plan's
+ * "reuse that mechanism, don't reinvent a second one" expressed in the type
+ * system: there is no second digest path that could drift out of sync with
+ * the first.
+ */
+export type Smi5879MergeShardsDbDeps = Pick<
+  Smi5879SimulateFullDbDeps,
+  'getRunSummary' | 'verifyDigest' | 'loadCohortRows'
+>
+
+export interface VerifiedPopulation {
+  population: SimSnapshotRow[]
+  summary: { purpose: Smi5879Purpose; status: Smi5879RunStatus }
+}
+
+/**
+ * Materialise the authoritative population for `runId`, refusing anything
+ * short of a sealed, digest-verified generation.
+ *
+ * The first three steps are the same binding `bindGeneration`
+ * (`smi5879-gate-check.binding.ts`) performs before any gate and
+ * `runSimulateFull` performs on a cold start — exists, `sealed`, digests
+ * re-verify — reused rather than re-derived; the population itself is then
+ * read through the SAME `loadCohortRows` the simulator used to build its own
+ * `coverage[cohort].total`. BOTH digests are required, not just the
+ * population one: a branch-digest mismatch means the generation as a whole is
+ * corrupt, and the design doc's answer to a corrupt generation is a new
+ * generation, never a repair.
+ *
+ * There is deliberately no flag to skip any of this. A merge produced without
+ * it is not a weaker artifact, it is an unsound one, and an escape hatch here
+ * would be an escape hatch on the merge gate itself.
+ */
+export async function loadVerifiedPopulation(
+  db: Smi5879MergeShardsDbDeps,
+  runId: string
+): Promise<VerifiedPopulation> {
+  const summary = await db.getRunSummary(runId)
+  if (!summary) {
+    throw new Error(
+      `SMI-6015: no smi5879_run row for run_id=${runId} — cannot verify the merged rows against ` +
+        'an authoritative population, so the merge cannot be trusted.'
+    )
+  }
+  if (summary.status !== 'sealed') {
+    throw new Error(
+      `SMI-6015: generation ${runId} is "${summary.status}", not "sealed" — shard reports may only ` +
+        'be merged against a sealed generation, whose population is immutable by construction.'
+    )
+  }
+  const digest = await db.verifyDigest(runId)
+  if (!digest.populationMatches || !digest.branchMatches) {
+    throw new Error(
+      `SMI-6015: digest verification failed for run_id=${runId} ` +
+        `(population_matches=${digest.populationMatches}, branch_matches=${digest.branchMatches}). ` +
+        'The generation is corrupt — the correct action is a new generation, not a repair. Merging ' +
+        'against a drifted population would make the set-equality check meaningless.'
+    )
+  }
+  const population = await db.loadCohortRows(runId)
+  if (population.length === 0) {
+    throw new Error(
+      `SMI-6015: the sealed population for run_id=${runId} is empty (zero C1-C4 rows). A merge ` +
+        'against an empty population would vacuously "prove" set equality for a report containing ' +
+        'no rows at all.'
+    )
+  }
+  return { population, summary }
+}
+
+/**
+ * The shard reports and the live generation must describe the same thing.
+ * Applies the `checkArtifactRunIdBinding` precedent
+ * (`smi5879-gate-check.binding.ts`): a plausible-looking but mismatched
+ * combination is rejected rather than silently gated on. Without the `run_id`
+ * half in particular, an operator could merge generation A's shard reports
+ * while verifying set equality against generation B's population.
+ */
+export function assertReportsBindToGeneration(
+  identity: { run_id: string; purpose: Smi5879Purpose; status: Smi5879RunStatus },
+  runId: string,
+  summary: { purpose: Smi5879Purpose; status: Smi5879RunStatus }
+): void {
+  const mismatches: string[] = []
+  if (identity.run_id !== runId) {
+    mismatches.push(`run_id (shard reports="${identity.run_id}", --run-id=${runId})`)
+  }
+  if (identity.purpose !== summary.purpose) {
+    mismatches.push(
+      `purpose (shard reports="${identity.purpose}", smi5879_run="${summary.purpose}")`
+    )
+  }
+  if (identity.status !== summary.status) {
+    mismatches.push(`status (shard reports="${identity.status}", smi5879_run="${summary.status}")`)
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      'SMI-6015: the shard reports do not bind to the generation being merged — ' +
+        `${mismatches.join('; ')}. Refusing to verify one generation's reports against another ` +
+        "generation's population."
+    )
+  }
+}
+
+/**
+ * THE safety property (plan §3, round-1 review Critical finding #2): exact set
+ * equality between the merged `rows` id set and the authoritative sealed
+ * population's id set — zero missing, zero extra, zero duplicate — plus
+ * agreement on every field each row carries over from its canonical row.
+ *
+ * `population` MUST come from {@link loadVerifiedPopulation}; see this
+ * module's own doc comment for why an unverified population makes this check
+ * vacuous.
+ *
+ * The per-row field checks mirror `assertCheckpointRowsBelongToGeneration`
+ * (`smi5879-simulate-full.checkpoint.ts`) one-for-one and for the same reason:
+ * `report.rows`/`report.counts` are built from the simulator's stored per-row
+ * results, never re-derived from the canonical row set, so a row carrying a
+ * real id but a wrong `cohort` would corrupt coverage/counts accounting while
+ * every id-level check still passed, and a wrong `author`/`name` would
+ * misattribute a row to the human reviewer reading the merged report.
+ */
+export function assertMergedRowsMatchPopulation(
+  mergedRows: readonly SimRowResult[],
+  population: readonly SimSnapshotRow[]
+): void {
+  const populationById = new Map(population.map((r) => [r.id, r]))
+  const mergedById = new Map<string, SimRowResult>()
+  const duplicates: string[] = []
+  for (const row of mergedRows) {
+    if (mergedById.has(row.id)) duplicates.push(row.id)
+    else mergedById.set(row.id, row)
+  }
+
+  const missing = population.filter((r) => !mergedById.has(r.id)).map((r) => r.id)
+  const extra = mergedRows.filter((r) => !populationById.has(r.id)).map((r) => r.id)
+  const fieldMismatches: string[] = []
+  for (const row of mergedRows) {
+    const canonical = populationById.get(row.id)
+    if (canonical === undefined) continue // already reported as `extra`
+    if (row.cohort !== canonical.cohort) {
+      fieldMismatches.push(
+        `${row.id} (reported cohort=${row.cohort}, population cohort=${canonical.cohort})`
+      )
+    } else if (row.author !== canonical.author || row.name !== canonical.name) {
+      fieldMismatches.push(
+        `${row.id} (reported author/name=${row.author}/${row.name}, ` +
+          `population author/name=${canonical.author}/${canonical.name})`
+      )
+    }
+  }
+
+  if (
+    missing.length === 0 &&
+    extra.length === 0 &&
+    duplicates.length === 0 &&
+    fieldMismatches.length === 0
+  ) {
+    return
+  }
+  const parts: string[] = []
+  if (missing.length > 0) {
+    parts.push(
+      `${missing.length} population row(s) reported by NO shard: ${formatIds(missing)} — the ` +
+        'merged report would silently omit them from every gate that reads report.rows'
+    )
+  }
+  if (extra.length > 0) {
+    parts.push(
+      `${extra.length} reported row(s) not present in the sealed population: ${formatIds(extra)}`
+    )
+  }
+  if (duplicates.length > 0) {
+    parts.push(`${duplicates.length} duplicate row id(s): ${formatIds(duplicates)}`)
+  }
+  if (fieldMismatches.length > 0) {
+    parts.push(
+      `${fieldMismatches.length} row(s) disagree with their canonical population row: ` +
+        `${fieldMismatches.slice(0, MAX_IDS_IN_ERROR).join('; ')}` +
+        `${fieldMismatches.length > MAX_IDS_IN_ERROR ? ', ...' : ''}`
+    )
+  }
+  throw new Error(
+    'SMI-6015: the merged rows are not EXACTLY the sealed population for this run_id — ' +
+      `${parts.join('; ')}. Row-count and digest agreement alone are not sufficient; set equality ` +
+      'is the actual requirement, because a same-cohort id can substitute for a genuinely-dropped ' +
+      'row while every count still balances. Refusing to write a gate-eligible merged report.'
+  )
+}
+
+/**
+ * Cross-check the (already agreed-upon) per-cohort `total` against the
+ * authoritative population rather than only against the other shards. All N
+ * shards agreeing on a WRONG total is not hypothetical — they would all
+ * inherit the same wrong value from the same wrong row load. Since
+ * `coverage[cohort].status === 'full'` hinges on `scanned === total`, an
+ * inflated total silently downgrades the merged report to `partial` (visible,
+ * survivable), but a DEFLATED total would let `scanned === total` hold while
+ * rows were missing.
+ */
+export function assertCoverageTotalsMatchPopulation(
+  coverage: CoverageByCohort,
+  population: readonly SimSnapshotRow[]
+): void {
+  const mismatches: string[] = []
+  for (const cohort of ALL_SIMULATED_COHORTS) {
+    const populationTotal = population.filter((r) => r.cohort === cohort).length
+    if (coverage[cohort].total !== populationTotal) {
+      mismatches.push(
+        `${cohort} (reports say total=${coverage[cohort].total}, sealed population has ${populationTotal})`
+      )
+    }
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      'SMI-6015: shard-reported cohort total(s) do not match the digest-verified sealed ' +
+        `population — ${mismatches.join('; ')}. G-2's "coverage is full" decision is exactly ` +
+        '`scanned === total`, so a wrong total makes that decision meaningless. Refusing to merge.'
+    )
+  }
+}

--- a/scripts/indexer/smi5879-merge-shards.ts
+++ b/scripts/indexer/smi5879-merge-shards.ts
@@ -64,6 +64,7 @@ import {
   recomputeCounts,
   type ShardReportInput,
 } from './smi5879-merge-shards.merge-rules.ts'
+import { assertRowOutcomeCoherence } from './smi5879-merge-shards.outcome-coherence.ts'
 import {
   assertCoverageTotalsMatchPopulation,
   assertMergedRowsMatchPopulation,
@@ -191,6 +192,12 @@ export async function runMergeShards(
   const inputs = loadShardReports(args.reportPaths)
   const identity = assertIdenticalIdentityFields(inputs)
   const mergedRows = mergeRows(inputs)
+  // Wave 2 adversarial review finding: a row can pass id-disjointness and
+  // (later) population set-equality while still carrying an `outcome` label
+  // that disagrees with its own prePortQuarantine/postPortQuarantine fields
+  // — neither check above would catch that. Cheap, purely local, so it runs
+  // before the DB round trip alongside the other structural checks.
+  assertRowOutcomeCoherence(mergedRows)
 
   const { population, summary } = await loadVerifiedPopulation(db, args.runId)
   assertReportsBindToGeneration(identity, args.runId, summary)

--- a/scripts/indexer/smi5879-merge-shards.ts
+++ b/scripts/indexer/smi5879-merge-shards.ts
@@ -1,0 +1,279 @@
+/**
+ * SMI-6015 PAT-sharded fetch, Wave 2 item 3: the N-way shard-report merge
+ * tool. Reads N `report_kind: 'full_simulation'` reports — one per completed,
+ * sealed shard of ONE decision generation — and produces the single merged
+ * report `smi5879-gate-check.ts` evaluates.
+ * @module scripts/indexer/smi5879-merge-shards
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)")
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.3.5.2.4/§8.4/§8.5
+ *
+ * WHY THIS TOOL IS SAFETY-CRITICAL
+ * --------------------------------
+ * `smi5879-gate-check.ts` accepts exactly ONE `full_simulation` report per
+ * decision `run_id` (`smi5879-gate-check.io.ts`, `evaluateG2`) and derives a
+ * merge-gate decision from it. This is the THIRD write site of that report
+ * shape (after `smi5879-simulate-full.ts` and its deadline-exit path), and
+ * the only one that constructs a report from data it did not itself observe.
+ * Everything the gate believes about population coverage flows through here.
+ *
+ * Two siblings hold the substance (CLAUDE.md's <500-line-per-file convention,
+ * mirroring how `smi5879-simulate-full.ts` splits
+ * `.cli.ts`/`.checkpoint.ts`/`.sweep.ts`/`.output.ts`): `.merge-rules.ts` owns
+ * every row of the plan's merge-rule table and its invariants, and
+ * `.population.ts` owns the digest-verified population load plus the
+ * set-equality check that is the actual safety property — both files state
+ * that property in full in their own module docs. THIS file owns argument
+ * parsing, shard-report loading, orchestration ORDER, and the atomic,
+ * self-validating write.
+ *
+ * ORDER MATTERS. The population is loaded ONLY after `verifyDigest` confirms
+ * the sealed generation still hashes to what it hashed to at seal time — the
+ * same `smi5879_population_digest()` re-verification `runSimulateFull`
+ * performs on a cold start and `bindGeneration` performs for every gate. A
+ * set-equality check against an unverified population proves nothing, because
+ * the population itself could have drifted to match a corrupted merge.
+ *
+ * There is deliberately NO flag to skip the population verification. A merge
+ * produced without it is not a weaker artifact, it is an unsound one, and an
+ * escape hatch on this path would be an escape hatch on the merge gate.
+ *
+ * Usage:
+ *   varlock run -- npx tsx scripts/indexer/smi5879-merge-shards.ts \
+ *     --run-id=<sealed decision generation run_id> \
+ *     --reports=<path1>,<path2>,<path3> \
+ *     --output=<merged-report-path>
+ */
+
+import { renameSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { poolerSessionConnParams } from './smi5879-census.pg.ts'
+import { createSmi5879SimulateFullDbDeps } from './smi5879-simulate-full.db.ts'
+import { loadSimulatorReport } from './smi5879-gate-check.io.ts'
+import { printSummary } from './smi5879-simulate-full.output.ts'
+import { decideExitCode } from './smi5879-simulate-full.sweep.ts'
+import {
+  assembleMergedReport,
+  assertCountsBalance,
+  assertIdenticalIdentityFields,
+  assertShardReportNumericSanity,
+  mergeCoverage,
+  mergeRows,
+  mergeSweep,
+  recomputeCounts,
+  type ShardReportInput,
+} from './smi5879-merge-shards.merge-rules.ts'
+import {
+  assertCoverageTotalsMatchPopulation,
+  assertMergedRowsMatchPopulation,
+  assertReportsBindToGeneration,
+  loadVerifiedPopulation,
+  type Smi5879MergeShardsDbDeps,
+} from './smi5879-merge-shards.population.ts'
+import type { Smi5879SimulateFullReport } from './smi5879-simulate-full.types.ts'
+
+export type { Smi5879MergeShardsDbDeps }
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export interface MergeShardsCliArgs {
+  runId: string
+  /** Absolute-or-relative paths, in the operator's own order; at least one. */
+  reportPaths: string[]
+  outputPath: string
+}
+
+export function parseArgs(argv: string[]): MergeShardsCliArgs {
+  const find = (name: string): string | undefined => {
+    const prefix = `--${name}=`
+    const hit = argv.find((a) => a.startsWith(prefix))
+    return hit ? hit.slice(prefix.length) : undefined
+  }
+
+  const runId = find('run-id')
+  if (!runId) {
+    throw new Error('SMI-6015: --run-id=<sealed decision generation run_id> is required.')
+  }
+
+  const reportsRaw = find('reports')
+  if (reportsRaw === undefined || reportsRaw.trim() === '') {
+    throw new Error(
+      'SMI-6015: --reports=<path1,path2,...> is required — the per-shard ' +
+        'full_simulation report files to merge.'
+    )
+  }
+  const reportPaths = reportsRaw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '')
+  if (reportPaths.length === 0) {
+    throw new Error(`SMI-6015: --reports="${reportsRaw}" contained no usable paths.`)
+  }
+  // A path repeated in --reports would surface downstream as a confusing
+  // "row id appears in more than one shard report" for EVERY row of that
+  // shard. Catch the actual operator mistake here, comparing resolved paths
+  // so two spellings of the same file (`./a.json` and `a.json`) are caught too.
+  const seen = new Map<string, string>()
+  const repeated: string[] = []
+  for (const path of reportPaths) {
+    const key = resolve(path)
+    const prior = seen.get(key)
+    if (prior !== undefined) repeated.push(`${prior} and ${path} resolve to the same file (${key})`)
+    else seen.set(key, path)
+  }
+  if (repeated.length > 0) {
+    throw new Error(
+      `SMI-6015: --reports lists the same report file more than once — ${repeated.join('; ')}. ` +
+        'Each shard report must be passed exactly once.'
+    )
+  }
+
+  const outputPath = find('output')
+  if (!outputPath) {
+    throw new Error('SMI-6015: --output=<merged-report-path> is required.')
+  }
+
+  return { runId, reportPaths, outputPath }
+}
+
+// ---------------------------------------------------------------------------
+// Input loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load every shard report through `loadSimulatorReport` — the EXACT validator
+ * `smi5879-gate-check.ts` applies to the artifact it gates on, including its
+ * `validateSimulatorReportConsistency` cross-check of coverage/rows/counts.
+ * A shard report the gate would reject can never become an input to a report
+ * the gate is meant to accept, and `loadSimulatorReport`'s
+ * missing-vs-malformed distinction is preserved in the thrown message.
+ */
+export function loadShardReports(reportPaths: readonly string[]): ShardReportInput[] {
+  const inputs: ShardReportInput[] = []
+  for (const path of reportPaths) {
+    const loaded = loadSimulatorReport(path, 'shard report')
+    if (loaded.status !== 'ok') {
+      throw new Error(
+        `SMI-6015: cannot merge — shard report at ${path} is ${loaded.status}: ${loaded.reason}. ` +
+          'Every shard report must be a complete, well-formed full_simulation report before it can ' +
+          'contribute to a gate-eligible merged report.'
+      )
+    }
+    const input: ShardReportInput = { path, report: loaded.value }
+    assertShardReportNumericSanity(input)
+    inputs.push(input)
+  }
+  return inputs
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the whole merge and return the assembled report. Exported for the test
+ * suite; `main()` is the CLI entrypoint (the same split
+ * `runSimulateFull`/`main` uses).
+ *
+ * Ordering is load-bearing: cheap structural checks first (so an operator
+ * mistake fails before a DB round trip), then the digest-verified population,
+ * then the set-equality check, then every derived field recomputed against
+ * the already-verified row set.
+ */
+export async function runMergeShards(
+  db: Smi5879MergeShardsDbDeps,
+  args: MergeShardsCliArgs,
+  now: Date = new Date()
+): Promise<Smi5879SimulateFullReport> {
+  const inputs = loadShardReports(args.reportPaths)
+  const identity = assertIdenticalIdentityFields(inputs)
+  const mergedRows = mergeRows(inputs)
+
+  const { population, summary } = await loadVerifiedPopulation(db, args.runId)
+  assertReportsBindToGeneration(identity, args.runId, summary)
+
+  // THE safety property — exact set equality against the digest-verified
+  // population. Everything below it is arithmetic over a row set already
+  // proven to be the whole population and nothing but the population.
+  assertMergedRowsMatchPopulation(mergedRows, population)
+
+  const coverage = mergeCoverage(inputs, mergedRows)
+  assertCoverageTotalsMatchPopulation(coverage, population)
+
+  // Recomputed from the merged rows, never summed from the shard reports'
+  // own `counts` fields (plan merge-rule table) — and immediately balanced
+  // against `rows.length`, so the "recompute, never sum" rule and its
+  // invariant stay paired at the call site.
+  const counts = recomputeCounts(mergedRows)
+  assertCountsBalance(counts, mergedRows)
+
+  const sweep = mergeSweep(inputs)
+
+  return assembleMergedReport(identity, coverage, mergedRows, counts, sweep, now.toISOString())
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+/**
+ * Write the merged report atomically, and only after re-reading it through
+ * `loadSimulatorReport` — the exact validator the gate will apply.
+ *
+ * Two precedents combined. The atomic temp-file-then-`renameSync` is
+ * `writeCheckpoint`'s (`smi5879-simulate-full.checkpoint.ts`): a crash
+ * mid-write can never leave `--output` itself truncated. The round trip
+ * through the gate's own loader is this tool's own addition: a merged report
+ * that the gate would reject must never reach the path an operator is about
+ * to hand the gate. On failure the temp file is deliberately LEFT in place
+ * and named in the error, matching `readCheckpoint`'s guidance to inspect a
+ * `.tmp` sibling rather than have it silently disappear.
+ */
+export function writeMergedReport(path: string, report: Smi5879SimulateFullReport): void {
+  const tmpPath = `${path}.tmp-${process.pid}`
+  writeFileSync(tmpPath, JSON.stringify(report, null, 2))
+  const reloaded = loadSimulatorReport(tmpPath, 'merged report')
+  if (reloaded.status !== 'ok') {
+    throw new Error(
+      `SMI-6015: the merged report failed the gate's own simulator-report validation ` +
+        `(${reloaded.status}: ${reloaded.reason}). This is a bug in the merge tool, not in the ` +
+        `shard reports — ${path} was NOT written. The rejected output is left at ${tmpPath} for ` +
+        'inspection.'
+    )
+  }
+  renameSync(tmpPath, path)
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  const conn = poolerSessionConnParams()
+  const db = createSmi5879SimulateFullDbDeps(conn)
+
+  const report = await runMergeShards(db, args)
+  writeMergedReport(args.outputPath, report)
+  printSummary(report)
+  console.log(
+    `Merged ${args.reportPaths.length} shard report(s) into ${args.outputPath} ` +
+      `(${report.rows.length} rows, set-equal to the digest-verified sealed population).`
+  )
+
+  // Same exit-code policy as the simulator itself (`decideExitCode`, reused
+  // rather than restated). Note that `scanned === total` is guaranteed by the
+  // time we get here — set equality plus the cohort-total cross-check force
+  // it — so a non-zero exit from a successful merge means either a non-null
+  // `sweep.hard_stopped` or a cohort with unevaluable > 0: real, reportable
+  // reasons the gate would return INCONCLUSIVE, surfaced now rather than at
+  // gate time.
+  process.exitCode = decideExitCode(report.coverage, report.sweep.hard_stopped)
+}
+
+// Run only when invoked directly (not when imported by the test suite).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/indexer/smi5879-merge-shards.ts
+++ b/scripts/indexer/smi5879-merge-shards.ts
@@ -64,7 +64,10 @@ import {
   recomputeCounts,
   type ShardReportInput,
 } from './smi5879-merge-shards.merge-rules.ts'
-import { assertRowOutcomeCoherence } from './smi5879-merge-shards.outcome-coherence.ts'
+import {
+  assertRowOutcomeCoherence,
+  assertRowOutcomeFieldPresence,
+} from './smi5879-merge-shards.outcome-coherence.ts'
 import {
   assertCoverageTotalsMatchPopulation,
   assertMergedRowsMatchPopulation,
@@ -197,6 +200,13 @@ export async function runMergeShards(
   // that disagrees with its own prePortQuarantine/postPortQuarantine fields
   // — neither check above would catch that. Cheap, purely local, so it runs
   // before the DB round trip alongside the other structural checks.
+  // Round-2 confirmation review found a gap in the round-1 fix: it only
+  // covered verdict-delta outcomes, so a real newly_quarantined row
+  // mislabeled unfetchable/unevaluable/content_drifted (while still
+  // carrying quarantine fields) skipped it entirely. Field-presence runs
+  // FIRST — it's the check that actually closes that gap; coherence then
+  // only needs to worry about the four outcomes it's scoped to.
+  assertRowOutcomeFieldPresence(mergedRows)
   assertRowOutcomeCoherence(mergedRows)
 
   const { population, summary } = await loadVerifiedPopulation(db, args.runId)

--- a/scripts/tests/indexer/run-gate-callsites.test.ts
+++ b/scripts/tests/indexer/run-gate-callsites.test.ts
@@ -48,10 +48,21 @@
  *     to run anywhere except a clean checkout of the pinned pre-port SHA
  *     (its own module doc's preconditions), which is a narrower, unrelated
  *     safety mechanism from the change-window freeze this census concerns
- *     itself with. Pinned as its own explicit set (Shape 1's "exactly N"
- *     assertion below is `PINNED_SHAPE1 ∪ PINNED_SHAPE4_UNGATED_GUARD`)
- *     rather than silently absorbed, so a FUTURE guard-shaped file that
- *     SHOULD be gated cannot hide behind this exclusion.
+ *     itself with. SMI-6015 Wave 2's `smi5879-merge-shards.ts` is the same
+ *     shape for the same reason as `smi5879-simulate-full.ts`/
+ *     `smi5879-gate-check.ts` above: it is a pure READER (its
+ *     `Smi5879MergeShardsDbDeps` is a structural `Pick` of
+ *     `getRunSummary`/`verifyDigest`/`loadCohortRows` only — no claim,
+ *     heartbeat, or write method — and it never touches `skills`; it writes
+ *     only its own `--output` report file), and it runs strictly BETWEEN
+ *     `smi5879-simulate-full.ts` and `smi5879-gate-check.ts` in the same
+ *     T-3d/T-0 freeze-window pipeline those two already run inside — gating
+ *     the merge step on the same freeze mechanism its neighbors on both
+ *     sides are already exempted from would be exactly as circular. Pinned
+ *     as its own explicit set (Shape 1's "exactly N" assertion below is
+ *     `PINNED_SHAPE1 ∪ PINNED_SHAPE4_UNGATED_GUARD`) rather than silently
+ *     absorbed, so a FUTURE guard-shaped file that SHOULD be gated cannot
+ *     hide behind this exclusion.
  *
  * Each shape's set is pinned exactly (not just "at least") so a new file in
  * any shape fails this suite with a message naming the new file, rather than
@@ -84,6 +95,7 @@ const PINNED_SHAPE4_UNGATED_GUARD = [
   'smi5879-simulate-preflight-estimate.ts',
   'smi5879-gate-check.ts',
   'smi5879-corroboration-generate.ts',
+  'smi5879-merge-shards.ts',
 ].sort()
 
 const PINNED_SHEBANG_FILES = [
@@ -120,7 +132,7 @@ describe('Shape 1 — guarded direct-entry census', () => {
 })
 
 describe('Shape 4 — guarded direct entry that is deliberately NOT an indexer writer', () => {
-  it('is EXACTLY the pinned set {smi5879-census.ts, smi5879-simulate-full.ts, smi5879-simulate-preflight-estimate.ts, smi5879-gate-check.ts, smi5879-corroboration-generate.ts}', () => {
+  it('is EXACTLY the pinned set {smi5879-census.ts, smi5879-simulate-full.ts, smi5879-simulate-preflight-estimate.ts, smi5879-gate-check.ts, smi5879-corroboration-generate.ts, smi5879-merge-shards.ts}', () => {
     const files = listIndexerSourceFiles()
     const shape4Files = files
       .filter(

--- a/scripts/tests/indexer/smi5879-merge-shards.fixtures.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.fixtures.ts
@@ -60,7 +60,7 @@ export interface FixtureRowPair {
 export function fixtureRow(
   id: string,
   cohort: SimulatedCohort = 'C2',
-  overrides: { outcome?: string } = {}
+  overrides: { outcome?: string; prePortQuarantine?: boolean; postPortQuarantine?: boolean } = {}
 ): FixtureRowPair {
   return {
     population: makeRow({ id, cohort, author: 'acme', name: id }),
@@ -70,6 +70,12 @@ export function fixtureRow(
       author: 'acme',
       name: id,
       outcome: overrides.outcome ?? 'unchanged_clean',
+      ...(overrides.prePortQuarantine !== undefined
+        ? { prePortQuarantine: overrides.prePortQuarantine }
+        : {}),
+      ...(overrides.postPortQuarantine !== undefined
+        ? { postPortQuarantine: overrides.postPortQuarantine }
+        : {}),
     }),
   }
 }

--- a/scripts/tests/indexer/smi5879-merge-shards.fixtures.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.fixtures.ts
@@ -1,0 +1,209 @@
+/**
+ * SMI-6015 PAT-sharded fetch, Wave 2 item 2 (plan
+ * `docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md`, "###
+ * Step 2: Merge-tool test suite"): shared fixtures for the
+ * smi5879-merge-shards.ts / .merge-rules.ts / .population.ts test suite,
+ * split across smi5879-merge-shards.test.ts / .invariants.test.ts /
+ * .population-binding.test.ts / .gate-wiring.test.ts (CLAUDE.md's
+ * <500-line-per-file convention — the same shape the sibling
+ * smi5879-gate-check.ts suite already uses around its own
+ * smi5879-gate-check.fixtures.ts).
+ * @module scripts/tests/indexer/smi5879-merge-shards.fixtures
+ *
+ * Every builder here produces a MATCHED population row + shard-report row
+ * pair for the same id/cohort/author/name —
+ * `assertMergedRowsMatchPopulation` (`smi5879-merge-shards.population.ts`)
+ * compares those exact fields between a shard-reported row and its
+ * canonical population row, so a fixture that hand-built the two separately
+ * would risk an accidental field drift the real tests never intend to
+ * exercise.
+ *
+ * Reuses, not reinvents, the two existing SMI-5879 fixture modules:
+ * `makeRow`/`makeFakeDb` (`smi5879-simulate-full.fixtures.ts`) for the
+ * population-row shape and the fake `Smi5879SimulateFullDbDeps` this tool's
+ * own `Smi5879MergeShardsDbDeps` is a structural `Pick` of (so `makeFakeDb`'s
+ * return value satisfies it directly, per that module's own module doc);
+ * `makeSimRow`/`makeCoverage`/`makeSimulatorReportJson`/`writeFixtureFile`/
+ * `makeScratchDir`/`SAMPLE_COMMIT` (`smi5879-gate-check.fixtures.ts`) for the
+ * shard-report JSON shape `loadSimulatorReport` validates.
+ */
+
+import {
+  makeCoverage,
+  makeSimRow,
+  makeSimulatorReportJson,
+  makeScratchDir,
+  writeFixtureFile,
+  SAMPLE_COMMIT,
+} from './smi5879-gate-check.fixtures.ts'
+import { makeFakeDb, makeRow } from './smi5879-simulate-full.fixtures.ts'
+import type {
+  MergeShardsCliArgs,
+  Smi5879MergeShardsDbDeps,
+} from '../../indexer/smi5879-merge-shards.ts'
+import { ALL_SIMULATED_COHORTS } from '../../indexer/smi5879-simulate-full.types.ts'
+import type { SimSnapshotRow, SimulatedCohort } from '../../indexer/smi5879-simulate-full.types.ts'
+
+export { makeScratchDir, writeFixtureFile, makeSimulatorReportJson, SAMPLE_COMMIT }
+
+export const MERGE_RUN_ID = 'smi5879-merge-test-run'
+
+// ---------------------------------------------------------------------------
+// One id's canonical population row + its matching shard-reported row
+// ---------------------------------------------------------------------------
+
+export interface FixtureRowPair {
+  population: SimSnapshotRow
+  reportRow: Record<string, unknown>
+}
+
+export function fixtureRow(
+  id: string,
+  cohort: SimulatedCohort = 'C2',
+  overrides: { outcome?: string } = {}
+): FixtureRowPair {
+  return {
+    population: makeRow({ id, cohort, author: 'acme', name: id }),
+    reportRow: makeSimRow({
+      id,
+      cohort,
+      author: 'acme',
+      name: id,
+      outcome: overrides.outcome ?? 'unchanged_clean',
+    }),
+  }
+}
+
+export function totalsFor(population: readonly SimSnapshotRow[]): Record<SimulatedCohort, number> {
+  const totals: Record<SimulatedCohort, number> = { C1: 0, C2: 0, C3: 0, C4: 0 }
+  for (const row of population) totals[row.cohort] += 1
+  return totals
+}
+
+/**
+ * Build one shard's `coverage` object. `scanned`/`unevaluable`/`unfetchable`
+ * are ALWAYS derived from THAT shard's own `reportRows` — `loadSimulatorReport`
+ * cross-validates every report individually via
+ * `validateSimulatorReportConsistency` (`coverage[cohort].scanned` must equal
+ * the actual cohort-row count in THAT SAME report), so a fixture that got
+ * this wrong would fail to load long before the merge tool's own logic ran.
+ * `total` is taken from `totals` — the authoritative per-cohort population
+ * count, identical across every shard's own coverage object unless a test
+ * deliberately passes a mismatched `totals` for one shard (the whole point of
+ * the coverage-total-mismatch and population-total-mismatch invariant tests).
+ */
+export function coverageForShard(
+  reportRows: readonly Record<string, unknown>[],
+  totals: Record<SimulatedCohort, number>
+): Record<string, unknown> {
+  const coverage: Record<string, unknown> = {}
+  for (const cohort of ALL_SIMULATED_COHORTS) {
+    const cohortRows = reportRows.filter((r) => r['cohort'] === cohort)
+    const unevaluable = cohortRows.filter((r) => r['outcome'] === 'unevaluable').length
+    const unfetchable = cohortRows.filter((r) => r['outcome'] === 'unfetchable').length
+    const total = totals[cohort]
+    coverage[cohort] = makeCoverage({
+      scanned: cohortRows.length,
+      total,
+      unevaluable,
+      unfetchable,
+      status: cohortRows.length === total && unevaluable === 0 ? 'full' : 'partial',
+    })
+  }
+  return coverage
+}
+
+/**
+ * Assemble one shard's full report JSON — `coverage` always explicit (see
+ * {@link coverageForShard}'s doc).
+ */
+export function shardReportJson(
+  reportRows: readonly Record<string, unknown>[],
+  totals: Record<SimulatedCohort, number>,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return makeSimulatorReportJson({
+    run_id: MERGE_RUN_ID,
+    rows: reportRows,
+    coverage: coverageForShard(reportRows, totals),
+    ...overrides,
+  })
+}
+
+/**
+ * {@link shardReportJson} + {@link writeFixtureFile} in one call — keeps
+ * every test file's per-shard call sites short.
+ */
+export function writeShardReport(
+  dir: string,
+  index: number,
+  reportRows: readonly Record<string, unknown>[],
+  totals: Record<SimulatedCohort, number>,
+  overrides: Record<string, unknown> = {}
+): string {
+  return writeFixtureFile(dir, `shard${index}.json`, shardReportJson(reportRows, totals, overrides))
+}
+
+export function makeMergeShardsDb(
+  population: readonly SimSnapshotRow[],
+  overrides: Partial<Smi5879MergeShardsDbDeps> = {}
+): Smi5879MergeShardsDbDeps {
+  return makeFakeDb({
+    async getRunSummary() {
+      return { purpose: 'decision', status: 'sealed' }
+    },
+    async verifyDigest() {
+      return { populationMatches: true, branchMatches: true }
+    },
+    async loadCohortRows() {
+      return [...population]
+    },
+    ...overrides,
+  })
+}
+
+export function mergeArgs(
+  reportPaths: readonly string[],
+  outputPath: string,
+  runId: string = MERGE_RUN_ID
+): MergeShardsCliArgs {
+  return { runId, reportPaths: [...reportPaths], outputPath }
+}
+
+// ---------------------------------------------------------------------------
+// A clean, 3-shard, 6-row, 2-cohort (C2/C3) disjoint population — the base
+// fixture the happy-path and gate-wiring tests build on, and the seed most
+// invariant tests mutate exactly ONE thing away from.
+// ---------------------------------------------------------------------------
+
+type ShardRowPair = [Record<string, unknown>, Record<string, unknown>]
+
+export interface ThreeShardFixture {
+  population: SimSnapshotRow[]
+  allReportRows: Record<string, unknown>[]
+  /**
+   * Each shard's own 2 rows, as a fixed-length pair — tuple-typed so
+   * `shardRows[i][j]` never needs an `undefined` guard.
+   */
+  shardRows: [ShardRowPair, ShardRowPair, ShardRowPair]
+  totals: Record<SimulatedCohort, number>
+}
+
+export function buildThreeShardFixture(): ThreeShardFixture {
+  const c2a = fixtureRow('row-c2-1', 'C2')
+  const c2b = fixtureRow('row-c2-2', 'C2')
+  const c2c = fixtureRow('row-c2-3', 'C2')
+  const c3a = fixtureRow('row-c3-1', 'C3')
+  const c3b = fixtureRow('row-c3-2', 'C3')
+  const c3c = fixtureRow('row-c3-3', 'C3')
+  const all = [c2a, c2b, c2c, c3a, c3b, c3c]
+  const population = all.map((p) => p.population)
+  const allReportRows = all.map((p) => p.reportRow)
+  const totals = totalsFor(population)
+  const shardRows: ThreeShardFixture['shardRows'] = [
+    [c2a.reportRow, c2b.reportRow],
+    [c2c.reportRow, c3a.reportRow],
+    [c3b.reportRow, c3c.reportRow],
+  ]
+  return { population, allReportRows, shardRows, totals }
+}

--- a/scripts/tests/indexer/smi5879-merge-shards.gate-wiring.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.gate-wiring.test.ts
@@ -1,0 +1,149 @@
+/**
+ * SMI-6015 PAT-sharded fetch, Wave 2 item 2: `smi5879-merge-shards.ts` test
+ * suite (part 4) — the two tests that prove the merge tool's OUTPUT wires
+ * correctly into the real gate evaluators (`evaluateG2`/`evaluateG3`,
+ * `smi5879-gate-check.gates.ts`), not just that the merge tool's own
+ * invariants hold in isolation:
+ *
+ *   1. a single shard's non-null `sweep.hard_stopped` survives the merge and
+ *      makes `evaluateG2` return INCONCLUSIVE against the MERGED report —
+ *      the plan's own explicit test-list item ("verify evaluateG2 then
+ *      returns INCONCLUSIVE against the merged output, not a separate unit
+ *      test of the gate itself — proves the wiring").
+ *   2. Wave 2 Step 2's own end-to-end requirement: a 3-shard merge over a
+ *      synthetic population produces a report that `evaluateG2`/`evaluateG3`
+ *      accept IDENTICALLY to how they'd accept a genuine single-process,
+ *      unsharded report over the SAME population — i.e. sharding is
+ *      provably transparent to the gate.
+ *
+ * N=3 happy path and CLI parsing live in `smi5879-merge-shards.test.ts`;
+ * row-level and population-binding hard-fail invariants live in
+ * `smi5879-merge-shards.invariants.test.ts` /
+ * `smi5879-merge-shards.population-binding.test.ts`. Shared fixtures in
+ * `smi5879-merge-shards.fixtures.ts`.
+ * @module scripts/tests/indexer/smi5879-merge-shards.gate-wiring
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)",
+ *       "### Step 2: Merge-tool test suite")
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { evaluateG2, evaluateG3 } from '../../indexer/smi5879-gate-check.gates.ts'
+import { loadSimulatorReport } from '../../indexer/smi5879-gate-check.io.ts'
+import { runMergeShards } from '../../indexer/smi5879-merge-shards.ts'
+import {
+  MERGE_RUN_ID,
+  buildThreeShardFixture,
+  makeMergeShardsDb,
+  makeScratchDir,
+  makeSimulatorReportJson,
+  mergeArgs,
+  writeFixtureFile,
+  writeShardReport,
+} from './smi5879-merge-shards.fixtures.ts'
+
+let scratchDirs: string[] = []
+
+function scratch(): string {
+  const dir = makeScratchDir()
+  scratchDirs.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  scratchDirs = []
+})
+
+afterEach(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// sweep.hard_stopped propagation -> G-2 INCONCLUSIVE (proves the wiring)
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — sweep.hard_stopped propagation wired to G-2 (end-to-end)', () => {
+  it('a non-null hard_stopped from one shard survives the merge, making evaluateG2 INCONCLUSIVE', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+
+    const path0 = writeShardReport(dir, 0, fixture.shardRows[0], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals, {
+      sweep: { passes_run: 5, hard_stopped: 'non_convergence' },
+    })
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    const report = await runMergeShards(db, args)
+
+    // Merge-tool-level assertion: hard_stopped propagated, passes_run is the max().
+    expect(report.sweep.hard_stopped).toBe('non_convergence')
+    expect(report.sweep.passes_run).toBe(5)
+
+    // Gate-level assertion: this is what actually matters — a real gate
+    // evaluator, unmodified, rejects the merged report for the right reason.
+    const gate = evaluateG2(report, MERGE_RUN_ID)
+    expect(gate.outcome).toBe('INCONCLUSIVE')
+    expect(gate.reason).toMatch(/hard-stopped \(non_convergence\)/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sharding is provably transparent to the gate
+// ---------------------------------------------------------------------------
+
+describe('sharding is provably transparent to the gate (end-to-end)', () => {
+  it('a 3-shard merge and a genuine unsharded report over the SAME population evaluate identically', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+
+    const shardPaths = fixture.shardRows.map((rows, i) =>
+      writeShardReport(dir, i, rows, fixture.totals)
+    )
+    const db = makeMergeShardsDb(fixture.population)
+    const mergedReport = await runMergeShards(db, mergeArgs(shardPaths, join(dir, 'merged.json')))
+
+    // A genuine single-process, unsharded report over the IDENTICAL
+    // population: one process's `rows` array is the full concatenation,
+    // never split, so its own coverage totals equal what it actually
+    // scanned — built independently of the merge tool's own code, straight
+    // from `makeSimulatorReportJson`'s default `deriveCoverageFromRows`
+    // behavior, then round-tripped through the SAME `loadSimulatorReport`
+    // the gate itself uses.
+    const unshardedPath = writeFixtureFile(
+      dir,
+      'unsharded.json',
+      makeSimulatorReportJson({ run_id: MERGE_RUN_ID, rows: fixture.allReportRows })
+    )
+    const loadedUnsharded = loadSimulatorReport(unshardedPath, 'unsharded report')
+    if (loadedUnsharded.status !== 'ok') {
+      throw new Error(`test fixture itself is invalid: ${loadedUnsharded.reason}`)
+    }
+    const unshardedReport = loadedUnsharded.value
+
+    const mergedG2 = evaluateG2(mergedReport, MERGE_RUN_ID)
+    const unshardedG2 = evaluateG2(unshardedReport, MERGE_RUN_ID)
+    expect(mergedG2.outcome).toBe('PASS')
+    expect(unshardedG2.outcome).toBe('PASS')
+    expect(mergedG2.outcome).toBe(unshardedG2.outcome)
+
+    const mergedG3 = evaluateG3(mergedReport)
+    const unshardedG3 = evaluateG3(unshardedReport)
+    expect(mergedG3.outcome).toBe('PASS')
+    expect(unshardedG3.outcome).toBe('PASS')
+    expect(mergedG3.outcome).toBe(unshardedG3.outcome)
+
+    // Not just "same verdict" — the same rows and the same derived
+    // counts/coverage a gate actually reads, proving the merge changed
+    // nothing observable to either gate.
+    expect(mergedReport.rows.map((r) => r.id).sort()).toEqual(
+      unshardedReport.rows.map((r) => r.id).sort()
+    )
+    expect(mergedReport.counts).toEqual(unshardedReport.counts)
+    expect(mergedReport.coverage).toEqual(unshardedReport.coverage)
+  })
+})

--- a/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
@@ -245,7 +245,7 @@ describe('runMergeShards — row-outcome coherence (hard fail)', () => {
     )
   })
 
-  it('throws when a verdict-delta outcome is missing its prePortQuarantine/postPortQuarantine fields', async () => {
+  it('throws (via field-presence, which runs first) when a verdict-delta outcome is missing its prePortQuarantine/postPortQuarantine fields', async () => {
     const dir = scratch()
     const fixture = buildThreeShardFixture()
     const tampered = {
@@ -261,8 +261,60 @@ describe('runMergeShards — row-outcome coherence (hard fail)', () => {
     const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
 
     await expect(runMergeShards(db, args)).rejects.toThrow(
-      /row-c2-1.*outcome=newly_quarantined but prePortQuarantine\/postPortQuarantine is missing/s
+      /row-c2-1.*outcome=newly_quarantined is a scored outcome, but has neither field/s
     )
+  })
+
+  it("throws (round-2 confirmation review finding) when a row mislabeled unfetchable still carries a real newly_quarantined row's quarantine fields", async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // The exact round-2 attack: a genuinely newly_quarantined row (pre=false,
+    // post=true) relabeled `unfetchable` — the round-1 coherence check alone
+    // would skip this entirely (unfetchable isn't in VERDICT_DELTA_OUTCOMES),
+    // and it would also skip G-5's checkDeltaBound and G-1's review set.
+    const tampered = fixtureRow('row-c2-1', 'C2', {
+      outcome: 'unfetchable',
+      prePortQuarantine: false,
+      postPortQuarantine: true,
+    })
+
+    const path0 = writeShardReport(
+      dir,
+      0,
+      [tampered.reportRow, fixture.shardRows[0][1]],
+      fixture.totals
+    )
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /row-c2-1.*outcome=unfetchable is NOT a scored outcome, but carries/s
+    )
+  })
+
+  it('does NOT flag a genuine unfetchable/unevaluable/content_drifted row with no quarantine fields at all', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    const genuine = {
+      ...fixtureRow('row-c2-1', 'C2', { outcome: 'unfetchable' }).reportRow,
+    }
+    // Matches the real simulator's own shape for these three outcomes
+    // (processRow's early-return sites never attach these fields at all).
+    delete genuine['prePortQuarantine']
+    delete genuine['postPortQuarantine']
+    delete genuine['prePortRiskScore']
+    delete genuine['postPortRiskScore']
+
+    const path0 = writeShardReport(dir, 0, [genuine, fixture.shardRows[0][1]], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    const report = await runMergeShards(db, args)
+    expect(report.rows.find((r) => r.id === 'row-c2-1')?.outcome).toBe('unfetchable')
   })
 
   it('does NOT flag bundle_absent rows, whose outcome is deliberately overridden past what the quarantine booleans would classify to', async () => {

--- a/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
@@ -294,6 +294,39 @@ describe('runMergeShards — row-outcome coherence (hard fail)', () => {
     )
   })
 
+  it('throws (round-3 confirmation review finding) when a bundle_absent row has exactly ONE of the two quarantine fields present', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // The exact round-3 attack: `hasFields` was OR-based, so a scored-outcome
+    // row with only ONE field present passed the round-2 fix, and
+    // assertRowOutcomeCoherence can't rescue bundle_absent (it's outside
+    // VERDICT_DELTA_OUTCOMES by design) — this shape slipped through BOTH
+    // checks before this fix.
+    const partial = fixtureRow('row-c2-1', 'C2', {
+      outcome: 'bundle_absent',
+      prePortQuarantine: false,
+      // postPortQuarantine deliberately left present-by-default from
+      // makeSimRow, then removed below to construct the exact "only one
+      // field" shape.
+    })
+    delete (partial.reportRow as Record<string, unknown>)['postPortQuarantine']
+
+    const path0 = writeShardReport(
+      dir,
+      0,
+      [partial.reportRow, fixture.shardRows[0][1]],
+      fixture.totals
+    )
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /row-c2-1.*has exactly one of prePortQuarantine\/postPortQuarantine present/s
+    )
+  })
+
   it('does NOT flag a genuine unfetchable/unevaluable/content_drifted row with no quarantine fields at all', async () => {
     const dir = scratch()
     const fixture = buildThreeShardFixture()

--- a/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
@@ -205,3 +205,91 @@ describe('runMergeShards — shard-report numeric sanity (hard fail)', () => {
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// Row-outcome coherence (Wave 2 adversarial review High finding): none of
+// the checks above catch a row whose `outcome` label disagrees with its own
+// prePortQuarantine/postPortQuarantine fields — this can pass id
+// disjointness, population set-equality, and every coverage/count arithmetic
+// check, because `counts` is recomputed from the SAME (already-wrong)
+// `outcome` field the label itself carries.
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — row-outcome coherence (hard fail)', () => {
+  it('throws when a verdict-delta outcome disagrees with its own prePortQuarantine/postPortQuarantine', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // Real quarantine booleans say unchanged_quarantined (true/true), but the
+    // row's own outcome label claims unchanged_clean — a genuine population
+    // id, so id-disjointness and set-equality both pass; the label itself is
+    // the only thing wrong.
+    const tampered = fixtureRow('row-c2-1', 'C2', {
+      outcome: 'unchanged_clean',
+      prePortQuarantine: true,
+      postPortQuarantine: true,
+    })
+
+    const path0 = writeShardReport(
+      dir,
+      0,
+      [tampered.reportRow, fixture.shardRows[0][1]],
+      fixture.totals
+    )
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /row-c2-1.*outcome=unchanged_clean.*prePortQuarantine=true.*postPortQuarantine=true.*implies unchanged_quarantined/s
+    )
+  })
+
+  it('throws when a verdict-delta outcome is missing its prePortQuarantine/postPortQuarantine fields', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    const tampered = {
+      ...fixtureRow('row-c2-1', 'C2', { outcome: 'newly_quarantined' }).reportRow,
+    }
+    delete tampered['prePortQuarantine']
+    delete tampered['postPortQuarantine']
+
+    const path0 = writeShardReport(dir, 0, [tampered, fixture.shardRows[0][1]], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /row-c2-1.*outcome=newly_quarantined but prePortQuarantine\/postPortQuarantine is missing/s
+    )
+  })
+
+  it('does NOT flag bundle_absent rows, whose outcome is deliberately overridden past what the quarantine booleans would classify to', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // bundle_absent with prePortQuarantine/postPortQuarantine that would
+    // classify to something else entirely (unchanged_clean) if this row's
+    // outcome were a verdict-delta bucket — must NOT be flagged, since
+    // bundle_absent is not in VERDICT_DELTA_OUTCOMES.
+    const bundleAbsent = fixtureRow('row-c2-1', 'C2', {
+      outcome: 'bundle_absent',
+      prePortQuarantine: false,
+      postPortQuarantine: false,
+    })
+
+    const path0 = writeShardReport(
+      dir,
+      0,
+      [bundleAbsent.reportRow, fixture.shardRows[0][1]],
+      fixture.totals
+    )
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    const report = await runMergeShards(db, args)
+    expect(report.rows.find((r) => r.id === 'row-c2-1')?.outcome).toBe('bundle_absent')
+  })
+})

--- a/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
@@ -261,7 +261,7 @@ describe('runMergeShards — row-outcome coherence (hard fail)', () => {
     const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
 
     await expect(runMergeShards(db, args)).rejects.toThrow(
-      /row-c2-1.*outcome=newly_quarantined is a scored outcome, but has neither field/s
+      /row-c2-1.*outcome=newly_quarantined is a scored outcome, but has neither prePortQuarantine nor postPortQuarantine/s
     )
   })
 
@@ -324,6 +324,27 @@ describe('runMergeShards — row-outcome coherence (hard fail)', () => {
 
     await expect(runMergeShards(db, args)).rejects.toThrow(
       /row-c2-1.*has exactly one of prePortQuarantine\/postPortQuarantine present/s
+    )
+  })
+
+  it('throws (round-4 confirmation review finding) when a row has a coherent quarantine pair but a partial risk-score pair', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // Quarantine pair is fully present and coherent (unchanged_clean,
+    // false/false) — the round-1/2/3 checks all pass this row. Only ONE
+    // risk-score field is present, a shape the real simulator can never
+    // emit (processRow always sets all four fields together).
+    const partial = { ...fixtureRow('row-c2-1', 'C2').reportRow }
+    delete partial['postPortRiskScore']
+
+    const path0 = writeShardReport(dir, 0, [partial, fixture.shardRows[0][1]], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /row-c2-1.*has exactly one of prePortRiskScore\/postPortRiskScore present/s
     )
   })
 

--- a/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.invariants.test.ts
@@ -1,0 +1,207 @@
+/**
+ * SMI-6015 PAT-sharded fetch, Wave 2 item 2: `smi5879-merge-shards.ts` test
+ * suite (part 2) — the merge-rule table's hard-fail invariants
+ * (`smi5879-merge-shards.merge-rules.ts`): row overlap, row gap, coverage-
+ * total disagreement (shard-vs-shard AND all-shards-agree-but-wrong-vs-
+ * reality), `sweep.hard_stopped` disagreement, identity-field mismatch, and
+ * shard-report numeric sanity. N=3 happy path and CLI parsing live in
+ * `smi5879-merge-shards.test.ts`; `loadVerifiedPopulation`/
+ * `assertReportsBindToGeneration` precondition hard-fails live in
+ * `smi5879-merge-shards.population-binding.test.ts`. Shared fixtures in
+ * `smi5879-merge-shards.fixtures.ts`.
+ * @module scripts/tests/indexer/smi5879-merge-shards.invariants
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)",
+ *       "### Step 2: Merge-tool test suite")
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { runMergeShards } from '../../indexer/smi5879-merge-shards.ts'
+import {
+  buildThreeShardFixture,
+  fixtureRow,
+  makeMergeShardsDb,
+  makeScratchDir,
+  mergeArgs,
+  writeShardReport,
+} from './smi5879-merge-shards.fixtures.ts'
+
+let scratchDirs: string[] = []
+
+function scratch(): string {
+  const dir = makeScratchDir()
+  scratchDirs.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  scratchDirs = []
+})
+
+afterEach(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Row overlap
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — row overlap (hard fail)', () => {
+  it('throws naming both shard file paths when a row id appears in 2+ shard reports', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    const dupRow = fixture.shardRows[1][0] // 'row-c2-3', originally only in shard 1
+    const dupId = dupRow['id'] as string
+
+    const path0 = writeShardReport(dir, 0, [...fixture.shardRows[0], dupRow], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      new RegExp(`${dupId}.*in both.*shard0\\.json.*shard1\\.json`)
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row gap — the exact-set-equality safety property
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — row gap (hard fail)', () => {
+  it('throws when a row in the true population is absent from every shard report', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // A population row NO shard's `rows` array mentions at all.
+    const ghost = fixtureRow('row-ghost', 'C2')
+    const population = [...fixture.population, ghost.population]
+
+    const paths = fixture.shardRows.map((rows, i) => writeShardReport(dir, i, rows, fixture.totals))
+    const db = makeMergeShardsDb(population)
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /population row\(s\) reported by NO shard.*row-ghost/s
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// coverage[cohort].total mismatch — shard vs. shard disagreement
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — mismatched coverage[cohort].total across shards (hard fail)', () => {
+  it('throws when shard reports disagree with each other on the same cohort total', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // Shard 1 alone claims a different C2 total than shards 0 and 2.
+    const badTotals = { ...fixture.totals, C2: fixture.totals.C2 + 1 }
+
+    const path0 = writeShardReport(dir, 0, fixture.shardRows[0], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], badTotals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(/disagree on coverage\.C2\.total/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// coverage[cohort].total mismatch — all shards agree, but wrong vs. reality
+// (distinct from the shard-vs-shard case above: exercises
+// assertCoverageTotalsMatchPopulation specifically)
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — population-total mismatch (all shards agree, all wrong)', () => {
+  it('throws via assertCoverageTotalsMatchPopulation when every shard agrees on a WRONG cohort total', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    // Every shard reports the SAME total, but it's wrong: the real sealed
+    // population has 3 C2 rows, every shard claims 4.
+    const wrongTotals = { ...fixture.totals, C2: fixture.totals.C2 + 1 }
+
+    const paths = fixture.shardRows.map((rows, i) => writeShardReport(dir, i, rows, wrongTotals))
+    const db = makeMergeShardsDb(fixture.population) // unchanged — really 3 C2 rows
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /shard-reported cohort total\(s\) do not match the digest-verified sealed population/
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sweep.hard_stopped disagreement
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — sweep.hard_stopped DISAGREEMENT across shards (hard fail)', () => {
+  it('throws when two shards report DIFFERENT non-null hard_stopped reasons', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+
+    const path0 = writeShardReport(dir, 0, fixture.shardRows[0], fixture.totals, {
+      sweep: { passes_run: 2, hard_stopped: 'non_convergence' },
+    })
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals, {
+      sweep: { passes_run: 3, hard_stopped: 'max_passes' },
+    })
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(/disagree on sweep\.hard_stopped/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Identity field mismatch
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — identity field mismatch (hard fail)', () => {
+  it('throws naming the field when shard reports disagree on baseline_commit', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+
+    const path0 = writeShardReport(dir, 0, fixture.shardRows[0], fixture.totals)
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals, {
+      baseline_commit: 'b'.repeat(40),
+    })
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /disagree on field\(s\).*baseline_commit/s
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shard-report numeric sanity (defense in depth beyond loadSimulatorReport's
+// bare `typeof n !== 'number'` check, which a negative/fractional/NaN value
+// passes — assertShardReportNumericSanity, smi5879-merge-shards.merge-rules.ts)
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — shard-report numeric sanity (hard fail)', () => {
+  it('throws when a shard report has a negative sweep.passes_run', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+
+    const path0 = writeShardReport(dir, 0, fixture.shardRows[0], fixture.totals, {
+      sweep: { passes_run: -1, hard_stopped: null },
+    })
+    const path1 = writeShardReport(dir, 1, fixture.shardRows[1], fixture.totals)
+    const path2 = writeShardReport(dir, 2, fixture.shardRows[2], fixture.totals)
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs([path0, path1, path2], join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /sweep\.passes_run=-1, which is not a non-negative integer/
+    )
+  })
+})

--- a/scripts/tests/indexer/smi5879-merge-shards.population-binding.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.population-binding.test.ts
@@ -1,0 +1,124 @@
+/**
+ * SMI-6015 PAT-sharded fetch, Wave 2 item 2: `smi5879-merge-shards.ts` test
+ * suite (part 3) — `loadVerifiedPopulation`/`assertReportsBindToGeneration`
+ * preconditions (`smi5879-merge-shards.population.ts`): an unsealed
+ * generation, a failed digest re-verification, an empty sealed population,
+ * and a shard-report/live-generation binding mismatch. These are not on the
+ * plan's own minimum test list, but they are the exact "digest-verified,
+ * sealed generation only" guardrails that module's doc comment calls
+ * "deliberately no flag to skip" — an obvious gap to close, not a separate
+ * unit test of `.population.ts` in isolation: every case here goes through
+ * the real `runMergeShards` orchestration, proving the wiring. Row-level
+ * invariants (overlap/gap/coverage/hard_stopped/identity) live in
+ * `smi5879-merge-shards.invariants.test.ts`. Shared fixtures in
+ * `smi5879-merge-shards.fixtures.ts`.
+ * @module scripts/tests/indexer/smi5879-merge-shards.population-binding
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)")
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { runMergeShards } from '../../indexer/smi5879-merge-shards.ts'
+import type { SimSnapshotRow } from '../../indexer/smi5879-simulate-full.types.ts'
+import {
+  buildThreeShardFixture,
+  makeMergeShardsDb,
+  makeScratchDir,
+  mergeArgs,
+  writeShardReport,
+} from './smi5879-merge-shards.fixtures.ts'
+
+let scratchDirs: string[] = []
+
+function scratch(): string {
+  const dir = makeScratchDir()
+  scratchDirs.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  scratchDirs = []
+})
+
+afterEach(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+/** Write the standard 3-shard fixture's reports and return ready-to-use args. */
+function setUpThreeShards(dir: string): { paths: string[]; population: SimSnapshotRow[] } {
+  const fixture = buildThreeShardFixture()
+  const paths = fixture.shardRows.map((rows, i) => writeShardReport(dir, i, rows, fixture.totals))
+  return { paths, population: fixture.population }
+}
+
+describe('runMergeShards — generation not sealed (hard fail)', () => {
+  it('throws when the live generation is not "sealed"', async () => {
+    const dir = scratch()
+    const { paths, population } = setUpThreeShards(dir)
+    const db = makeMergeShardsDb(population, {
+      async getRunSummary() {
+        return { purpose: 'decision', status: 'open' }
+      },
+    })
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(/is "open", not "sealed"/)
+  })
+})
+
+describe('runMergeShards — digest re-verification failure (hard fail)', () => {
+  it('throws when the population digest no longer matches its sealed-time value', async () => {
+    const dir = scratch()
+    const { paths, population } = setUpThreeShards(dir)
+    const db = makeMergeShardsDb(population, {
+      async verifyDigest() {
+        return { populationMatches: false, branchMatches: true }
+      },
+    })
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(/digest verification failed/)
+  })
+})
+
+describe('runMergeShards — empty sealed population (hard fail)', () => {
+  it('throws rather than vacuously "proving" set equality for an empty population', async () => {
+    const dir = scratch()
+    const { paths } = setUpThreeShards(dir)
+    const db = makeMergeShardsDb([]) // loadCohortRows returns zero rows
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(/sealed population.*is empty/)
+  })
+})
+
+describe('runMergeShards — shard reports do not bind to the generation being merged (hard fail)', () => {
+  it('throws when --run-id does not match the shard reports own run_id', async () => {
+    const dir = scratch()
+    const { paths, population } = setUpThreeShards(dir)
+    const db = makeMergeShardsDb(population)
+    const args = mergeArgs(paths, join(dir, 'merged.json'), 'a-completely-different-run-id')
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /do not bind to the generation being merged/
+    )
+  })
+
+  it('throws when the live generation summary purpose disagrees with the shard reports', async () => {
+    const dir = scratch()
+    const { paths, population } = setUpThreeShards(dir)
+    const db = makeMergeShardsDb(population, {
+      async getRunSummary() {
+        return { purpose: 'rehearsal', status: 'sealed' }
+      },
+    })
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    await expect(runMergeShards(db, args)).rejects.toThrow(
+      /do not bind to the generation being merged.*purpose/s
+    )
+  })
+})

--- a/scripts/tests/indexer/smi5879-merge-shards.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.test.ts
@@ -1,0 +1,193 @@
+/**
+ * SMI-6015 PAT-sharded fetch, Wave 2 item 2: `smi5879-merge-shards.ts` test
+ * suite (part 1) — CLI arg parsing and the N=3 happy path. Invariant hard-
+ * fail cases live in `smi5879-merge-shards.invariants.test.ts`;
+ * `loadVerifiedPopulation`/`assertReportsBindToGeneration` precondition
+ * hard-fails live in `smi5879-merge-shards.population-binding.test.ts`; the
+ * `sweep.hard_stopped` -> G-2 wiring and the end-to-end
+ * sharding-is-transparent-to-the-gate proof live in
+ * `smi5879-merge-shards.gate-wiring.test.ts`. Shared fixtures in
+ * `smi5879-merge-shards.fixtures.ts`.
+ * @module scripts/tests/indexer/smi5879-merge-shards
+ *
+ * Plan: docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+ *       ("### 3. N-way checkpoint/report merge tool (new script)",
+ *       "### Step 2: Merge-tool test suite")
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { loadSimulatorReport } from '../../indexer/smi5879-gate-check.io.ts'
+import { parseArgs, runMergeShards, writeMergedReport } from '../../indexer/smi5879-merge-shards.ts'
+import {
+  MERGE_RUN_ID,
+  buildThreeShardFixture,
+  makeMergeShardsDb,
+  makeScratchDir,
+  mergeArgs,
+  writeShardReport,
+} from './smi5879-merge-shards.fixtures.ts'
+
+// ---------------------------------------------------------------------------
+// Scratch-dir lifecycle — matches `makeScratchDir()`'s own convention
+// (`smi5879-gate-check.fixtures.ts`) of one `mkdtempSync` per test, cleaned
+// up here rather than left for the OS temp-dir reaper.
+// ---------------------------------------------------------------------------
+
+let scratchDirs: string[] = []
+
+function scratch(): string {
+  const dir = makeScratchDir()
+  scratchDirs.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  scratchDirs = []
+})
+
+afterEach(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('parses --run-id/--reports/--output into MergeShardsCliArgs', () => {
+    const args = parseArgs(['--run-id=run-1', '--reports=a.json,b.json', '--output=out.json'])
+    expect(args).toEqual({
+      runId: 'run-1',
+      reportPaths: ['a.json', 'b.json'],
+      outputPath: 'out.json',
+    })
+  })
+
+  it('requires --run-id', () => {
+    expect(() => parseArgs(['--reports=a.json', '--output=out.json'])).toThrow(/--run-id/)
+  })
+
+  it('requires --reports', () => {
+    expect(() => parseArgs(['--run-id=run-1', '--output=out.json'])).toThrow(/--reports/)
+  })
+
+  it('rejects an empty --reports value', () => {
+    expect(() => parseArgs(['--run-id=run-1', '--reports=', '--output=out.json'])).toThrow(
+      /--reports/
+    )
+  })
+
+  it('requires --output', () => {
+    expect(() => parseArgs(['--run-id=run-1', '--reports=a.json'])).toThrow(/--output/)
+  })
+
+  it('rejects the exact same --reports path listed twice (SMI-6015 Wave 2 CLI safeguard)', () => {
+    expect(() =>
+      parseArgs(['--run-id=run-1', '--reports=shard0.json,shard0.json', '--output=out.json'])
+    ).toThrow(/resolve to the same file/)
+  })
+
+  it('rejects two different spellings of the same file passed as separate --reports entries', () => {
+    // `./shard0.json` and `shard0.json` resolve to the identical absolute
+    // path from the same cwd — the exact "confusing downstream overlap
+    // error" scenario `parseArgs`'s own doc comment names.
+    expect(() =>
+      parseArgs(['--run-id=run-1', '--reports=./shard0.json,shard0.json', '--output=out.json'])
+    ).toThrow(/resolve to the same file/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// N=3 happy path
+// ---------------------------------------------------------------------------
+
+describe('runMergeShards — N=3 happy path', () => {
+  it('merges 3 disjoint shard reports covering the whole population into one report', async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    const paths = fixture.shardRows.map((rows, i) => writeShardReport(dir, i, rows, fixture.totals))
+    const db = makeMergeShardsDb(fixture.population)
+    const args = mergeArgs(paths, join(dir, 'merged.json'))
+
+    const report = await runMergeShards(db, args)
+
+    expect(report.report_kind).toBe('full_simulation')
+    expect(report.run_id).toBe(MERGE_RUN_ID)
+    expect(report.purpose).toBe('decision')
+    expect(report.status).toBe('sealed')
+    expect(report.token_source).toBe('pat')
+    expect(report.estimated_completion_at).toBeNull()
+
+    // rows: concatenated, set-equal to the whole population, zero duplicates.
+    expect(report.rows).toHaveLength(6)
+    expect(report.rows.map((r) => r.id).sort()).toEqual(fixture.population.map((r) => r.id).sort())
+
+    // coverage: total identical to the true per-cohort population count,
+    // scanned summed across shards, status recomputed as 'full' since every
+    // row was accounted for and none is unevaluable.
+    expect(report.coverage.C2).toEqual({
+      status: 'full',
+      scanned: 3,
+      total: 3,
+      unevaluable: 0,
+      unfetchable: 0,
+    })
+    expect(report.coverage.C3).toEqual({
+      status: 'full',
+      scanned: 3,
+      total: 3,
+      unevaluable: 0,
+      unfetchable: 0,
+    })
+    expect(report.coverage.C1).toEqual({
+      status: 'full',
+      scanned: 0,
+      total: 0,
+      unevaluable: 0,
+      unfetchable: 0,
+    })
+    expect(report.coverage.C4).toEqual({
+      status: 'full',
+      scanned: 0,
+      total: 0,
+      unevaluable: 0,
+      unfetchable: 0,
+    })
+
+    // counts: recomputed from the merged rows, sum(counts) === rows.length.
+    expect(report.counts.unchanged_clean).toBe(6)
+    const countsSum = Object.values(report.counts).reduce((a, b) => a + b, 0)
+    expect(countsSum).toBe(report.rows.length)
+
+    // sweep: no shard hard-stopped, passes_run is the max across shards
+    // (every shard defaults to `makeSimulatorReportJson`'s passes_run: 1).
+    expect(report.sweep).toEqual({ passes_run: 1, hard_stopped: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// writeMergedReport
+// ---------------------------------------------------------------------------
+
+describe('writeMergedReport', () => {
+  it("writes a merged report that round-trips through the gate's own loadSimulatorReport as ok", async () => {
+    const dir = scratch()
+    const fixture = buildThreeShardFixture()
+    const paths = fixture.shardRows.map((rows, i) => writeShardReport(dir, i, rows, fixture.totals))
+    const db = makeMergeShardsDb(fixture.population)
+    const outputPath = join(dir, 'merged.json')
+    const args = mergeArgs(paths, outputPath)
+    const report = await runMergeShards(db, args)
+
+    writeMergedReport(outputPath, report)
+
+    const reloaded = loadSimulatorReport(outputPath, 'merged report')
+    expect(reloaded.status).toBe('ok')
+    if (reloaded.status === 'ok') {
+      expect(reloaded.value.run_id).toBe(MERGE_RUN_ID)
+      expect(reloaded.value.rows).toHaveLength(6)
+    }
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** The N-way shard-merge tool for the PAT-sharded fetch plan. Once N independent processes each finish fetching their own slice of the population, this tool combines their reports into the single report the security scanner's merge-gate actually evaluates — the piece that was missing to make Wave 1's sharding useful end to end.

**Quality bar:** Opus-tier implementation, Sonnet-tier test suite, then a 5-round adversarial review (GPT-5.6-Sol) specifically on this tool — not reused from Wave 1's or Wave 3's review, since this sits directly on the security-gate's row-accounting path. The review found a real gap and kept finding a narrower version of the same gap in each fix, four times in a row, before a fifth round came back genuinely clean: a row could carry a security verdict label (quarantined or not) that disagreed with the underlying data backing that verdict, while every count and coverage number the tool checks still balanced perfectly. Closed for good — the tool now verifies a row's outcome label against its own supporting fields, and verifies those fields are present exactly when they're supposed to be, both individually and in relation to each other.

**Found along the way:** two pre-existing, unrelated issues, filed separately rather than folded into this PR — SMI-6171 (this repo's `scripts/` directory has no static type-checking or lint coverage in CI at all, which is how the next issue went undetected) and SMI-6172 (a real bug in a sibling fetch tool, `smi5879-simulate-preflight-estimate.ts`, passing stale auth headers instead of fresh ones).

**Net result:** Fully shipped. Wave 3 (the manual dispatch runbook for the real multi-day production run) is separate, unstarted work.

---

## Technical detail

**New files:**
- `scripts/indexer/smi5879-merge-shards.ts` — CLI (`--run-id`, `--reports`, `--output`), orchestration, atomic self-validating write (the merged output is round-tripped through the gate's own report loader before it's committed to disk).
- `scripts/indexer/smi5879-merge-shards.merge-rules.ts` — the plan's full merge-rule table: identity fields must match exactly, coverage totals must match exactly, scanned/unevaluable/unfetchable are summed (never double-counted against `scanned`), status is recomputed rather than trusted, rows are concatenated with disjointness enforced, counts are recomputed from the rows directly, sweep state propagates with any disagreement treated as a hard failure.
- `scripts/indexer/smi5879-merge-shards.population.ts` — independently loads and digest-verifies the real, sealed population and asserts exact set equality against the merged rows (zero missing, zero extra, zero duplicate) — row-disjointness alone can't prove nothing went missing, only that nothing got double-counted.
- `scripts/indexer/smi5879-merge-shards.outcome-coherence.ts` — the review-driven addition: verifies each row's outcome label agrees with the quarantine and risk-score fields backing it, and that those fields are present exactly when the outcome says they should be.
- 5 new test files (happy path, invariant violations, population-binding preconditions, gate-wiring, shared fixtures) — 25 tests total for this tool.

**Changed files:**
- `scripts/tests/indexer/run-gate-callsites.test.ts` — this repo's entry-point census correctly flagged the new tool as an unclassified guarded direct-entry point. Classified it as a pure reader that's deliberately not gated by the change-window freeze mechanism, for the same reason its two pipeline neighbors already aren't: it runs strictly between them in the same window, so gating it on that mechanism would be circular.

**CI:** Docker-first, full test suite via pre-push hook. `scripts/` has no `npm run typecheck` coverage (SMI-6171) — manually typechecked via `npx tsc --noEmit -p scripts/indexer/tsconfig.json`, clean except the pre-existing SMI-6172 bug.
