### PR TITLE
fix(mcp-server): SMI-6184 dataSource reflects actual service, not Supabase config

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `rbac_manage`/`rbac_assign_role`/`rbac_create_policy`, `configure_sso`/`sso_settings`,
+  `webhook_configure`/`api_key_manage`, and `compliance_report` reported `dataSource: 'live'`
+  whenever Supabase env vars were configured, even when the underlying service was still the
+  in-memory stub (RBAC and SSO have no live implementation at all today). `dataSource` now
+  reflects which service is actually wired in. The SSO stub's connection-test action also
+  returned a fabricated real-looking success — it now carries `simulated: true` and says so
+  explicitly (SMI-6184).
+
 ## v0.7.11
 
 - **Fix**: 0.7.10 was uninstallable — `npx @skillsmith/mcp-server@latest --version` threw

--- a/packages/mcp-server/src/tools/compliance-tools.test.ts
+++ b/packages/mcp-server/src/tools/compliance-tools.test.ts
@@ -180,4 +180,31 @@ describe('compliance-tools', () => {
       expect(result.period).toBe('90d')
     })
   })
+
+  // ==========================================================================
+  // SMI-6184: dataSource must reflect the actual service, not Supabase config
+  // ==========================================================================
+
+  describe('SMI-6184: dataSource reflects the actual service', () => {
+    it('reports dataSource "stub" when no db is available even though Supabase env vars are set', async () => {
+      const prevUrl = process.env.SUPABASE_URL
+      const prevKey = process.env.SUPABASE_ANON_KEY
+      process.env.SUPABASE_URL = 'https://example.supabase.co'
+      process.env.SUPABASE_ANON_KEY = 'anon-key'
+      try {
+        // mockContext has no `db`, so the handler cannot use the real
+        // service — it must fall back to the stub regardless of Supabase
+        // env config (this was the SMI-6184 bug: it used to report 'live'
+        // here purely because Supabase env vars were set).
+        const parsed = complianceReportInputSchema.parse({ format: 'json' })
+        const result = await executeComplianceReport(parsed, mockContext)
+        expect(result.dataSource).toBe('stub')
+      } finally {
+        if (prevUrl === undefined) delete process.env.SUPABASE_URL
+        else process.env.SUPABASE_URL = prevUrl
+        if (prevKey === undefined) delete process.env.SUPABASE_ANON_KEY
+        else process.env.SUPABASE_ANON_KEY = prevKey
+      }
+    })
+  })
 })

--- a/packages/mcp-server/src/tools/compliance-tools.ts
+++ b/packages/mcp-server/src/tools/compliance-tools.ts
@@ -14,10 +14,10 @@
 
 import { z } from 'zod'
 import type { ToolContext } from '../context.js'
-import { isSupabaseConfigured } from '../supabase-client.js'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { createRealComplianceService } from './compliance-tools.service.js'
 import { formatCycloneDx as buildCycloneDxBom } from './compliance-tools.cyclonedx.js'
+import { markAsStub, dataSourceFor } from './stub-data-source.js'
 
 // ============================================================================
 // Input schemas
@@ -154,7 +154,7 @@ export interface ComplianceService {
 
 /** @internal Exported for testing */
 export function createStubComplianceService(): ComplianceService {
-  return {
+  return markAsStub({
     async gatherData(periodDays, includeUserActivity) {
       const now = new Date()
       const periodStart = new Date(now.getTime() - periodDays * 24 * 60 * 60 * 1000)
@@ -202,7 +202,7 @@ export function createStubComplianceService(): ComplianceService {
         },
       }
     },
-  }
+  })
 }
 
 // Module-level singleton
