### PR TITLE
fix(website): align pricing page with shipped features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `rbac_manage` | Manage RBAC roles: create, list, get, delete (Enterprise) |
 | `rbac_assign_role` | Assign or revoke roles for users (Enterprise) |
 | `rbac_create_policy` | Create and manage RBAC access policies (Enterprise) |
-| `compliance_report` | Generate SOC2, CycloneDX SBOM, or JSON compliance reports (Enterprise) |
+| `compliance_report` | Generate SOC2, CycloneDX SBOM, or JSON compliance reports (Team+) |
 
 **Auth**: Personal API Key (`X-API-Key: sk_live_*`, tier-based), Supabase Anon Key (30/min), No Auth (10 trial). Configure in `~/.skillsmith/config.json` or `SKILLSMITH_API_KEY` env. Shell exports don't reach MCP subprocesses. Team-tool resolution chain (SMI-4312/ADR-116), trust tiers, CLI surface: see [mcp-tools-guide.md](.claude/development/mcp-tools-guide.md).
 

--- a/packages/website/src/content/blog/enterprise-reference-architecture.md
+++ b/packages/website/src/content/blog/enterprise-reference-architecture.md
@@ -17,9 +17,10 @@ for that — what the pieces are, how they fit, and what changes when Skillsmith
 runs on infrastructure you control.
 
 A note on honesty up front: **this is a target-state blueprint.** The discovery,
-indexing, and distribution layers ship today. The access-control layer —
-IAM/RBAC and SSO — is partially built: the tools and a Supabase-backed data path
-exist, but maturity varies. Where that matters, the text says so.
+indexing, and distribution layers ship today. The private registry has a real
+Supabase-backed live mode. IAM/RBAC and SSO are further behind: the MCP tool
+surface exists, but the backing service is stub-only today, with no live mode
+yet. Where that matters, the text says so.
 
 ![Architecture diagram of Skillsmith showing three developer surfaces — CLI, MCP server, and VS Code extension — reading from a per-developer local SQLite database, which is synced from a hosted Supabase registry of Postgres tables and edge functions.](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/enterprise-reference-architecture/01-system-overview)
 
@@ -57,7 +58,7 @@ service. That is the whole model.
 | Per-developer local SQLite index | Shipped |
 | GitHub indexer + `skillsmith sync` | Shipped |
 | Private internal registry | Tooling shipped; backend matures with a configured database |
-| IAM/RBAC enforcement, SSO/SAML | Designed; Supabase-backed mode exists, maturity varies |
+| IAM/RBAC enforcement, SSO/SAML | Designed; MCP tool surface exists, backing service is stub-only |
 
 ## The entities that make up Skillsmith
 
@@ -141,11 +142,13 @@ and the model lets you treat them differently. Every action is written to an
 audit log, queryable and exportable to a SIEM.
 
 To be straight about maturity: the RBAC, SSO, and private-registry **tools**
-exist and are wired into the MCP server, with a Supabase-backed live mode that
-activates when a database is configured and a stub fallback when one is not.
-Treat this layer as the *designed* access-control model of the reference
-architecture — real, in progress, and not yet something to put in front of an
-auditor as finished.
+all exist and are wired into the MCP server, but they are not equally far
+along. The private registry has a real Supabase-backed live mode that
+activates when a database is configured, with a stub fallback when one is
+not. RBAC and SSO are stub-only right now — no live backing service exists
+yet, database or not. Treat this layer as the *designed* access-control model
+of the reference architecture — real for the registry, not yet for RBAC and
+SSO, and none of it something to put in front of an auditor as finished.
 
 ## Why this matters for partners
 

--- a/packages/website/src/lib/pricing-data.ts
+++ b/packages/website/src/lib/pricing-data.ts
@@ -5,8 +5,10 @@
  *
  * SMI-2081: Extracted from pricing.astro to comply with 500-line limit
  * SMI-3909: Consolidated as single canonical source for all pricing data
- * Source of truth for pricing tiers from ADR-013 (Open Core Licensing)
- * and ADR-017 (Quota Enforcement).
+ * Feature-tier gating ground truth lives in code, not ADR-013 (superseded
+ * by ADR-119): see packages/enterprise/src/license/FeatureFlags.ts and
+ * packages/mcp-server/src/middleware/toolFeatureMapping.ts. Quota figures
+ * per ADR-017 (Quota Enforcement).
  */
 
 import type { PricingTier, PricingFeature } from '../types/index.js'
