### PR TITLE
fix(ci): SMI-6187 replace GH_PAT with SKILLSMITH_SUPPORT_PAT

### DIFF
--- a/.github/workflows/batch-transform.yml
+++ b/.github/workflows/batch-transform.yml
@@ -7,7 +7,7 @@
 # Required secrets:
 #   - SUPABASE_URL
 #   - SUPABASE_SERVICE_ROLE_KEY
-#   - GH_PAT (GitHub Personal Access Token for 5,000 req/hr rate limit)
+#   - SKILLSMITH_SUPPORT_PAT (GitHub Personal Access Token for 5,000 req/hr rate limit; SMI-6187, was GH_PAT)
 
 name: Batch Skill Transformation
 
@@ -58,7 +58,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }} # 5,000 req/hr vs 60 req/hr anonymous
+          GITHUB_TOKEN: ${{ secrets.SKILLSMITH_SUPPORT_PAT }} # 5,000 req/hr vs 60 req/hr anonymous
         run: |
           ARGS="--verbose"
 

--- a/.github/workflows/website-deploy-staging.yml
+++ b/.github/workflows/website-deploy-staging.yml
@@ -342,13 +342,16 @@ jobs:
       # Re-fire the repository_dispatch that smoke-prod.yml listens for. Once
       # native git integration is disconnected (Phase 2), Vercel stops emitting
       # the deploy webhook, so this CLI-deploy path must fire it itself.
-      # Must be a real PAT (GH_PAT) -- the default GITHUB_TOKEN will not
-      # re-trigger smoke-prod.yml (GitHub's workflow-recursion guard).
+      # Must be a real PAT (SKILLSMITH_SUPPORT_PAT) -- the default GITHUB_TOKEN
+      # will not re-trigger smoke-prod.yml (GitHub's workflow-recursion guard).
+      # SMI-6187: previously GH_PAT, replaced 2026-08-26 -- GH_PAT resolved
+      # empty in this job's context (confirmed under normal, non-outage
+      # platform conditions), root cause never isolated before rotation.
       - name: Re-fire post-deploy smoke dispatch
         id: smoke_dispatch
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.SKILLSMITH_SUPPORT_PAT }}
         run: |
           gh api repos/${{ github.repository }}/dispatches \
             -f event_type=vercel-prod-deployed \
@@ -360,7 +363,7 @@ jobs:
       - name: Warn if smoke dispatch failed
         if: steps.smoke_dispatch.outcome == 'failure'
         run: |
-          echo "::warning::Failed to re-fire vercel-prod-deployed dispatch; smoke-prod.yml did not auto-run. Check the GH_PAT secret, then trigger smoke-prod.yml manually."
+          echo "::warning::Failed to re-fire vercel-prod-deployed dispatch; smoke-prod.yml did not auto-run. Check the SKILLSMITH_SUPPORT_PAT secret, then trigger smoke-prod.yml manually."
 
       - name: Generate deployment summary
         run: |


### PR DESCRIPTION
## Business Summary

**What shipped:** Every production deploy has been silently skipping its automated post-deploy smoke validation, because the `GH_PAT` secret it needs was resolving empty. Confirmed genuine (not a platform outage artifact) by re-testing after GitHub Actions returned to operational status — same failure, same signature. The secret owner deleted `GH_PAT` and provisioned a fresh one, `SKILLSMITH_SUPPORT_PAT`. This PR points the two affected workflows at the new secret name.

**Quality bar:** Grepped every workflow file for `GH_PAT` references before and after — confirmed exactly two files needed the change (`website-deploy-staging.yml`'s smoke-test dispatch, `batch-transform.yml`'s GitHub API token), and confirmed `indexer-backfill.yml` was correctly unaffected (it uses a separate secret, `GH_PAT_SKILLSMITH`, not `GH_PAT`). Typecheck and lint clean.

**Net result:** Fully shipped. Will verify with a real test rerun of the production deploy job after merge — same method used to confirm the original bug.

---

## Technical detail

Tracked as SMI-6187. `.github/workflows/` changes normally require SPARC + plan-review under ADR-109; skipped for this one with explicit user sign-off, given it's a pure secret-name substitution (no new logic, triggers, or permissions) directly closing an already-diagnosed, already-filed bug.

Root cause: `secrets.GH_PAT` returned a literal empty string in the `production`-environment job context (confirmed via the `gh` CLI's specific "set GH_TOKEN" error, which only fires on an unset/empty variable, not an auth failure against an expired-but-present token). Reproduced twice — once during an active GitHub Actions outage (initially misattributed to that), and again after the outage cleared, ruling out the outage as the cause.