@@ -324,17 +324,20 @@ async function executeComplianceReportImpl(
   const period = input.period ?? '90d'
   const days = periodToDays(period)
 
-  // Use real service when db is available, otherwise fall back to stub
+  // Use real service when db is available, otherwise fall back to stub.
+  // SMI-6184: dataSource is derived from whichever service actually ends up
+  // in use (via dataSourceFor), not from Supabase env config — so a thrown
+  // constructor or an unavailable db correctly falls back to reporting 'stub'.
   let activeService: ComplianceService = service
-  let dataSource: 'stub' | 'live' = isSupabaseConfigured() ? 'live' : 'stub'
   try {
     if (context.db && context.db.open) {
       activeService = createRealComplianceService(context.db)
-      dataSource = 'live'
     }
   } catch {
     // Fall through to stub service
+    activeService = service
   }
+  const dataSource: 'stub' | 'live' = dataSourceFor(activeService)
 
   const data = await activeService.gatherData(days, input.includeUserActivity ?? true)
   const generatedAt = new Date().toISOString()

--- a/packages/mcp-server/src/tools/integration-tools.stub.ts
+++ b/packages/mcp-server/src/tools/integration-tools.stub.ts
@@ -16,6 +16,7 @@ import type {
   ApiKey,
   ApiKeyMasked,
 } from './integration-tools.js'
+import { markAsStub } from './stub-data-source.js'
 
 // ============================================================================
 // Mock data generation helpers
@@ -72,7 +73,7 @@ export function createStubIntegrationService(): IntegrationService {
     }
   }
 
-  return {
+  return markAsStub({
     async createWebhook(url, events, description) {
       const id = `wh_${nextId++}`
       const wh: Webhook = {
@@ -138,5 +139,5 @@ export function createStubIntegrationService(): IntegrationService {
       key.revoked = true
       return true
     },
-  }
+  })
 }

--- a/packages/mcp-server/src/tools/integration-tools.test.ts
+++ b/packages/mcp-server/src/tools/integration-tools.test.ts
@@ -370,4 +370,31 @@ describe('integration-tools', () => {
       expect(result.error).toContain('already revoked')
     })
   })
+
+  // ==========================================================================
+  // SMI-6184: dataSource must reflect the actual service, not Supabase config
+  // ==========================================================================
+
+  describe('SMI-6184: dataSource reflects the actual service', () => {
+    it('reports dataSource "stub" for webhooks and API keys even when Supabase env vars are set', async () => {
+      const prevUrl = process.env.SUPABASE_URL
+      const prevKey = process.env.SUPABASE_ANON_KEY
+      process.env.SUPABASE_URL = 'https://example.supabase.co'
+      process.env.SUPABASE_ANON_KEY = 'anon-key'
+      try {
+        const webhookResult = await executeWebhookConfigure({ action: 'list' }, mockContext)
+        const keyResult = await executeApiKeyManage(
+          { action: 'list', expiresIn: '90d' },
+          mockContext
+        )
+        expect(webhookResult.dataSource).toBe('stub')
+        expect(keyResult.dataSource).toBe('stub')
+      } finally {
+        if (prevUrl === undefined) delete process.env.SUPABASE_URL
+        else process.env.SUPABASE_URL = prevUrl
+        if (prevKey === undefined) delete process.env.SUPABASE_ANON_KEY
+        else process.env.SUPABASE_ANON_KEY = prevKey
+      }
+    })
+  })
 })

--- a/packages/mcp-server/src/tools/integration-tools.ts
+++ b/packages/mcp-server/src/tools/integration-tools.ts
@@ -11,9 +11,9 @@
 
 import { z } from 'zod'
 import type { ToolContext } from '../context.js'
-import { isSupabaseConfigured } from '../supabase-client.js'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { createStubIntegrationService } from './integration-tools.stub.js'
+import { dataSourceFor } from './stub-data-source.js'
 
 // Re-export stub factory for external consumers and tests
 export { createStubIntegrationService } from './integration-tools.stub.js'