@@ -122,7 +124,15 @@ export const pricingTiers: PricingTier[] = [
     description: 'The lifecycle layer for teams — publish, version, and deprecate together.',
     apiCalls: 10000,
     apiCallsFormatted: '10,000 API calls/month',
-    features: [{ name: 'Everything in Individual' }, { name: 'Priority support' }],
+    features: [
+      { name: 'Everything in Individual' },
+      { name: 'Private skill publishing (local, single-device)' },
+      { name: 'Team workspaces & skill sharing' },
+      { name: 'Team usage analytics' },
+      { name: 'Skill security audits' },
+      { name: 'Compliance reports (SOC 2 / CycloneDX AI-BOM)' },
+      { name: 'Priority support' },
+    ],
     cta: 'Start Trial',
     ctaHref: '/signup?tier=team',
     highlighted: true,
@@ -139,6 +149,9 @@ export const pricingTiers: PricingTier[] = [
     apiCallsFormatted: 'Unlimited API calls',
     features: [
       { name: 'Everything in Team' },
+      { name: 'Private team registry (shared, versioned)' },
+      { name: 'Audit logging & SIEM export' },
+      { name: 'SSO/SAML & RBAC (configured during onboarding)' },
       { name: '99.9% SLA guarantee' },
       { name: 'Dedicated support' },
     ],

--- a/packages/website/src/lib/pricing-data.ts
+++ b/packages/website/src/lib/pricing-data.ts
@@ -128,7 +128,7 @@ export const pricingTiers: PricingTier[] = [
       { name: 'Everything in Individual' },
       { name: 'Private skill publishing (local, single-device)' },
       { name: 'Team workspaces & skill sharing' },
-      { name: 'Team usage analytics' },
+      { name: 'Usage analytics & reporting (per-user)' },
       { name: 'Skill security audits' },
       { name: 'Compliance reports (SOC 2 / CycloneDX AI-BOM)' },
       { name: 'Priority support' },

--- a/packages/website/src/pages/docs/faq.astro
+++ b/packages/website/src/pages/docs/faq.astro
@@ -87,7 +87,7 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "What's included in the analytics dashboard?",
-        answer: "The analytics dashboard (Individual and above) shows your skill usage patterns, most-used skills, recommendation accuracy, and API consumption trends. Team plans include aggregated team analytics."
+        answer: "The analytics dashboard (Individual and above) shows your skill usage patterns, most-used skills, recommendation accuracy, and API consumption trends. Team plans add usage analytics and reporting tools: per-user counts, top tools, and period-over-period trends. This is not a cross-team rollup."
       },
       {
         question: "What is the Trust Tier system?",

--- a/packages/website/src/pages/pricing.astro
+++ b/packages/website/src/pages/pricing.astro
@@ -2,7 +2,8 @@
 /**
  * Skillsmith Pricing Page
  *
- * Pricing tiers from ADR-013 (Open Core Licensing) and ADR-017 (Quota Enforcement)
+ * Pricing tiers: quota figures per ADR-017 (Quota Enforcement); feature-tier
+ * gating ground truth is code (see pricing-data.ts), not ADR-013 (superseded)
  * License: Elastic License 2.0
  * SMI-1071: Annual billing toggle support
  * SMI-1554: Migrated to BaseLayout for layout consistency
@@ -227,17 +228,15 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
             <td>Analytics Dashboard</td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td>Basic</td>
-            <td class="highlighted"><span class="dash" aria-label="No">&mdash;</span></td>
+            <td class="highlighted">Team</td>
             <td>Advanced</td>
           </tr>
           <tr>
             <td>Team Workspaces</td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
-            <td class="highlighted"
-              ><span class="roadmap" aria-label="On roadmap">&#128336;</span></td
-            >
-            <td><span class="roadmap" aria-label="On roadmap">&#128336;</span></td>
+            <td class="highlighted"><span class="check" aria-label="Yes">&#10003;</span></td>
+            <td><span class="check" aria-label="Yes">&#10003;</span></td>
           </tr>
           <tr>
             <td>Private Skill Registry</td>
@@ -253,14 +252,14 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td class="highlighted"><span class="dash" aria-label="No">&mdash;</span></td>
-            <td><span class="roadmap" aria-label="On roadmap">&#128336;</span></td>
+            <td><span class="check" aria-label="Yes">&#10003;</span></td>
           </tr>
           <tr>
             <td>Role-Based Access Control</td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td class="highlighted"><span class="dash" aria-label="No">&mdash;</span></td>
-            <td><span class="roadmap" aria-label="On roadmap">&#128336;</span></td>
+            <td><span class="check" aria-label="Yes">&#10003;</span></td>
           </tr>
           <tr>
             <td>Audit Logging</td>
@@ -300,6 +299,10 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
         </tbody>
       </table>
     </div>
+    <p class="roadmap-legend">
+      SSO/SAML and Role-Based Access Control are included with Enterprise and configured as part of
+      your onboarding engagement -- contact sales for details.
+    </p>
   </section>
 
   <section class="pricing-roadmap" id="roadmap">
@@ -311,19 +314,14 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
       <div class="roadmap-column">
         <h3>Team tier</h3>
         <ul>
-          <li>Team workspaces</li>
           <li>
             Private skills (team-wide sync -- a local-only, single-device version ships today)
           </li>
-          <li>Skill sharing controls</li>
-          <li>Usage analytics</li>
         </ul>
       </div>
       <div class="roadmap-column">
         <h3>Enterprise tier</h3>
         <ul>
-          <li>SSO / SAML integration</li>
-          <li>Role-based access control</li>
           <li>Custom integrations</li>
         </ul>
       </div>

--- a/packages/website/src/pages/pricing.astro
+++ b/packages/website/src/pages/pricing.astro
@@ -228,7 +228,7 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
             <td>Analytics Dashboard</td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td>Basic</td>
-            <td class="highlighted">Team</td>
+            <td class="highlighted">Per-user</td>
             <td>Advanced</td>
           </tr>
           <tr>
@@ -300,8 +300,8 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
       </table>
     </div>
     <p class="roadmap-legend">
-      SSO/SAML and Role-Based Access Control are included with Enterprise and configured as part of
-      your onboarding engagement -- contact sales for details.
+      SSO/SAML and Role-Based Access Control are included with Enterprise, configured as part of
+      your onboarding engagement. Contact sales for details.
     </p>
   </section>
 


### PR DESCRIPTION
## Business Summary

**What shipped:** The pricing page (skillsmith.app/pricing) undersold real, shipped features -- private skills, team workspaces, team analytics, skill security audits, and compliance reports weren't mentioned on the Team/Enterprise cards at all, and the comparison table wrongly marked Team Workspaces and Analytics Dashboard as unavailable/roadmap for Team even though they're live. SSO/SAML and Role-Based Access Control move from "on roadmap" to included Enterprise features, framed as configured during onboarding (Enterprise is Contact-Sales/custom) rather than self-serve, per an explicit product-owner decision. `CLAUDE.md`'s `compliance_report` tier annotation is corrected to match code (Team+, not Enterprise-only). `docs/internal/legal/TERMS.md` gets its missing $9.99/mo Individual tier (merged separately, skillsmith-docs#860).

**Quality bar:** Cross-checked every claim against the actual gating code (`toolFeatureMapping.ts`, `FeatureFlags.ts`) and the real tool implementations (confirmed which of team-workspace/analytics/SSO/RBAC/private-registry/integrations are genuinely live vs. stub-only), plus the internal `01-pricing-packaging.md` strategy doc. An independent Opus-tier adversarial review pass re-verified all of that ground truth from scratch and caught two overclaims the first pass introduced ("Team usage analytics" implied cross-teammate aggregation that doesn't exist) and a matching pre-existing FAQ inaccuracy plus a false "Supabase-backed live mode" claim for RBAC/SSO on a public blog post -- all corrected in a follow-up commit.

**Found along the way:** SMI-6182 (the larger, unimplemented `01-pricing-packaging.md` repricing initiative -- staged Team pricing, dropping self-serve checkout, etc. -- explicitly out of scope here per the user), SMI-6183 (`standards-enterprise.md` describes an aspirational Ed25519 private-registry model instead of the real Postgres-JSONB one), SMI-6184 (sso-tools.ts/rbac-tools.ts/integration-tools.ts report `dataSource:'live'` while always serving the stub -- a real code bug), SMI-6185 (TERMS.md's Enterprise price/Team SLA figures vs. the public page's suppressed price/blank SLA cell -- needs legal/business sign-off, not a code fix).

**Net result:** Fully shipped. Four follow-ups filed and tracked (SMI-6182 through SMI-6185), none blocking this PR.

---

## Technical detail

- `packages/website/src/lib/pricing-data.ts` -- Team/Enterprise card `features` arrays gained real shipped differentiators; stale ADR-013 doc-comment replaced with a pointer to the actual gating code.
- `packages/website/src/pages/pricing.astro` -- comparison table: Team Workspaces (checkmark for Team+Enterprise), Analytics Dashboard (Team cell now "Per-user", not "--" or "Team" -- avoids implying cross-teammate aggregation), SSO/SAML + RBAC (checkmark for Enterprise) with a new fine-print note; roadmap section pruned of shipped items.
- `packages/website/src/pages/docs/faq.astro` -- corrected an "aggregated team analytics" claim that doesn't match how `team_analytics_dashboard`/`team_usage_report` actually work (per-user, local SQLite, no `team_id` filter).
- `packages/website/src/content/blog/enterprise-reference-architecture.md` -- corrected three spots claiming RBAC/SSO have "a Supabase-backed live mode" (false -- `sso-tools.ts`/`rbac-tools.ts` are stub-only, no live branch anywhere), while preserving the accurate claim that the private registry genuinely does have one.
- `CLAUDE.md` -- `compliance_report` MCP tool tier annotation `(Enterprise)` -> `(Team+)`, matching SMI-3140.
- `docs/internal` submodule pointer bump -- picks up skillsmith-docs#860 (merged), adding the missing Individual tier to `TERMS.md`.

Verification: `npm run build`/`typecheck`/`lint` for the website package (green), `npm run audit:standards` (0 failures), Prettier clean, full pre-push suite passed on push. Linear: SMI-6181 (this PR), SMI-6182/6183/6184/6185 (follow-ups).