### PR TITLE
fix(website): getWebsiteSsrApiKey() falls back to the anon key, not empty (SMI-6190 hotfix)

### DIFF
--- a/packages/website/src/lib/supabase-config.server.test.ts
+++ b/packages/website/src/lib/supabase-config.server.test.ts
@@ -7,27 +7,43 @@ describe('getWebsiteSsrApiKey', () => {
     vi.unstubAllEnvs()
   })
 
-  it('returns an empty string, not undefined, when the env var is unset', () => {
-    // vi.stubEnv('KEY', undefined) simulates the var never having been set —
-    // import.meta.env.SKILLSMITH_WEBSITE_SSR_API_KEY reads back as undefined,
-    // exactly like local dev before the real secret is provisioned.
+  it('falls back to the anon key, not an empty string, when the dedicated secret is unset', () => {
+    // Hotfix (SMI-6190 post-merge): an empty bearer token doesn't match the
+    // anon key's exact-string check, so it would fall all the way through
+    // runAuthMiddleware() to the trial limiter's 10-requests-TOTAL-EVER cap
+    // (confirmed already exhausted in prod) instead of the anon-key
+    // community-tier bucket this credential is meant to replace. Falling
+    // back to the anon key preserves pre-SMI-6190 behavior until the real
+    // key is provisioned, rather than making things worse in the meantime.
     vi.stubEnv('SKILLSMITH_WEBSITE_SSR_API_KEY', undefined)
+    vi.stubEnv('PUBLIC_SUPABASE_ANON_KEY', 'anon-key-fallback-value')
 
     const result = getWebsiteSsrApiKey()
 
-    expect(result).toBe('')
-    expect(result).not.toBeUndefined()
+    expect(result).toBe('anon-key-fallback-value')
     expect(() => getWebsiteSsrApiKey()).not.toThrow()
   })
 
-  it('returns an empty string when the env var is explicitly set to an empty string', () => {
+  it('falls back to the anon key when the dedicated secret is explicitly set to an empty string', () => {
     vi.stubEnv('SKILLSMITH_WEBSITE_SSR_API_KEY', '')
-    expect(getWebsiteSsrApiKey()).toBe('')
+    vi.stubEnv('PUBLIC_SUPABASE_ANON_KEY', 'anon-key-fallback-value')
+    expect(getWebsiteSsrApiKey()).toBe('anon-key-fallback-value')
   })
 
-  it('returns the configured value when the env var is set', () => {
+  it('returns the dedicated key when configured, not the anon key', () => {
     vi.stubEnv('SKILLSMITH_WEBSITE_SSR_API_KEY', 'sk_live_test_dedicated_key')
+    vi.stubEnv('PUBLIC_SUPABASE_ANON_KEY', 'anon-key-fallback-value')
     expect(getWebsiteSsrApiKey()).toBe('sk_live_test_dedicated_key')
+  })
+
+  it('returns an empty string (never throws) when neither the dedicated key nor the anon key is configured', () => {
+    // Degenerate case — no real deployment should ever reach this, since the
+    // anon key is a build-time-baked public constant, but the accessor must
+    // not throw regardless.
+    vi.stubEnv('SKILLSMITH_WEBSITE_SSR_API_KEY', undefined)
+    vi.stubEnv('PUBLIC_SUPABASE_ANON_KEY', undefined)
+    expect(() => getWebsiteSsrApiKey()).not.toThrow()
+    expect(getWebsiteSsrApiKey()).toBe('')
   })
 })
 
@@ -40,13 +56,14 @@ describe('getWebsiteSsrApiKey fallback isolation (module-level re-import)', () =
     vi.unstubAllEnvs()
   })
 
-  it('degrades to an empty string rather than throwing when the module is freshly loaded with no env var set', async () => {
+  it('falls back to the anon key rather than throwing when the module is freshly loaded with no dedicated key set', async () => {
     vi.stubEnv('SKILLSMITH_WEBSITE_SSR_API_KEY', undefined)
+    vi.stubEnv('PUBLIC_SUPABASE_ANON_KEY', 'anon-key-fallback-value')
 
     const { getWebsiteSsrApiKey: freshGetWebsiteSsrApiKey } =
       await import('./supabase-config.server')
 
     expect(() => freshGetWebsiteSsrApiKey()).not.toThrow()
-    expect(freshGetWebsiteSsrApiKey()).toBe('')
+    expect(freshGetWebsiteSsrApiKey()).toBe('anon-key-fallback-value')
   })
 })

--- a/packages/website/src/lib/supabase-config.server.ts
+++ b/packages/website/src/lib/supabase-config.server.ts
@@ -13,6 +13,7 @@
  * with a concrete assertion that neither the env var name nor the `sk_live_`
  * key shape ever reaches the client-shipped bundle.
  */
+import { getSupabaseConfig } from './supabase-config'
 
 /**
  * Returns the dedicated internal API key used to authenticate the website's
@@ -21,11 +22,24 @@
  * anon key, which shares a single per-endpoint rate bucket with every other
  * anonymous caller (see SMI-6190 for the full investigation).
  *
- * Returns `''` when the secret is unset (local dev, or before the real key
- * is provisioned) rather than throwing — callers degrade gracefully to the
- * existing trial-limiter fallback path exactly like any other failed/absent
- * auth, rather than crashing the SSR render.
+ * Falls back to the anon key when the dedicated secret is unset (local dev,
+ * or the window between this code deploying and the real credential being
+ * provisioned) rather than an empty string. This matters: an empty bearer
+ * token doesn't match the anon key's exact-string check
+ * (`isSupabaseAnonKey()`, `api-key-auth.ts`), so it would fall all the way
+ * through `runAuthMiddleware()` to the unauthenticated trial limiter — a
+ * 10-requests-TOTAL-EVER cap, confirmed already exhausted in prod, which is
+ * far stricter than the anon-key bucket this credential replaces. Live
+ * verification during rollout caught this: post-merge, every SSR render
+ * sitewide was silently spending down Vercel's own egress-IP trial budget
+ * toward zero, which would have made every skill/category page's degraded
+ * state permanent (no time-window reset) instead of the pre-existing
+ * partial-degrade-under-anon-bucket-pressure behavior. Falling back to the
+ * anon key preserves the exact pre-SMI-6190 behavior until the dedicated key
+ * exists, then silently and correctly switches over once it's provisioned —
+ * no redeploy needed, no window where behavior is worse than before this
+ * feature shipped.
  */
 export function getWebsiteSsrApiKey(): string {
-  return import.meta.env.SKILLSMITH_WEBSITE_SSR_API_KEY || ''
+  return import.meta.env.SKILLSMITH_WEBSITE_SSR_API_KEY || getSupabaseConfig().anonKey
 }


### PR DESCRIPTION
## Business Summary

**What shipped:** A same-session self-caught regression fix. PR #2552 (merged minutes ago) added a dedicated API key for skill-page fetches, and I claimed in that PR's description that behavior would be "completely unchanged" until the real credential is provisioned. That claim was wrong — I caught it through post-merge production verification, not before merge. An unset secret resolves to an empty string, which doesn't match the site's anon key, so the request falls all the way through to the trial limiter — a 10-requests-total-**ever** cap that's already exhausted in production. Every page render since the merge has been silently spending down Vercel's own trial budget toward a *permanent* fully-degraded state (no time-window reset), which is worse than before that PR shipped.

**Quality bar:** Fixed by falling back to the real anon key instead of an empty string — this exactly restores pre-PR-#2552 behavior until the dedicated key is provisioned, then switches over automatically once it is, no redeploy required. Full verification suite (704 tests, was 703 pre-hotfix) plus a live production check (confirmed via direct API calls with rate-limit headers) before writing this fix.

**Found along the way:** none — this PR is itself the finding.

**Net result:** Fully shipped. Merging this immediately given the live production impact.

---

## Technical detail

`packages/website/src/lib/supabase-config.server.ts` — `getWebsiteSsrApiKey()` now returns `import.meta.env.SKILLSMITH_WEBSITE_SSR_API_KEY || getSupabaseConfig().anonKey` instead of `|| ''`.

`packages/website/src/lib/supabase-config.server.test.ts` — updated all 4 existing test assertions (they asserted the old, wrong `''`-fallback behavior) and added a degenerate-case test for when neither key is configured.

No migrations, no other file changes. Follows directly from PR #2552 (SMI-6190) — see that PR and [ADR-134](https://github.com/smith-horn/skillsmith-docs/pull/871) for the full design context this hotfix operates within.