### PR TITLE
fix(indexer): SMI-6015 classify HTTP 451 as not-found, not the transient catch-all

### DIFF
--- a/scripts/indexer/smi5879-census.branches.helpers.ts
+++ b/scripts/indexer/smi5879-census.branches.helpers.ts
@@ -260,6 +260,25 @@ export async function resolveOne(
           attempts: totalRequests,
         }
       }
+      // 451 ("Unavailable For Legal Reasons") is GitHub's own status for a
+      // repo blocked by a DMCA/legal takedown -- a permanent state, not a
+      // transient one. Retrying never resolves it (confirmed live, SMI-6015
+      // Wave 3 rehearsal, 2026-08-27: dzcmemory-web/bazi-ziwei-skill returned
+      // 451 across both its attempts and again on a fresh census run,
+      // repeatedly refusing I-6's seal check). Classified as `not-found`
+      // (same terminal bucket as 404) rather than falling into the generic
+      // "unclassified status" catch-all below, which defaults to `transient`
+      // and would keep this repo permanently `unevaluable` -- exactly the
+      // outcome G-2's coverage gate zero-tolerates.
+      if (response.status === 451) {
+        return {
+          repo,
+          resolution: 'not-found',
+          defaultBranch: null,
+          httpStatus: 451,
+          attempts: totalRequests,
+        }
+      }
       if (response.status === 403 || response.status === 429) {
         await waitOutRateLimit(response)
         continue

--- a/scripts/tests/indexer/smi5879-census.branches.helpers.test.ts
+++ b/scripts/tests/indexer/smi5879-census.branches.helpers.test.ts
@@ -93,6 +93,15 @@ describe('resolveOne', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('SMI-6015 Wave 3: 451 (legal takedown) is classified not-found, not the generic transient catch-all', async () => {
+    const fetchMock = queueFetch([new Response('', { status: 451 })])
+    const outcome = await resolveOne(REPO, async () => ({}), newRateLimitTelemetry(), fastBucket())
+    expect(outcome.resolution).toBe('not-found')
+    expect(outcome.defaultBranch).toBeNull()
+    expect(outcome.httpStatus).toBe(451)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('200 with no default_branch is transient, never fabricated as resolved', async () => {
     queueFetch([new Response(JSON.stringify({}), { status: 200 })])
     const outcome = await resolveOne(REPO, async () => ({}), newRateLimitTelemetry(), fastBucket())


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixes a real classification gap in the SMI-6015 Wave 3 census tool: GitHub's HTTP 451 (a repo blocked for legal/DMCA reasons — a permanent state) was falling through to a generic "unclassified status" catch-all that defaults to `transient` (implying retryable). It isn't retryable — a legally-blocked repo returns 451 forever.

**Quality bar:** Caught live, not speculatively — the Wave 3 rehearsal census ran all 31,749 branch resolutions to completion, then refused to seal on its own I-6 invariant check because one repo (`dzcmemory-web/bazi-ziwei-skill`) kept coming back `transient` across two retry attempts and a dedicated re-resolution sweep. Traced the downstream effect: `transient` becomes `unevaluable` in the simulator, which the G-2 coverage gate zero-tolerates — so this repo would have silently blocked every future census (this rehearsal and the real, ~90-hour decision run) forever, with no path to seal. Verified the fix is scoped correctly: `not-found`/`unparseable` already map to a legitimate terminal outcome downstream, not `unevaluable`. Added a unit test covering the new branch; all 26 existing tests in the file still pass. Deliberately did not add speculative handling for other HTTP codes without live evidence, matching this file's own existing evidence-driven discipline.

**Found along the way:** the invariant check (I-6) and re-resolution sweep both worked exactly as designed — they caught a real data-quality problem rather than letting a bad seal through. The gap was purely in the initial classification step.

**Net result:** Done. Unblocks re-running the SMI-6015 Wave 3 rehearsal census, which will otherwise hit this same repo and fail the same way again.

## Technical detail

- `scripts/indexer/smi5879-census.branches.helpers.ts`: adds an explicit `response.status === 451` branch in `resolveOne()`, returning `resolution: 'not-found'` (same shape as the existing 404 branch), ahead of the generic unclassified-status catch-all.
- `scripts/tests/indexer/smi5879-census.branches.helpers.test.ts`: new test asserting 451 classifies as `not-found` with no retry, mirroring the existing 404 test.