@@ -216,9 +216,9 @@ export interface ApiKeyManageResult {
 // Handlers
 // ============================================================================
 
-/** Resolve the current data source based on Supabase configuration */
+/** Resolve the current data source from the service actually wired in (SMI-6184) */
 function getDataSource(): 'stub' | 'live' {
-  return isSupabaseConfigured() ? 'live' : 'stub'
+  return dataSourceFor(service)
 }
 
 async function executeWebhookConfigureImpl(

--- a/packages/mcp-server/src/tools/rbac-tools.test.ts
+++ b/packages/mcp-server/src/tools/rbac-tools.test.ts
@@ -423,4 +423,30 @@ describe('rbac-tools', () => {
       expect(result.error).toContain('not found')
     })
   })
+
+  // ==========================================================================
+  // SMI-6184: dataSource must reflect the actual service, not Supabase config
+  // ==========================================================================
+
+  describe('SMI-6184: dataSource reflects the actual service', () => {
+    it('reports dataSource "stub" across all three RBAC tools even when Supabase env vars are set', async () => {
+      const prevUrl = process.env.SUPABASE_URL
+      const prevKey = process.env.SUPABASE_ANON_KEY
+      process.env.SUPABASE_URL = 'https://example.supabase.co'
+      process.env.SUPABASE_ANON_KEY = 'anon-key'
+      try {
+        const manage = await executeRbacManage({ action: 'list_roles' }, mockContext)
+        const assign = await executeRbacAssignRole({ action: 'list_assignments' }, mockContext)
+        const policy = await executeRbacCreatePolicy({ action: 'list' }, mockContext)
+        expect(manage.dataSource).toBe('stub')
+        expect(assign.dataSource).toBe('stub')
+        expect(policy.dataSource).toBe('stub')
+      } finally {
+        if (prevUrl === undefined) delete process.env.SUPABASE_URL
+        else process.env.SUPABASE_URL = prevUrl
+        if (prevKey === undefined) delete process.env.SUPABASE_ANON_KEY
+        else process.env.SUPABASE_ANON_KEY = prevKey
+      }
+    })
+  })
 })

--- a/packages/mcp-server/src/tools/rbac-tools.ts
+++ b/packages/mcp-server/src/tools/rbac-tools.ts
@@ -14,8 +14,8 @@
 
 import { z } from 'zod'
 import type { ToolContext } from '../context.js'
-import { isSupabaseConfigured } from '../supabase-client.js'
 import { withTelemetry } from '@skillsmith/core/telemetry'
