### PR TITLE
docs(claude-md): SMI-6186 note fork subagents can't act as model-tiering queen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,8 @@ High-cadence: Skill Indexer (maintenance 00:00 UTC + recheck 03:00 UTC + discove
 
 **Worktrees are the default workspace.** Doing implementation work directly on `main` (or in the main checkout) requires an **explicitly approved exception** — state the rationale and get sign-off before proceeding. This keeps parallel sessions from colliding (SMI-4776) and keeps `main` clean.
 
+**A `fork`-type subagent cannot itself act as the queen for model-tiered delegation.** Forks share the parent's context and always run on the parent's model by design, and are barred from spawning their own Agent-tool subagents — so a fork told to delegate work across the model tiers below will instead do all of it itself, in one long single-model run (observed: a fork handed a 4-PR queen-coordination task did exactly this, needing ~250 tool uses and two turn-limit resumes across ~2 hours). If the queen role itself needs to run in the background, keep the top-level/foreground session as the queen issuing model-tiered `Agent` calls directly, or use a fresh (non-fork) background subagent as the queen instead. A fork is still the right call for a single large task that doesn't need further fan-out.
+
 **Route worker tasks by difficulty across model tiers** (the queen assigns each task to the cheapest tier that can do it well):
 
 | Model | Role | Tasks |


### PR DESCRIPTION
## Business Summary

**What shipped:** CLAUDE.md's execution-model guidance now documents that a `fork`-type subagent can't be handed the "queen" role when a plan calls for delegating work across model tiers (Haiku/Opus/Sonnet) — it can't spawn its own subagents, so it silently does everything itself in one long run instead.

**Quality bar:** One-paragraph doc addition, prettier-formatted, typecheck/lint clean via the standard pre-commit/pre-push checks. No code touched.

**Net result:** Done, no follow-up.

---

## Technical detail

`CLAUDE.md`'s "Default Execution Model — Ruflo Queen + Worktrees + Model Tiering" section — one new paragraph after the worktree-default rule, before the model-tiering table. Written after directly observing the behavior: a fork asked to queen-coordinate a 4-PR task ran all of it itself (~250 tool uses, two turn-limit resumes, ~2 hours) instead of delegating, since forks can't call the Agent tool.

[skip-impl-check]