### PR TITLE
fix(security): exclude .env from pre-push hardcoded-secrets grep

### DIFF
--- a/.security-scan-ignore
+++ b/.security-scan-ignore
@@ -20,3 +20,12 @@ docs/site/**
 # Local vector index (gitignored; metadata.json contains indexed doc text
 # that discusses secret patterns — not actual secrets)
 .ruvector/**
+
+# .env is unconditionally gitignored (.gitignore:65) — nothing in it can ever
+# reach a commit through normal git operations, so this scan provides zero
+# protection against secret leakage here. Scanning it anyway guarantees any
+# real credential configured for local dev gets grep-matched and echoed to
+# stdout on every single push (pre-push-check.sh:332) — a live secret-to-log
+# exposure vector with no compensating benefit. Excluded 2026-08-26 after a
+# real PAT was printed to a terminal transcript this way; see SMI-6219.
+.env


### PR DESCRIPTION
## Summary

Anyone with real credentials configured in their local `.env` (the Varlock-sanctioned place for
them) hits a guaranteed false positive on every push: the pre-push hardcoded-secrets check greps
the whole working directory, not the diff, and `.env` was never in its exclude list. Since `.env`
is unconditionally gitignored, the check catches nothing real there — it only creates a live
secret-to-stdout leak vector on every push from a machine with real keys configured.

Two real GitHub PATs were printed into a terminal transcript this way today. Both have been
rotated.

## What changed

Added `.env` to `.security-scan-ignore` — the existing, documented mechanism this check already
reads for false-positive suppression. This is a config/data change, not an edit to
`scripts/pre-push-check.sh` itself, so it doesn't fall under ADR-109's SPARC + plan-review gate
for hook/CI script changes.

A script-level fix (excluding `.env` in the check's own `EXCLUDE_FILES` by default, so a fresh
clone doesn't need this file) is filed as a follow-up in SMI-6219, since that touches the hook
script and does fall under ADR-109.

[skip-impl-check] — config/data-only change (`.security-scan-ignore` is a plain exclude list, not
source code); SMI-6219 also tracks a separate, real code follow-up which will go through the
normal check.

## Test plan

- [x] Verified locally: pushing with this change in place now reports "No hardcoded secrets
      detected" instead of printing `.env`'s contents

Linear: SMI-6219

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
