### PR TITLE
docs(env): SMI-6015 register the 3 Wave 3 shard-dispatch PATs in .env.schema

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -43,24 +43,48 @@ LINEAR_PROJECT_TEAM=
 # @type=string(startsWith=gh) @sensitive
 # GITHUB_TOKEN=
 
-# GitHub PAT (redundant/fallback token) - mirrors the `GH_PAT` GitHub Actions
-# repo secret used by batch-transform.yml/website-deploy-staging.yml. Not
+# GitHub PAT (redundant/fallback token) - mirrors the `SKILLSMITH_SUPPORT_PAT`
+# GitHub Actions repo secret used by batch-transform.yml/website-deploy-staging.yml
+# (renamed from `GH_PAT`, SMI-6187 - the old secret was resolving empty). Not
 # consumed by any script yet; registered so a local diagnostic run (e.g.
 # probing GitHub code-search behavior) can use it via `varlock run --` without
 # ever needing GITHUB_TOKEN above. Populate locally only if you hold a copy of
-# the same PAT value used for the GH_PAT Actions secret.
+# the same PAT value used for the SKILLSMITH_SUPPORT_PAT Actions secret.
 # @type=string(startsWith=gh) @required=false @sensitive
 # GH_PAT=
 
-# GitHub PAT - dedicated token for the planned SMI-6015 simulate-full CI
-# workflow (docs/internal/implementation/smi-6015-wave3-simulate-full-ci-workflow-plan.md).
-# Provisioned under a SEPARATE GitHub account (not the account behind
-# BACKFILL_GITHUB_TOKEN/GH_PAT_SKILLSMITH) specifically so this workflow's
-# multi-day PAT rate-bucket usage doesn't compete with indexer-backfill.yml's.
-# Not yet consumed by any script; registered so `varlock run --` can validate
-# it locally ahead of wiring it into a GitHub Actions secret.
+# GitHub PAT - one of three dedicated tokens for the SMI-6015 PAT-sharded
+# fetch plan (docs/internal/implementation/smi-6015-pat-sharded-fetch-plan.md
+# Wave 3), each under a genuinely separate GitHub account so N=3 parallel
+# shard dispatches don't share a rate-limit bucket. This one: ryan@smithhorn.ca.
+# Provisioned under a SEPARATE account from BACKFILL_GITHUB_TOKEN/
+# GH_PAT_SKILLSMITH (indexer-backfill.yml's own dedicated account) and from
+# RELEASE_PAT/SKILLSMITH_SUPPORT_PAT (already committed to release-cadence.yml/
+# batch-transform.yml/website-deploy-staging.yml respectively). Not yet
+# consumed by any script; the Wave 3 dispatch is a manual `docker exec`
+# invocation (not a GitHub Actions workflow), so this value only needs to
+# live here for `varlock run --` to hand to that dispatch as GITHUB_TOKEN --
+# it does not need a matching GitHub Actions secret.
 # @type=string(startsWith=gh) @required=false @sensitive
 # SKILLSMITH_PAT_RYAN=
+
+# GitHub PAT - second of the three SMI-6015 Wave 3 shard-dispatch tokens (see
+# SKILLSMITH_PAT_RYAN above for the full rationale). This one: security@smithhorn.ca.
+# Mirrors the SECURITY_SKILLSMITH_PAT GitHub Actions repo secret, added
+# 2026-08-26 specifically for this plan -- confirmed via `gh secret list` +
+# a repo-wide grep that no existing workflow/script references it yet, so
+# it carries no other job's rate-limit load.
+# @type=string(startsWith=gh) @required=false @sensitive
+# SECURITY_SKILLSMITH_PAT=
+
+# GitHub PAT - third of the three SMI-6015 Wave 3 shard-dispatch tokens (see
+# SKILLSMITH_PAT_RYAN above for the full rationale). This one: contact@smithhorn.ca.
+# Mirrors the SKILLSMITH_CONTACT_PAT GitHub Actions repo secret, added
+# 2026-08-26 specifically for this plan -- confirmed via `gh secret list` +
+# a repo-wide grep that no existing workflow/script references it yet, so
+# it carries no other job's rate-limit load.
+# @type=string(startsWith=gh) @required=false @sensitive
+# SKILLSMITH_CONTACT_PAT=
 
 # =============================================================================
 # GITHUB APP - For high-rate skill discovery (15K req/hr)


### PR DESCRIPTION
## Business Summary

**What shipped:** Registers `SECURITY_SKILLSMITH_PAT` and `SKILLSMITH_CONTACT_PAT` in `.env.schema`, alongside the existing `SKILLSMITH_PAT_RYAN` entry — the three separate-GitHub-account PATs SMI-6015 Wave 3's manual shard dispatch needs so parallel shards don't share one account's 5,000 req/hr rate limit. Also fixes a stale comment on the existing entry that still referenced the old `GH_PAT` secret name, renamed to `SKILLSMITH_SUPPORT_PAT` in SMI-6187.

**Quality bar:** Docs/schema-only change — verified neither new secret is already wired into an existing workflow (so neither carries another job's rate-limit load), unlike the two initially-proposed candidates (`RELEASE_PAT`, `SKILLSMITH_SUPPORT_PAT`), which are already committed elsewhere. Typecheck, lint, and the full test suite passed pre-push.

**Net result:** Done. Unblocks SMI-6015 Wave 3 pending final confirmation that all three PAT values are genuinely usable.

---

## Technical detail

- `.env.schema` — 2 new entries (`SECURITY_SKILLSMITH_PAT`, `SKILLSMITH_CONTACT_PAT`) matching the existing `SKILLSMITH_PAT_RYAN` pattern; comment fix on the pre-existing `GH_PAT`→`SKILLSMITH_SUPPORT_PAT` rename.
- No code changes — schema/template only, no real values (per Varlock convention, real values live only in the gitignored `.env`).



[skip-impl-check]
