### PR TITLE
chore(env): SMI-6015 rename Wave 3 PAT vars to match actual .env naming

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -70,21 +70,27 @@ LINEAR_PROJECT_TEAM=
 
 # GitHub PAT - second of the three SMI-6015 Wave 3 shard-dispatch tokens (see
 # SKILLSMITH_PAT_RYAN above for the full rationale). This one: security@smithhorn.ca.
-# Mirrors the SECURITY_SKILLSMITH_PAT GitHub Actions repo secret, added
-# 2026-08-26 specifically for this plan -- confirmed via `gh secret list` +
-# a repo-wide grep that no existing workflow/script references it yet, so
-# it carries no other job's rate-limit load.
+# The same value is also registered as the SECURITY_SKILLSMITH_PAT GitHub
+# Actions repo secret, added 2026-08-26 for potential future workflow use --
+# confirmed via `gh secret list` that no existing workflow/script reads it
+# yet, so it carries no other job's rate-limit load. The local var name here
+# intentionally differs from the repo secret's name (matches the
+# SKILLSMITH_PAT_RYAN naming pattern instead); the manual Wave 3 dispatch
+# reads only this local value via `varlock run --`, never the repo secret.
 # @type=string(startsWith=gh) @required=false @sensitive
-# SECURITY_SKILLSMITH_PAT=
+# SKILLSMITH_PAT_SECURITY=
 
 # GitHub PAT - third of the three SMI-6015 Wave 3 shard-dispatch tokens (see
 # SKILLSMITH_PAT_RYAN above for the full rationale). This one: contact@smithhorn.ca.
-# Mirrors the SKILLSMITH_CONTACT_PAT GitHub Actions repo secret, added
-# 2026-08-26 specifically for this plan -- confirmed via `gh secret list` +
-# a repo-wide grep that no existing workflow/script references it yet, so
-# it carries no other job's rate-limit load.
+# The same value is also registered as the SKILLSMITH_CONTACT_PAT GitHub
+# Actions repo secret, added 2026-08-26 for potential future workflow use --
+# confirmed via `gh secret list` that no existing workflow/script reads it
+# yet, so it carries no other job's rate-limit load. The local var name here
+# intentionally differs from the repo secret's name (matches the
+# SKILLSMITH_PAT_RYAN naming pattern instead); the manual Wave 3 dispatch
+# reads only this local value via `varlock run --`, never the repo secret.
 # @type=string(startsWith=gh) @required=false @sensitive
-# SKILLSMITH_CONTACT_PAT=
+# SKILLSMITH_PAT_CONTACT=
 
 # =============================================================================
 # GITHUB APP - For high-rate skill discovery (15K req/hr)


### PR DESCRIPTION
## Business Summary

**What shipped:** Renames two SMI-6015 Wave 3 PAT variables in `.env.schema` from `SECURITY_SKILLSMITH_PAT`/`SKILLSMITH_CONTACT_PAT` to `SKILLSMITH_PAT_SECURITY`/`SKILLSMITH_PAT_CONTACT`, matching the names the real credentials were actually provisioned under (and the existing `SKILLSMITH_PAT_RYAN` pattern). Also bumps the `docs/internal` submodule pointer to pick up the matching runbook fix.

**Quality bar:** Caught by the runbook's own Step 0 live pre-flight, run before this PR — two of three PATs resolved as empty under the old schema names, both in the main checkout and this worktree. Confirmed with `gh secret list` that the old names genuinely belong to separately-registered GitHub Actions repo secrets (added 2026-08-26, unrelated to this local dispatch), so the schema comments now distinguish "local `.env` var" from "GitHub Actions repo secret of similar name" rather than conflating them. All three PATs then re-verified live under the corrected names, resolving to three genuinely distinct GitHub accounts.

**Found along the way:** none beyond the naming mismatch itself.

**Net result:** `.env.schema` and the Wave 3 runbook are now consistent with the actual live environment. Unblocks the Wave 3 Step 2 rehearsal dispatch, still pending separately on explicit go-ahead (real external action against real GitHub accounts).

## Technical detail

- `.env.schema`: two variable declarations renamed, comments updated to clarify local-var-vs-repo-secret naming.
- `docs/internal` pointer bump: picks up `smith-horn/skillsmith-docs` PR #874 (runbook rename) and #875 (naming-scheme clarification + Step 0 result recorded).

[skip-impl-check]