### PR TITLE
fix(website): sitewide indexing bugs from Search Console audit (SMI-6180)

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -81,6 +81,30 @@ export default defineConfig({
   // Build output configuration - static with SSR adapter for dynamic routes
   output: 'static',
 
+  // SMI-6180: with trailingSlash left at its default ('ignore'), Astro's own
+  // default build.format ('directory') makes Astro.url.pathname carry a
+  // trailing slash for every prerendered page during the static build —
+  // BaseLayout's self-referencing canonical (src/layouts/BaseLayout.astro)
+  // inherits that slash, while Vercel serves every page WITHOUT one. Every
+  // page's own canonical tag ends up pointing at a trailing-slash duplicate
+  // of itself, confirmed live against production (curl'd multiple pages: 200
+  // at the no-slash URL, canonical pointing to .../<path>/, which also
+  // resolves 200).
+  //
+  // build.format: 'file' alone does NOT fix this under @astrojs/vercel —
+  // confirmed by building both ways: the adapter's own static-output
+  // structure (still page/index.html either way) overrides build.format's
+  // effect on Astro.url.pathname for these pages. trailingSlash: 'never' is
+  // unconditional in Astro's own core build-format helper (see
+  // astro/dist/core/build/util.js's slash-append decision) regardless of
+  // buildFormat — confirmed this is what actually removes the trailing
+  // slash from the rendered canonical tag.
+  // vercel.json's own top-level "trailingSlash": false (both copies) is the
+  // complementary fix: it stops Vercel itself from serving a page at both
+  // the slash and no-slash URL with no redirect between them, which is the
+  // other half of this bug (verified live: both forms returned 200).
+  trailingSlash: 'never',
+
   // SMI-6110: account dashboard UX consolidation (H2) — the `/account/team`
   // → `/account` true HTTP 301 is declared in vercel.json (both the root and
   // packages/website copies, per SMI-4641 structural sync), NOT here.

--- a/packages/website/src/lib/skill-page-meta.test.ts
+++ b/packages/website/src/lib/skill-page-meta.test.ts
@@ -5,6 +5,7 @@ import {
   deriveSkillPageMeta,
   resolveSkillId,
   safeJsonLdScript,
+  shouldCacheSkillPage,
   type SkillMeta,
 } from './skill-page-meta'
 
@@ -32,6 +33,16 @@ describe('safeJsonLdScript', () => {
 describe('resolveSkillId', () => {
   it('returns undefined for an undefined id', () => {
     expect(resolveSkillId(undefined)).toBeUndefined()
+  })
+
+  it('falls back to the raw value for malformed percent-encoding instead of throwing', () => {
+    // SMI-6180 regression: decodeURIComponent throws URIError on a lone '%'
+    // or an incomplete/invalid UTF-8 escape — this must degrade gracefully,
+    // not crash the SSR render for a crawler hitting a garbled URL.
+    expect(() => resolveSkillId('bad%id')).not.toThrow()
+    expect(resolveSkillId('bad%id')).toBe('bad%id')
+    expect(() => resolveSkillId('%E0%A4%A')).not.toThrow()
+    expect(resolveSkillId('%E0%A4%A')).toBe('%E0%A4%A')
   })
 
   it('decodes a percent-encoded slash in an author/name id', () => {
@@ -131,5 +142,21 @@ describe('deriveSkillPageMeta', () => {
     expect(meta.title).toBe('Skill Details | Skillsmith')
     expect(meta.jsonLd).toBeNull()
     expect(meta.description).toContain('View skill details')
+  })
+})
+
+describe('shouldCacheSkillPage', () => {
+  it('caches a genuinely successful metadata fetch', () => {
+    const skill: SkillMeta = { id: 'smith-horn/example-skill', name: 'Example Skill' }
+    expect(shouldCacheSkillPage(skill)).toBe(true)
+  })
+
+  it('does not cache a degraded response (network error, 5xx, or rate limit — skillMeta null)', () => {
+    // SMI-6180 regression: caching this would bake a transient failure's
+    // generic-shell fallback into the CDN for the full cache lifetime,
+    // reintroducing the exact indexing problem this page fix exists to
+    // solve. See SMI-6190 for the underlying shared-rate-limit exposure
+    // this mitigates the practical impact of.
+    expect(shouldCacheSkillPage(null)).toBe(false)
   })
 })

--- a/packages/website/src/lib/skill-page-meta.test.ts
+++ b/packages/website/src/lib/skill-page-meta.test.ts
@@ -4,8 +4,30 @@ import {
   buildSkillGetUrl,
   deriveSkillPageMeta,
   resolveSkillId,
+  safeJsonLdScript,
   type SkillMeta,
 } from './skill-page-meta'
+
+describe('safeJsonLdScript', () => {
+  it('escapes </script> so it cannot break out of the surrounding script tag', () => {
+    const payload = { name: 'evil</script><script>alert(1)</script>' }
+    const serialized = safeJsonLdScript(payload)
+    expect(serialized).not.toContain('</script>')
+    expect(serialized).toContain('\\u003c/script>')
+  })
+
+  it('round-trips back to the original value once un-escaped and parsed', () => {
+    const payload = { name: 'evil</script><script>alert(1)</script>' }
+    const serialized = safeJsonLdScript(payload)
+    const parsed = JSON.parse(serialized.replace(/\\u003c/g, '<'))
+    expect(parsed).toEqual(payload)
+  })
+
+  it('leaves ordinary payloads unaffected', () => {
+    const payload = { name: 'Example Skill', description: 'Does something useful.' }
+    expect(safeJsonLdScript(payload)).toBe(JSON.stringify(payload))
+  })
+})
 
 describe('resolveSkillId', () => {
   it('returns undefined for an undefined id', () => {

--- a/packages/website/src/lib/skill-page-meta.test.ts
+++ b/packages/website/src/lib/skill-page-meta.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSkillCanonicalUrl,
+  buildSkillGetUrl,
+  deriveSkillPageMeta,
+  resolveSkillId,
+  type SkillMeta,
+} from './skill-page-meta'
+
+describe('resolveSkillId', () => {
+  it('returns undefined for an undefined id', () => {
+    expect(resolveSkillId(undefined)).toBeUndefined()
+  })
+
+  it('decodes a percent-encoded slash in an author/name id', () => {
+    // Astro.params.id arrives pre-encoded (e.g. from a link built with
+    // encodeURIComponent()) rather than auto-decoded by Astro.
+    expect(resolveSkillId('smith-horn%2Fexample-skill')).toBe('smith-horn/example-skill')
+  })
+
+  it('leaves a plain id without special characters unchanged', () => {
+    expect(resolveSkillId('my-simple-skill')).toBe('my-simple-skill')
+  })
+})
+
+describe('buildSkillGetUrl + buildSkillCanonicalUrl (encode round-trip)', () => {
+  it('re-encodes a decoded author/name id back to exactly one layer of encoding', () => {
+    // SMI-6180 regression: resolveSkillId() then encodeURIComponent() without
+    // the decode step first would double-encode the slash (%2F -> %252F),
+    // breaking the skills-get lookup and producing a canonical URL Google
+    // would never match against the actual served URL.
+    const rawParam = 'smith-horn%2Fexample-skill'
+    const decoded = resolveSkillId(rawParam)
+    expect(decoded).toBeDefined()
+
+    const fetchUrl = buildSkillGetUrl('https://api.skillsmith.app', decoded as string)
+    expect(fetchUrl).toBe(
+      'https://api.skillsmith.app/functions/v1/skills-get/smith-horn%2Fexample-skill'
+    )
+    expect(fetchUrl).not.toContain('%25')
+
+    const canonical = buildSkillCanonicalUrl(decoded)
+    expect(canonical).toBe('https://www.skillsmith.app/skills/smith-horn%2Fexample-skill')
+    expect(canonical).not.toContain('%25')
+  })
+
+  it('round-trips a plain id with no special characters', () => {
+    const decoded = resolveSkillId('my-simple-skill')
+    expect(buildSkillGetUrl('https://api.skillsmith.app', decoded as string)).toBe(
+      'https://api.skillsmith.app/functions/v1/skills-get/my-simple-skill'
+    )
+    expect(buildSkillCanonicalUrl(decoded)).toBe(
+      'https://www.skillsmith.app/skills/my-simple-skill'
+    )
+  })
+
+  it('falls back to an empty-id canonical URL when decodedId is undefined', () => {
+    expect(buildSkillCanonicalUrl(undefined)).toBe('https://www.skillsmith.app/skills/')
+  })
+})
+
+describe('deriveSkillPageMeta', () => {
+  const decodedId = 'smith-horn/example-skill'
+
+  it('builds real title/description/canonical/JSON-LD when the skill was found', () => {
+    const skill: SkillMeta = {
+      id: decodedId,
+      name: 'Example Skill',
+      author: 'Smith Horn',
+      description: 'Does something useful.',
+      trust_tier: 'verified',
+    }
+
+    const meta = deriveSkillPageMeta(skill, false, decodedId)
+
+    expect(meta.title).toBe('Example Skill | Skillsmith')
+    expect(meta.description).toBe('Does something useful.')
+    expect(meta.canonical).toBe('https://www.skillsmith.app/skills/smith-horn%2Fexample-skill')
+    expect(meta.jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareSourceCode',
+      name: 'Example Skill',
+      description: 'Does something useful.',
+      author: { '@type': 'Person', name: 'Smith Horn' },
+      url: meta.canonical,
+    })
+  })
+
+  it('omits the JSON-LD author field when the skill has no author', () => {
+    const skill: SkillMeta = { id: decodedId, name: 'Example Skill' }
+    const meta = deriveSkillPageMeta(skill, false, decodedId)
+    expect(meta.jsonLd).not.toHaveProperty('author')
+  })
+
+  it('falls back to the decoded id as the JSON-LD name when the skill has no name', () => {
+    const skill: SkillMeta = { id: decodedId }
+    const meta = deriveSkillPageMeta(skill, false, decodedId)
+    expect(meta.jsonLd?.name).toBe(decodedId)
+  })
+
+  it('uses a real 404 title and no JSON-LD when the skill was genuinely not found', () => {
+    const meta = deriveSkillPageMeta(null, true, decodedId)
+    expect(meta.title).toBe('Skill Not Found | Skillsmith')
+    expect(meta.jsonLd).toBeNull()
+  })
+
+  it('falls back to a generic title and no JSON-LD when the fetch degraded (not a real 404)', () => {
+    const meta = deriveSkillPageMeta(null, false, decodedId)
+    expect(meta.title).toBe('Skill Details | Skillsmith')
+    expect(meta.jsonLd).toBeNull()
+    expect(meta.description).toContain('View skill details')
+  })
+})

--- a/packages/website/src/lib/skill-page-meta.ts
+++ b/packages/website/src/lib/skill-page-meta.ts
@@ -43,7 +43,17 @@ const DEFAULT_SKILL_DESCRIPTION =
  */
 export function resolveSkillId(rawId: string | undefined): string | undefined {
   if (!rawId) return rawId
-  return decodeURIComponent(rawId)
+  try {
+    return decodeURIComponent(rawId)
+  } catch {
+    // Malformed percent-encoding (a lone '%', or an incomplete/invalid UTF-8
+    // sequence like '%E0%A4%A') throws URIError. Caught here rather than
+    // left to propagate into the page frontmatter, which would otherwise
+    // crash the SSR render for any crawler or link hitting a garbled URL.
+    // Falling back to the raw, still-encoded value lets skills-get 404
+    // naturally on it instead — an honest "not found" for a malformed ID.
+    return rawId
+  }
 }
 
 /**
@@ -61,6 +71,19 @@ export function resolveSkillId(rawId: string | undefined): string | undefined {
  */
 export function safeJsonLdScript(payload: unknown): string {
   return JSON.stringify(payload).replace(/</g, '\\u003c')
+}
+
+/**
+ * Whether the SSR skill-page response should be cached at the CDN edge.
+ * Only a genuinely successful metadata fetch (`skillMeta` populated) may be
+ * cached — a degraded response (network error, 5xx, or a rate limit on the
+ * shared anon-key bucket, see SMI-6190) must NOT be cached, or a purely
+ * transient failure gets baked into the CDN as the pre-SMI-6180 generic
+ * shell for the full cache lifetime, silently reintroducing the exact
+ * indexing problem this page fix exists to solve.
+ */
+export function shouldCacheSkillPage(skillMeta: SkillMeta | null): boolean {
+  return skillMeta !== null
 }
 
 /** Builds the server-side skills-get fetch URL from an already-decoded id. */

--- a/packages/website/src/lib/skill-page-meta.ts
+++ b/packages/website/src/lib/skill-page-meta.ts
@@ -46,6 +46,23 @@ export function resolveSkillId(rawId: string | undefined): string | undefined {
   return decodeURIComponent(rawId)
 }
 
+/**
+ * Serializes a JSON-LD payload for safe injection into a
+ * `<script type="application/ld+json" set:html={...}>` tag.
+ *
+ * `JSON.stringify()` alone does NOT escape `</script>` — if any field in the
+ * payload originates from external, semi-trusted content (a skill or
+ * category name/description, scraped from a GitHub repo) and happens to
+ * contain that literal sequence, it breaks out of the surrounding
+ * `<script>` tag and injects arbitrary markup/script into the page. `<`
+ * is a valid escape inside a JSON string and is never re-interpreted by a
+ * JSON-LD consumer, so this is safe for every reader while closing the HTML
+ * parser's `</script>` escape hatch.
+ */
+export function safeJsonLdScript(payload: unknown): string {
+  return JSON.stringify(payload).replace(/</g, '\\u003c')
+}
+
 /** Builds the server-side skills-get fetch URL from an already-decoded id. */
 export function buildSkillGetUrl(apiBaseUrl: string, decodedId: string): string {
   return `${apiBaseUrl}/functions/v1/skills-get/${encodeURIComponent(decodedId)}`

--- a/packages/website/src/lib/skill-page-meta.ts
+++ b/packages/website/src/lib/skill-page-meta.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure, DOM/network-free helpers for the individual skill detail page's
+ * server-side metadata (SMI-6180). Split out of skills/[id].astro so the
+ * URL-encoding and title/description/canonical derivation logic is directly
+ * unit-testable — the actual fetch() call and Astro.response side effects
+ * stay in the page frontmatter.
+ *
+ * See docs/internal/analysis/2026-08-25-search-console-indexing-audit.md for
+ * the Search Console findings this fixes: individual skill pages rendered a
+ * fully generic client-only shell with no per-skill metadata in the initial
+ * HTML, the root cause of the "Crawled - currently not indexed" bucket.
+ */
+
+export interface SkillMeta {
+  id: string
+  name?: string
+  author?: string
+  description?: string
+  trust_tier?: string
+}
+
+export interface SkillPageMeta {
+  title: string
+  description: string
+  canonical: string
+  jsonLd: Record<string, unknown> | null
+}
+
+const DEFAULT_SKILL_DESCRIPTION =
+  'View skill details and installation instructions for this Skillsmith agent skill.'
+
+/**
+ * Astro.params.id for this single dynamic route segment arrives AS-IS from
+ * the URL, already percent-encoded for skill IDs that contain a literal "/"
+ * (the common "author/name" shape, itself generated via encodeURIComponent()
+ * everywhere this site links to a skill page — see the client script's own
+ * "Decode first to normalize" comment in skills/[id].astro, which this
+ * mirrors server-side). Re-encoding it without decoding first double-encodes
+ * the slash (%2F becomes %252F), breaking the skills-get lookup for every
+ * author/name-style skill: confirmed live, this previously 404'd every such
+ * ID against a literal "%2F" in the search string instead of splitting on a
+ * real slash.
+ */
+export function resolveSkillId(rawId: string | undefined): string | undefined {
+  if (!rawId) return rawId
+  return decodeURIComponent(rawId)
+}
+
+/** Builds the server-side skills-get fetch URL from an already-decoded id. */
+export function buildSkillGetUrl(apiBaseUrl: string, decodedId: string): string {
+  return `${apiBaseUrl}/functions/v1/skills-get/${encodeURIComponent(decodedId)}`
+}
+
+/** Builds the canonical skills page URL from an already-decoded id. */
+export function buildSkillCanonicalUrl(decodedId: string | undefined): string {
+  return `https://www.skillsmith.app/skills/${encodeURIComponent(decodedId ?? '')}`
+}
+
+/**
+ * Derives title/description/canonical/JSON-LD for the skill detail page from
+ * the server-side fetch outcome. Three states: found (real metadata), not
+ * found (real 404 — see the page frontmatter for why this matters for SEO),
+ * and degraded (fetch failed/rate-limited/etc — falls back to the pre-SMI-6180
+ * generic shell + client-side fetch/retry rather than a false 404).
+ */
+export function deriveSkillPageMeta(
+  skillMeta: SkillMeta | null,
+  skillNotFound: boolean,
+  decodedId: string | undefined
+): SkillPageMeta {
+  const title = skillMeta?.name
+    ? `${skillMeta.name} | Skillsmith`
+    : skillNotFound
+      ? 'Skill Not Found | Skillsmith'
+      : 'Skill Details | Skillsmith'
+
+  const description = skillMeta?.description || DEFAULT_SKILL_DESCRIPTION
+  const canonical = buildSkillCanonicalUrl(decodedId)
+
+  const jsonLd = skillMeta
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareSourceCode',
+        name: skillMeta.name || decodedId,
+        description,
+        ...(skillMeta.author ? { author: { '@type': 'Person', name: skillMeta.author } } : {}),
+        url: canonical,
+      }
+    : null
+
+  return { title, description, canonical, jsonLd }
+}

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -22,6 +22,7 @@ import {
   deriveSkillPageMeta,
   resolveSkillId,
   safeJsonLdScript,
+  shouldCacheSkillPage,
   type SkillMeta,
 } from '../../lib/skill-page-meta'
 
@@ -252,7 +253,7 @@ if (!isCategory && decodedId) {
     // itself a contributor to the "crawled, not indexed" bucket, since
     // Google had no way to distinguish a gone skill from a slow-loading one.
     Astro.response.status = 404
-  } else {
+  } else if (shouldCacheSkillPage(skillMeta)) {
     Astro.response.headers.set('Cache-Control', 's-maxage=300, stale-while-revalidate=60')
   }
 }

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -21,6 +21,7 @@ import {
   buildSkillGetUrl,
   deriveSkillPageMeta,
   resolveSkillId,
+  safeJsonLdScript,
   type SkillMeta,
 } from '../../lib/skill-page-meta'
 
@@ -272,7 +273,12 @@ const {
     >
       {categoryJsonLd &&
         categoryJsonLd.map((ld) => (
-          <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(ld)} />
+          <script
+            is:inline
+            type="application/ld+json"
+            slot="head"
+            set:html={safeJsonLdScript(ld)}
+          />
         ))}
       {/* SMI-6180: no explicit canonical prop is passed to BaseLayout above, so its
         own self-referencing default (Astro.url.pathname, correct for this SSR route —
@@ -378,7 +384,7 @@ const {
           is:inline
           type="application/ld+json"
           slot="head"
-          set:html={JSON.stringify(skillJsonLd)}
+          set:html={safeJsonLdScript(skillJsonLd)}
         />
       )}
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -15,6 +15,14 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 // the bundled <script> below (no longer injected via define:vars). The frontmatter keeps
 // TRUST_TIER_PILL_CLASSES + DEFAULT_TRUST_TIER for the SSR related-skills pill.
 import { TRUST_TIER_PILL_CLASSES, DEFAULT_TRUST_TIER } from '../../constants/trust-tier-badges'
+// SMI-6180: server-side skill metadata fetch for individual skill pages (see below).
+import { getSupabaseConfig } from '../../lib/supabase-config'
+import {
+  buildSkillGetUrl,
+  deriveSkillPageMeta,
+  resolveSkillId,
+  type SkillMeta,
+} from '../../lib/skill-page-meta'
 
 export const prerender = false
 
@@ -201,6 +209,59 @@ const categoryJsonLd =
           : []),
       ]
     : null
+
+// ─── Individual Skill Detail Page — Server-Side Metadata (SMI-6180) ────────
+// Individual skill pages used to render a fully generic client-only shell
+// with no per-skill metadata in the initial HTML — every skill page looked
+// like a near-identical duplicate to Googlebot, the root cause of the
+// "Crawled - currently not indexed" bucket in the Search Console audit
+// (docs/internal/analysis/2026-08-25-search-console-indexing-audit.md, the
+// largest bucket in that report). This fetches real metadata server-side,
+// mirroring the category-page pattern above; the full interactive detail
+// (README, tags, related skills, install commands) stays on the existing
+// client-side fetch below, since that part doesn't affect indexability and
+// doesn't need duplicating server-side.
+let skillMeta: SkillMeta | null = null
+let skillNotFound = false
+
+const decodedId = resolveSkillId(id)
+
+if (!isCategory && decodedId) {
+  try {
+    const { apiBaseUrl, anonKey } = getSupabaseConfig()
+    const res = await fetch(buildSkillGetUrl(apiBaseUrl, decodedId), {
+      headers: { Authorization: `Bearer ${anonKey}` },
+    })
+    if (res.status === 404) {
+      skillNotFound = true
+    } else if (res.ok) {
+      const body = (await res.json()) as { data?: SkillMeta }
+      skillMeta = body.data ?? null
+    }
+    // Any other non-OK status (5xx, rate limit, etc.) falls through with
+    // skillMeta null and skillNotFound false — degrades to the pre-SMI-6180
+    // generic-shell + client-side fetch/retry rather than a false 404.
+  } catch {
+    // Network error server-side — same degrade-to-generic-shell fallback.
+  }
+
+  if (skillNotFound) {
+    // A real 404 for genuinely-removed/nonexistent skills, instead of a 200
+    // that eventually shows a client-rendered "not found" message — this was
+    // itself a contributor to the "crawled, not indexed" bucket, since
+    // Google had no way to distinguish a gone skill from a slow-loading one.
+    Astro.response.status = 404
+  } else {
+    Astro.response.headers.set('Cache-Control', 's-maxage=300, stale-while-revalidate=60')
+  }
+}
+
+const {
+  title: skillTitle,
+  description: skillDescription,
+  canonical: skillCanonical,
+  jsonLd: skillJsonLd,
+} = deriveSkillPageMeta(skillMeta, skillNotFound, decodedId)
 ---
 
 {
@@ -213,11 +274,12 @@ const categoryJsonLd =
         categoryJsonLd.map((ld) => (
           <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(ld)} />
         ))}
-      <link
-        rel="canonical"
-        href={`https://www.skillsmith.app/skills/${categoryMeta.slug}/`}
-        slot="head"
-      />
+      {/* SMI-6180: no explicit canonical prop is passed to BaseLayout above, so its
+        own self-referencing default (Astro.url.pathname, correct for this SSR route —
+        no trailing slash) already renders the canonical tag. A hardcoded trailing-slash
+        <link rel="canonical"> used to be injected here too, producing two conflicting
+        canonical tags on the same page (confirmed live via curl) — removed rather than
+        fixed in place, since BaseLayout's own default already does this correctly. */}
 
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <nav aria-label="Breadcrumb" class="mb-8">
@@ -306,9 +368,19 @@ const categoryJsonLd =
 {
   !isCategory && (
     <BaseLayout
-      title="Skill Details"
-      description="View skill details and installation instructions"
+      title={skillTitle}
+      description={skillDescription}
+      canonical={skillCanonical}
+      noindex={skillNotFound}
     >
+      {skillJsonLd && (
+        <script
+          is:inline
+          type="application/ld+json"
+          slot="head"
+          set:html={JSON.stringify(skillJsonLd)}
+        />
+      )}
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <nav class="mb-8">
           <ol class="flex items-center space-x-2 text-sm">
@@ -325,17 +397,48 @@ const categoryJsonLd =
             </li>
             <li class="text-dark-600">/</li>
             <li id="breadcrumb-name" class="text-dark-300">
-              Loading...
+              {skillMeta?.name || (skillNotFound ? 'Not found' : 'Loading...')}
             </li>
           </ol>
         </nav>
 
-        <div id="loading-state" class="text-center py-20" data-skill-id={id}>
+        {/* SMI-6180: server-rendered preview — real, visible content in the initial
+          HTML response so each skill page is distinguishable to a crawler without
+          executing JS. The client script below hides this once it finishes rendering
+          the fully interactive #skill-content section (readme, tags, related skills). */}
+        {skillMeta && (
+          <div
+            id="skill-ssr-preview"
+            class="bg-dark-900 rounded-xl border border-dark-800 p-8 mb-8"
+          >
+            <div class="flex items-center gap-4 mb-4">
+              <h1 class="text-3xl md:text-4xl font-bold text-white">
+                {skillMeta.name || decodedId}
+              </h1>
+              {skillMeta.trust_tier && (
+                <span class="px-3 py-1 text-sm font-medium rounded-full border border-dark-700 text-dark-300">
+                  {skillMeta.trust_tier}
+                </span>
+              )}
+            </div>
+            {skillMeta.author && <p class="text-dark-400 text-lg mb-4">by {skillMeta.author}</p>}
+            <p class="text-dark-300 leading-relaxed">{skillDescription}</p>
+          </div>
+        )}
+
+        <div
+          id="loading-state"
+          class={skillNotFound ? 'hidden' : 'text-center py-20'}
+          data-skill-id={id}
+        >
           <div class="inline-block animate-spin rounded-full h-12 w-12 border-2 border-primary-500 border-t-transparent" />
           <p class="text-dark-400 mt-6">Loading skill details...</p>
         </div>
 
-        <div id="error-state" class="hidden text-center py-20">
+        <div
+          id="error-state"
+          class={skillNotFound ? 'text-center py-20' : 'hidden text-center py-20'}
+        >
           <svg
             class="w-20 h-20 mx-auto text-red-500 mb-6"
             fill="none"
@@ -845,6 +948,11 @@ const categoryJsonLd =
       loadingState.classList.add('hidden')
       errorState.classList.add('hidden')
       skillContent.classList.remove('hidden')
+
+      // SMI-6180: hide the server-rendered preview (name/author/description)
+      // now that the fully interactive #skill-content section above has taken
+      // over rendering the same fields, so nothing appears twice.
+      document.getElementById('skill-ssr-preview')?.classList.add('hidden')
 
       // GA4: Track skill view (SMI-2453)
       if (typeof window.gtag === 'function') {

--- a/packages/website/src/pages/status.astro
+++ b/packages/website/src/pages/status.astro
@@ -23,7 +23,7 @@ const banner = OVERALL_BANNER.unknown
   title="Status | Skillsmith"
   description="Live status and 90-day uptime history for Skillsmith's website, API, MCP backend, and infrastructure."
   activePath="/status"
-  canonical="https://www.skillsmith.app/status/"
+  canonical="https://www.skillsmith.app/status"
 >
   <Fragment slot="head">
     <link

--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -3,6 +3,7 @@
   "framework": "astro",
   "installCommand": "npm install",
   "buildCommand": "npm run build",
+  "trailingSlash": false,
   "git": {
     "deploymentEnabled": {
       "main": false
@@ -38,6 +39,11 @@
       "permanent": true
     },
     {
+      "source": "/changelog/",
+      "destination": "https://github.com/smith-horn/skillsmith/releases",
+      "permanent": true
+    },
+    {
       "source": "/:path*",
       "has": [
         {
@@ -50,6 +56,11 @@
     },
     {
       "source": "/docs/authoring",
+      "destination": "/docs/tutorials/author",
+      "permanent": true
+    },
+    {
+      "source": "/docs/authoring/",
       "destination": "/docs/tutorials/author",
       "permanent": true
     },

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "framework": "astro",
   "installCommand": "npm install",
   "buildCommand": "npx turbo run build --filter=@skillsmith/website && rm -rf .vercel/output && mkdir -p .vercel && cp -r packages/website/.vercel/output .vercel/output",
+  "trailingSlash": false,
   "rewrites": [
     {
       "source": "/",
@@ -33,6 +34,11 @@
       "permanent": true
     },
     {
+      "source": "/changelog/",
+      "destination": "https://github.com/smith-horn/skillsmith/releases",
+      "permanent": true
+    },
+    {
       "source": "/:path*",
       "has": [
         {
@@ -45,6 +51,11 @@
     },
     {
       "source": "/docs/authoring",
+      "destination": "/docs/tutorials/author",
+      "permanent": true
+    },
+    {
+      "source": "/docs/authoring/",
       "destination": "/docs/tutorials/author",
       "permanent": true
     },


### PR DESCRIPTION
## Business Summary

**What shipped:** Three fixes for why Google wasn't indexing large parts of skillsmith.app: every page's canonical tag now matches the URL it's actually served at (was pointing at a duplicate URL sitewide); individual skill pages now tell Google their real title, description, and content up front instead of a generic loading screen; and two broken redirect links (`/changelog`, `/docs/authoring`) now work for both URL forms Google was crawling.

**Quality bar:** Verified against the live generated HTML before and after each fix, not just "tests pass" — confirmed the canonical tag actually changed and duplicate tags are gone. A real bug (skill URLs with a slash in the ID breaking due to double-encoding) was caught by writing tests before shipping, not after. Full typecheck, lint, format check, and both test suites (690 + 17,481 tests) pass. A governance review after the first commit found and fixed a second issue: a way malicious content in a skill's name could break out of its structured-data tag — fixed here, with the same pattern elsewhere in the site filed as a separate follow-up.

**Found along the way:** Two issues filed separately rather than bundled in here — SMI-6188 (a pre-existing, repo-wide bug that currently blocks the website's production build inside Docker, unrelated to this change) and SMI-6189 (the same script-injection pattern this PR fixes exists in other places across the site and needs its own pass).

**Net result:** All three confirmed bugs from the audit are fixed. The two follow-ups are tracked, not blocking.

---

## Technical detail

**Files changed:**
- `packages/website/astro.config.mjs` — adds `trailingSlash: 'never'`. Root cause: with it left at Astro's default, every prerendered page's self-referencing canonical tag carried a trailing slash the actual served URL never had. Confirmed live via curl before/after; `build.format: 'file'` was tried first and does *not* fix this under `@astrojs/vercel` (the adapter overrides it) — see the in-file comment for the full trace.
- `packages/website/vercel.json` + root `vercel.json` — `"trailingSlash": false` (stops Vercel itself serving both URL forms with no redirect), plus explicit `/changelog/` and `/docs/authoring/` redirect rules (the existing rules only matched the no-slash form, so Google's crawled slash-variants 404'd).
- `packages/website/src/pages/skills/[id].astro` — individual skill pages fetch metadata server-side now (mirrors the existing category-page pattern in the same file) instead of rendering a static "Skill Details" shell for every skill. Sets real title/description/canonical/JSON-LD, and a genuine 404 (not a 200 that shows an error client-side) for skills that don't exist. Also removes a second, conflicting canonical tag that was being injected on category pages alongside `BaseLayout`'s own correct one.
- `packages/website/src/pages/status.astro` — trailing slash removed from its explicit canonical override, matching the sitewide fix.
- `packages/website/src/lib/skill-page-meta.ts` (new) + `skill-page-meta.test.ts` (new, 14 tests) — the URL-decode/encode, title/description/canonical/JSON-LD derivation, and JSON-LD escaping logic pulled out of the page frontmatter so it's directly unit-tested. Includes `safeJsonLdScript()`, the fix for the script-injection issue.

**Verification:** `astro check` (0 errors/warnings across 206 files), `tsc --build`, `eslint .`, `prettier --check .`, `vitest run` in `packages/website` (690 tests) and at the repo root (17,481 tests) — all clean. Generated HTML inspected directly (both via a full `astro build` for prerendered pages and a local dev server for the SSR skill/category routes) to confirm canonical tags, title tags, and 404 status codes match expectations.

**Not run:** `npm run build` / `npm run preflight` for `packages/website` — currently fails in Docker on an unrelated, pre-existing bug (SMI-6188), confirmed via `git stash` to reproduce identically without this PR's changes, on both the main checkout's container and a fresh worktree's. Substituted the targeted commands listed above.

Linear: SMI-6180 (parent), SMI-6188 and SMI-6189 (follow-ups, out of scope here).