### PR TITLE
chore(settings): deny Claude's own reads/greps of .env files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,7 +74,12 @@
       "mcp__ruflo__claims_accept-handoff",
       "mcp__ruflo__hooks_post-task",
       "mcp__ruflo__hooks_model-outcome",
-      "mcp__ruflo__hooks_model-route"
+      "mcp__ruflo__hooks_model-route",
+      "Read(//Users/williamsmith/Documents/GitHub/Smith-Horn/skillsmith/.env)",
+      "Read(//Users/williamsmith/Documents/GitHub/Smith-Horn/skillsmith/.worktrees/**/.env)",
+      "Bash(cat .env)",
+      "Bash(cat .env:*)",
+      "Bash(echo $.env:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Business Summary

**What shipped:** Adds 5 entries to `permissions.deny` in `.claude/settings.json` blocking Claude Code's own tool-initiated reads and `cat`s of `.env` files (main checkout and any worktree), closing a gap where Claude's own tool calls could bypass Varlock's masking entirely.

**Quality bar:** Root-caused in-session: a raw, unmasked `.env` dump surfaced after `varlock load` (itself correctly masked) was followed shortly after by an edit to `.env` — best-effort read is a harness-level "file changed since last read" staleness notifier, unrelated to Varlock's own masking, re-surfacing the file's raw content on the subsequent change. The full ~87KB settings file was manually scanned (secret-prefix grep, long-line audit, high-entropy sweep) before committing to confirm it's safe to publish to this public repo.

**Found along the way:** the pre-push hardcoded-secrets scanner (`scripts/pre-push-check.sh`) greps the whole working tree rather than the push diff, so it false-triggers on real secrets sitting in the gitignored, untracked `.env` — this push had to bypass with `--no-verify` under explicit, scoped consent as a result. Filed separately as SMI-6196 (ADR-109-gated infra fix, not folded into this PR).

**Net result:** Done, no further follow-up on this PR itself.

---

## Technical detail

- `.claude/settings.json` — 5 new `permissions.deny` entries: `Read(//.../skillsmith/.env)`, `Read(//.../skillsmith/.worktrees/**/.env)`, `Bash(cat .env)`, `Bash(cat .env:*)`, `Bash(echo $.env:*)`. A `.claude/settings.json.bak` backup of the pre-change file is kept locally (untracked, not part of this diff) at the user's request.
- Edited directly in the main checkout rather than a worktree: `.claude/settings.json` edits are blocked outright for Claude's own Edit/Write tool calls by the harness's permission-classifier (regardless of tightening vs. loosening intent), so the change had to be applied by the user directly via a shell command — this is the explicitly-approved exception to the "worktrees are the default workspace" rule for this one file.
- Pushed with `--no-verify`: `.env` is gitignored/untracked (`git check-ignore -v .env` confirms), so nothing in it was ever part of this diff — the scanner's whole-tree grep, not this push's content, produced the block. See SMI-6196.



[skip-impl-check]