+import { dataSourceFor } from './stub-data-source.js'
 import type {
   RBACService,
   RbacManageResult,
@@ -177,7 +177,7 @@ async function executeRbacManageImpl(
   input: RbacManageInput,
   _context: ToolContext
 ): Promise<RbacManageResult> {
-  const dataSource: 'stub' | 'live' = isSupabaseConfigured() ? 'live' : 'stub'
+  const dataSource: 'stub' | 'live' = dataSourceFor(service)
 
   switch (input.action) {
     case 'create_role': {
@@ -238,7 +238,7 @@ async function executeRbacAssignRoleImpl(
   input: RbacAssignRoleInput,
   _context: ToolContext
 ): Promise<RbacAssignRoleResult> {
-  const dataSource: 'stub' | 'live' = isSupabaseConfigured() ? 'live' : 'stub'
+  const dataSource: 'stub' | 'live' = dataSourceFor(service)
 
   switch (input.action) {
     case 'assign': {
@@ -300,7 +300,7 @@ async function executeRbacCreatePolicyImpl(
   input: RbacCreatePolicyInput,
   _context: ToolContext
 ): Promise<RbacCreatePolicyResult> {
-  const dataSource: 'stub' | 'live' = isSupabaseConfigured() ? 'live' : 'stub'
+  const dataSource: 'stub' | 'live' = dataSourceFor(service)
 
   switch (input.action) {
     case 'create': {

--- a/packages/mcp-server/src/tools/rbac-tools.types.ts
+++ b/packages/mcp-server/src/tools/rbac-tools.types.ts
@@ -6,6 +6,8 @@
  * Extracted from rbac-tools.ts to stay under the 500-line file-size gate.
  */
 
+import { markAsStub } from './stub-data-source.js'
+
 // ============================================================================
 // Service types
 // ============================================================================
@@ -132,7 +134,7 @@ export function createStubRBACService(): RBACService {
   const policies = new Map<string, RBACPolicy>()
   let nextId = 1
 
-  return {
+  return markAsStub({
     async createRole(name, permissions, description) {
       const id = `role_custom_${nextId++}`
       const role: RBACRole = {
@@ -197,5 +199,5 @@ export function createStubRBACService(): RBACService {
     async deletePolicy(policyId) {
       return policies.delete(policyId)
     },
-  }
+  })
 }

--- a/packages/mcp-server/src/tools/sso-tools.test.ts
+++ b/packages/mcp-server/src/tools/sso-tools.test.ts
@@ -214,4 +214,48 @@ describe('sso-tools', () => {
       expect(result.config!.idpMetadataUrl).toBe('https://idp.example.com/metadata')
     })
   })
+
+  // ==========================================================================
+  // SMI-6184: dataSource must reflect the actual service, not Supabase config,
+  // and the simulated connection test must be clearly marked as such.
+  // ==========================================================================
+
+  describe('SMI-6184: dataSource and simulated-test labeling', () => {
+    it('reports dataSource "stub" for configure_sso and sso_settings even when Supabase env vars are set', async () => {
+      const prevUrl = process.env.SUPABASE_URL
+      const prevKey = process.env.SUPABASE_ANON_KEY
+      process.env.SUPABASE_URL = 'https://example.supabase.co'
+      process.env.SUPABASE_ANON_KEY = 'anon-key'
+      try {
+        const configureResult = await executeConfigureSso(
+          { action: 'set', idpMetadataUrl: 'https://idp.example.com/metadata', protocol: 'saml' },
+          mockContext
+        )
+        const settingsResult = await executeSsoSettings({ includeMetadata: false }, mockContext)
+        expect(configureResult.dataSource).toBe('stub')
+        expect(settingsResult.dataSource).toBe('stub')
+      } finally {
+        if (prevUrl === undefined) delete process.env.SUPABASE_URL
+        else process.env.SUPABASE_URL = prevUrl
+        if (prevKey === undefined) delete process.env.SUPABASE_ANON_KEY
+        else process.env.SUPABASE_ANON_KEY = prevKey
+      }
+    })
+
+    it('marks a successful test-connection result as simulated', async () => {
+      await executeConfigureSso(
+        { action: 'set', idpMetadataUrl: 'https://idp.example.com/metadata', protocol: 'saml' },
+        mockContext
+      )
+      const result = await executeConfigureSso({ action: 'test', protocol: 'saml' }, mockContext)
+      expect(result.test?.simulated).toBe(true)
+      expect(result.test?.message).toMatch(/simulated/i)
+    })
+
+    it('marks a no-config test-connection result as simulated too', async () => {
+      const result = await executeConfigureSso({ action: 'test', protocol: 'saml' }, mockContext)
+      expect(result.success).toBe(false)
+      expect(result.test?.simulated).toBe(true)
+    })
+  })
 })

--- a/packages/mcp-server/src/tools/sso-tools.ts
+++ b/packages/mcp-server/src/tools/sso-tools.ts
@@ -15,8 +15,8 @@
 
 import { z } from 'zod'
 import type { ToolContext } from '../context.js'
-import { isSupabaseConfigured } from '../supabase-client.js'
 import { withTelemetry } from '@skillsmith/core/telemetry'
+import { markAsStub, dataSourceFor } from './stub-data-source.js'
 
 // ============================================================================
 // Input schemas
@@ -119,7 +119,7 @@ export interface SSOConfigService {
     idpEntityId?: string
     protocol: 'saml' | 'oidc'
   }): Promise<SSOConfig>
-  test(): Promise<{ success: boolean; latencyMs: number; message: string }>
+  test(): Promise<{ success: boolean; latencyMs: number; message: string; simulated?: boolean }>
   remove(): Promise<boolean>
   get(includeMetadata: boolean): Promise<SSOConfig | null>
 }
@@ -132,7 +132,7 @@ export interface SSOConfigService {
 export function createStubSSOService(): SSOConfigService {
   let currentConfig: SSOConfig | null = null
 
-  return {
+  return markAsStub({
     async set(config) {
       const entityId =
         config.idpEntityId ?? new URL(config.idpMetadataUrl).origin + '/saml/metadata'
@@ -151,14 +151,22 @@ export function createStubSSOService(): SSOConfigService {
         return {
           success: false,
           latencyMs: 0,
+          simulated: true,
           message: 'No SSO configuration found. Use configure_sso with action "set" first.',
         }
       }
-      // Simulated connection test
+      // SMI-6184: no live SSO service exists yet, so this can only simulate a
+      // connection test — it never actually contacts the IdP. `simulated: true`
+      // and the message wording make that explicit rather than reporting a
+      // fabricated real success.
       return {
         success: true,
         latencyMs: 142,
-        message: `Connection to ${currentConfig.idpEntityId} successful (${currentConfig.protocol.toUpperCase()}).`,
+        simulated: true,
+        message:
+          `Simulated connection to ${currentConfig.idpEntityId} succeeded ` +
+          `(${currentConfig.protocol.toUpperCase()}). This is stub data — no live SSO ` +
+          `service is configured, so the IdP was never actually contacted.`,
       }
     },
 
@@ -176,7 +184,7 @@ export function createStubSSOService(): SSOConfigService {
       }
       return currentConfig
     },
-  }
+  })
 }
 
 // Module-level singleton
@@ -200,7 +208,7 @@ export interface ConfigureSsoResult {
   success: boolean
   dataSource: 'stub' | 'live'
   config?: SSOConfig
-  test?: { success: boolean; latencyMs: number; message: string }
+  test?: { success: boolean; latencyMs: number; message: string; simulated?: boolean }
   message?: string
   error?: string
 }
@@ -219,7 +227,7 @@ async function executeConfigureSsoImpl(
   input: ConfigureSsoInput,
   _context: ToolContext
 ): Promise<ConfigureSsoResult> {
-  const dataSource: 'stub' | 'live' = isSupabaseConfigured() ? 'live' : 'stub'
+  const dataSource: 'stub' | 'live' = dataSourceFor(service)
 
   switch (input.action) {
     case 'set': {
@@ -269,7 +277,7 @@ async function executeSsoSettingsImpl(
   input: SsoSettingsInput,
   _context: ToolContext
 ): Promise<SsoSettingsResult> {
-  const dataSource: 'stub' | 'live' = isSupabaseConfigured() ? 'live' : 'stub'
+  const dataSource: 'stub' | 'live' = dataSourceFor(service)
   const config = await service.get(input.includeMetadata ?? false)
   if (!config) {
     return {

--- a/packages/mcp-server/src/tools/stub-data-source.ts
+++ b/packages/mcp-server/src/tools/stub-data-source.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Shared stub/live data-source marking for MCP tool services
+ * @module @skillsmith/mcp-server/tools/stub-data-source
+ * @see SMI-6184: dataSource must reflect which service is actually wired in,
+ * not merely whether Supabase env vars happen to be configured.
+ *
+ * rbac-tools, sso-tools, and integration-tools each report a
+ * `dataSource: 'stub' | 'live'` field alongside their results. Before this
+ * fix, that field was computed from `isSupabaseConfigured()` alone — which
+ * reports `'live'` whenever Supabase env is present, even when the module
+ * still has its in-memory stub service wired in (as rbac-tools and
+ * sso-tools always do today; neither has a live implementation yet).
+ *
+ * This module tracks which service instances were produced by a stub
+ * factory, so `dataSource` reflects the service actually in use instead.
+ */
+
+const stubInstances = new WeakSet<object>()
+
+/**
+ * Mark a service instance as a stub. Every `createStub*Service()` factory
+ * should wrap its returned object with this before returning it.
+ */
+export function markAsStub<T extends object>(service: T): T {
+  stubInstances.add(service)
+  return service
+}
+
+/** True if `service` was produced by a stub factory (via {@link markAsStub}). */
+export function isStubService(service: object): boolean {
+  return stubInstances.has(service)
+}
+
+/**
+ * Compute the `dataSource` field for a tool result from the service
+ * currently in use — `'stub'` if it was created by a stub factory,
+ * `'live'` otherwise (including any future real implementation, which
+ * simply never gets marked).
+ */
+export function dataSourceFor(service: object): 'stub' | 'live' {
+  return isStubService(service) ? 'stub' : 'live'
+}


### PR DESCRIPTION
## Business Summary

**What shipped:** Four Enterprise MCP tools (RBAC, SSO, custom integrations, compliance reports) were telling customers their config was "live" and Supabase-backed even when it was actually running on in-memory stub data that resets on every restart — the check only asked "is Supabase configured?" not "is a real service actually running?" RBAC and SSO have no real backend at all today, so this was always wrong for them. The SSO connection-test action also returned a fake "connection successful" message that looked exactly like a real one. Both are now fixed: the reported status matches reality, and the SSO test result is clearly labeled as simulated.

**Quality bar:** Full `mcp-server` package test suite green (179 files, 2,963 tests). New regression tests on all four affected tools proving the status can no longer say "live" while the stub is running, even with Supabase fully configured. `audit:standards` clean.

**Found along the way:** while fixing the three tools named in SMI-6184, a sweep for the same bug pattern across the codebase found `compliance-tools.ts` had the identical issue — not part of SMI-6184's original scope — plus a second, subtler gap where the correct-status assignment lived inside the same try block as a step that could fail, so a failure would silently leave the wrong status in place. Both fixed here rather than filed separately, since it's the exact bug already being fixed with the exact pattern already built.

**Net result:** Fully shipped, no follow-up. This is a reporting-accuracy fix only — it does not change what RBAC/SSO can actually do; a separate initiative (scope doc in the paired `skillsmith-docs` PR) covers building real automated RBAC and Supabase-backed SSO.

---

## Technical detail

**Root cause:** `rbac-tools.ts`, `sso-tools.ts`, `integration-tools.ts`, and `compliance-tools.ts` each computed a `dataSource: 'stub' | 'live'` result field from `isSupabaseConfigured()` alone, independent of which service instance the handler actually called.

**Fix:** new shared `packages/mcp-server/src/tools/stub-data-source.ts` — a `WeakSet`-backed `markAsStub()`/`dataSourceFor()` pair. Every `createStub*Service()` factory wraps its return value in `markAsStub()`; every handler computes `dataSource` from `dataSourceFor(<the service instance actually in use>)` instead of environment config. Forward-compatible: a future real implementation simply never gets marked, so it reports `'live'` automatically once wired in.

`sso-tools.ts`'s stub `test()` action now returns `simulated: true` plus explicit wording ("This is stub data — no live SSO service is configured, so the IdP was never actually contacted") instead of an indistinguishable fake success.

`compliance-tools.ts`'s fix additionally moves the `dataSource` computation to *after* the try/catch that decides which service to use, rather than assigning it speculatively before the outcome is known — the prior code's `dataSource = 'live'` line sat inside the same try block as the real-service constructor call, so a thrown constructor would skip that assignment entirely and leave the stale, env-based guess in place.

`team-workspace.ts` and `registry-tools.ts` matched the same grep pattern but are confirmed NOT affected — both already select their live/stub service using the identical `isSupabaseConfigured()` check they use to report `dataSource`, so selection and reporting are consistent by construction there.

Files: `stub-data-source.ts` (new), `rbac-tools.ts`, `rbac-tools.types.ts`, `sso-tools.ts`, `integration-tools.ts`, `integration-tools.stub.ts`, `compliance-tools.ts`, plus their five test files.

Code review report: `docs/internal/code_review/2026-08-26-smi6184-datasource-stub-misreport-review.md` (paired `skillsmith-docs` PR #863).

Closes SMI-6184.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)