### PR TITLE
fix: link status page from README, fix status banner's false retry claim (SMI-6220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ node packages/cli/dist/index.js install community/jest-helper
 - [**Security Guide**](https://skillsmith.app/docs/security) - Understanding skill trust, safety, and protections
 - [5-Minute Setup](https://skillsmith.app/docs/quickstart) - Quick start guide
 - [Configuration Guide](https://skillsmith.app/docs/getting-started) - Complete setup and usage
+- [Status](https://www.skillsmith.app/status) - Live status and uptime history for Skillsmith's core services
 
 ### Internal
 

--- a/packages/website/src/lib/status-vocab.ts
+++ b/packages/website/src/lib/status-vocab.ts
@@ -332,7 +332,7 @@ export const OVERALL_BANNER: Record<ComponentStatus, OverallBannerConfig> = {
   },
   unknown: {
     headline: 'Status unavailable',
-    sub: "We couldn't load live status data. This page will keep retrying.",
+    sub: "We couldn't load live status data. If this doesn't update, see the live feed at /status.rss.xml.",
     dot: 'bg-gray-500',
     text: 'text-gray-400',
   },


### PR DESCRIPTION
Two small plan-reviewed fixes: README links the status page; the status page's no-JS fallback banner no longer falsely claims it 'will keep retrying' (that's JS-only behavior) and points to the working /status.rss.xml feed instead. No app-code risk — copy/docs only.