### PR TITLE
fix(ci): audit:standards File Length check now scans .astro files (SMI-6191)

### DIFF
--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -252,7 +252,7 @@ try {
 console.log(`\n${BOLD}3. File Length (max ${FILE_LENGTH_MAX_LINES} lines)${RESET}`)
 try {
   const sourceFiles = TYPE_SAFETY_AND_LENGTH_ROOTS.flatMap((root) =>
-    getFilesRecursive(root, ['.ts', '.tsx'])
+    getFilesRecursive(root, ['.ts', '.tsx', '.astro'])
   ).filter((f) => !isExemptFromLengthCheck(f))
 
   const longFiles = []


### PR DESCRIPTION
## Business Summary

**What shipped:** The repo's automated 500-line-per-file check has been blind to every `.astro` page on the entire website — it only ever looked at `.ts`/`.tsx` files. Now it looks at `.astro` too.

**Quality bar:** Full ADR-109 process — a SPARC research doc, then an independent adversarial review (GPT-5.6-Sol) that caught two real bugs in the plan's *own verification steps* before implementation started (a wrong expected-warning-count, and a verification command that tested the wrong thing entirely). Implementation verified independently again after the fact: exact warning-count check, a real test commit proving pre-commit is unaffected, and the full typecheck/lint/format/test suite.

**Found along the way:** turning this check on doesn't just catch the one file that prompted it — it surfaces 21 files across the website already over the limit. That cleanup is tracked separately (SMI-6198, SMI-6199), not bundled into this PR.

**Net result:** Fully shipped. The 21-file cleanup is real follow-up work, not blocking.

---

## Technical detail

`scripts/audit-standards.mjs` line 255 — Check 3's scanned extensions changed from `['.ts', '.tsx']` to `['.ts', '.tsx', '.astro']`. Matches the identical pattern already used by five other `.astro`-scanning checks in the same file.

Verified: `audit:standards` exit code stays `0` (warn-only, unchanged); the new warning is a single `⚠ 21 files exceed 500 lines` line, not 21 separate warnings; pre-commit's hard-fail file-length check is untouched (`lint-staged.config.js` routes `.astro` to `prettier` only); Check 2 ("no `any` types") is structurally independent — confirmed unaffected. Full `docker exec ... npm run typecheck/lint/format:check` and `scripts/tests` suite (3,693 tests) pass.

Plan doc: `docs/internal/implementation/smi-6191-audit-standards-astro-file-length-gap.md` (merging separately in the docs repo, PR #869).

No migrations, no edge function changes, no schema changes.