### PR TITLE
fix(website): explicit no-store on degraded skill-page responses (SMI-6180)

### DIFF
--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -253,8 +253,15 @@ if (!isCategory && decodedId) {
     // itself a contributor to the "crawled, not indexed" bucket, since
     // Google had no way to distinguish a gone skill from a slow-loading one.
     Astro.response.status = 404
-  } else if (shouldCacheSkillPage(skillMeta)) {
-    Astro.response.headers.set('Cache-Control', 's-maxage=300, stale-while-revalidate=60')
+  } else {
+    // Explicit either way, rather than only setting a header on success and
+    // relying on Vercel's default (unset-header) behavior for the degraded
+    // case — the whole point of shouldCacheSkillPage() is "never cache a
+    // degraded response," so that intent should be stated, not implied.
+    Astro.response.headers.set(
+      'Cache-Control',
+      shouldCacheSkillPage(skillMeta) ? 's-maxage=300, stale-while-revalidate=60' : 'no-store'
+    )
   }
 }
 


### PR DESCRIPTION
## Business Summary

**What shipped:** When a skill page's metadata fetch fails or gets rate-limited, the response now explicitly tells caches not to store it — previously it just left the caching instruction blank and hoped for the best.

**Quality bar:** Found during the mandatory post-merge review of PR #2540, which this directly follows up on. Full typecheck, lint, format check, and the website's test suite (693 tests) all clean.

**Net result:** Done, no follow-up.

---

## Technical detail

`packages/website/src/pages/skills/[id].astro` — the degraded-response branch (network error, 5xx, or a rate-limited fetch) now sets `Cache-Control: no-store` explicitly instead of skipping the header and relying on Vercel's default unset-header behavior. The underlying `shouldCacheSkillPage()` predicate this wires in was already added and unit-tested in PR #2540 — this change makes an already-correct intent explicit rather than implicit.

Related: SMI-6180.