### PR TITLE
fix(cli): logout/whoami now detect JWT device-code sessions

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skillsmith logout` and `skillsmith whoami` now detect a JWT device-code session
+  (`skillsmith login`'s default flow, SMI-4402) — previously they only checked the legacy
+  API-key store, so `login` would report "Already authenticated" while `logout` immediately
+  after reported "Not authenticated. Nothing to log out.", a stuck loop with no way to
+  actually end the session. `logout` now clears both credential stores on confirm. (SMI-6235)
 - **Docs**: README's framing sentence updated from the "lifecycle layer" tagline to a plain
   descriptive sentence ("a registry for sharing, scanning, and tracking agent skills across
   teams") as part of the site-wide positioning reframe. Wording-only. (SMI-6194)

--- a/packages/cli/src/commands/logout.test.ts
+++ b/packages/cli/src/commands/logout.test.ts
@@ -103,25 +103,6 @@ describe('createLogoutCommand', () => {
       expect(mockClearApiKey).not.toHaveBeenCalled()
       expect(mockClearCredentials).not.toHaveBeenCalled()
     })
-
-    it('exits 0 when an expired JWT session is the only credential present', async () => {
-      mockGetAuthStatus.mockResolvedValue({
-        authenticated: false,
-        keyPrefix: null,
-        source: 'none',
-      })
-      mockLoadCredentials.mockResolvedValue({
-        accessToken: 'expired-token',
-        refreshToken: 'refresh',
-        expiresAt: Date.now() - 1000,
-        version: 2,
-      })
-
-      await expect(runCommand()).rejects.toThrow('process.exit(0)')
-
-      const output = consoleLogSpy.mock.calls.flat().join('\n')
-      expect(output).toContain('Not authenticated')
-    })
   })
 
   describe('JWT-only session (SMI-4402 regression — the reported login/logout mismatch)', () => {
@@ -140,6 +121,29 @@ describe('createLogoutCommand', () => {
         version: 2,
       })
       mockConfirm.mockResolvedValue(true)
+    })
+
+    // PR review finding (SMI-6235): logout must be able to clear a JWT
+    // session even when its access token has expired — an expired access
+    // token with a live refresh token is still a session to end, not
+    // "nothing to log out of". Distinct from the "not authenticated guard"
+    // describe above, which covers loadCredentials() returning null entirely.
+    it('proceeds to log out when the stored JWT session has an expired access token', async () => {
+      mockLoadCredentials.mockResolvedValue({
+        accessToken: 'expired-token',
+        refreshToken: 'refresh',
+        expiresAt: Date.now() - 1000,
+        version: 2,
+      })
+      mockClearApiKey.mockResolvedValue({ success: true, source: 'config file' })
+      mockClearCredentials.mockResolvedValue({ success: true, source: 'keyring and config file' })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).not.toContain('Not authenticated')
+      expect(output).toContain('Logged out')
+      expect(mockClearCredentials).toHaveBeenCalledOnce()
     })
 
     it('does not print "Not authenticated" and proceeds to log out', async () => {
@@ -214,6 +218,21 @@ describe('createLogoutCommand', () => {
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('Logged out')
       expect(output).toContain('config file')
+    })
+
+    // PR review finding (SMI-6235): each result's `source` is itself a
+    // composite string ("keyring and config file"), so deduping the two
+    // composite strings whole (instead of their individual parts) produced
+    // "keyring and config file and config file" whenever they overlapped.
+    it('does not repeat an overlapping source location across both results', async () => {
+      mockClearApiKey.mockResolvedValue({ success: true, source: 'keyring and config file' })
+      mockClearCredentials.mockResolvedValue({ success: true, source: 'config file' })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).not.toContain('config file and config file')
+      expect(output).toContain('keyring and config file')
     })
   })
 

--- a/packages/cli/src/commands/logout.test.ts
+++ b/packages/cli/src/commands/logout.test.ts
@@ -2,7 +2,9 @@
  * SMI-2715: Logout Command Tests
  *
  * Tests for `skillsmith logout` — not-authenticated guard, confirmation prompt,
- * successful logout, and partial failure (keyring error) handling.
+ * successful logout, partial failure (keyring error) handling, and JWT
+ * device-code session detection/clearing (SMI-4402 — the bug where `login`
+ * saw a live JWT session but `logout` only checked the legacy API key).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -14,6 +16,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 vi.mock('@skillsmith/core', () => ({
   getAuthStatus: vi.fn(),
   clearApiKey: vi.fn(),
+  loadCredentials: vi.fn(),
+  clearCredentials: vi.fn(),
 }))
 
 vi.mock('@inquirer/prompts', () => ({
@@ -25,11 +29,13 @@ vi.mock('@inquirer/prompts', () => ({
 // ---------------------------------------------------------------------------
 
 import { createLogoutCommand } from './logout.js'
-import { getAuthStatus, clearApiKey } from '@skillsmith/core'
+import { getAuthStatus, clearApiKey, loadCredentials, clearCredentials } from '@skillsmith/core'
 import { confirm } from '@inquirer/prompts'
 
 const mockGetAuthStatus = vi.mocked(getAuthStatus)
 const mockClearApiKey = vi.mocked(clearApiKey)
+const mockLoadCredentials = vi.mocked(loadCredentials)
+const mockClearCredentials = vi.mocked(clearCredentials)
 const mockConfirm = vi.mocked(confirm)
 
 // ---------------------------------------------------------------------------
@@ -59,6 +65,11 @@ describe('createLogoutCommand', () => {
       .mockImplementation((code?: string | number | null | undefined) => {
         throw new Error(`process.exit(${code ?? 0})`)
       })
+
+    // Default: no JWT session, and both clear calls succeed. Individual
+    // tests override these to exercise the JWT-only / partial-failure paths.
+    mockLoadCredentials.mockResolvedValue(null)
+    mockClearCredentials.mockResolvedValue({ success: true, source: 'config file' })
   })
 
   afterEach(() => {
@@ -77,18 +88,79 @@ describe('createLogoutCommand', () => {
   })
 
   describe('not authenticated guard', () => {
-    it('exits 0 when not authenticated', async () => {
+    it('exits 0 when not authenticated (no API key, no JWT session)', async () => {
       mockGetAuthStatus.mockResolvedValue({
         authenticated: false,
         keyPrefix: null,
         source: 'none',
       })
+      mockLoadCredentials.mockResolvedValue(null)
 
       await expect(runCommand()).rejects.toThrow('process.exit(0)')
 
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('Not authenticated')
       expect(mockClearApiKey).not.toHaveBeenCalled()
+      expect(mockClearCredentials).not.toHaveBeenCalled()
+    })
+
+    it('exits 0 when an expired JWT session is the only credential present', async () => {
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: false,
+        keyPrefix: null,
+        source: 'none',
+      })
+      mockLoadCredentials.mockResolvedValue({
+        accessToken: 'expired-token',
+        refreshToken: 'refresh',
+        expiresAt: Date.now() - 1000,
+        version: 2,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Not authenticated')
+    })
+  })
+
+  describe('JWT-only session (SMI-4402 regression — the reported login/logout mismatch)', () => {
+    beforeEach(() => {
+      // Exactly the state a device-code login leaves behind: no legacy API
+      // key, but a live, unexpired JWT session.
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: false,
+        keyPrefix: null,
+        source: 'none',
+      })
+      mockLoadCredentials.mockResolvedValue({
+        accessToken: 'live-access-token',
+        refreshToken: 'live-refresh-token',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        version: 2,
+      })
+      mockConfirm.mockResolvedValue(true)
+    })
+
+    it('does not print "Not authenticated" and proceeds to log out', async () => {
+      mockClearApiKey.mockResolvedValue({ success: true, source: 'config file' })
+      mockClearCredentials.mockResolvedValue({ success: true, source: 'keyring and config file' })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).not.toContain('Not authenticated')
+      expect(output).toContain('Logged out')
+    })
+
+    it('clears both the legacy API key store and the JWT session store', async () => {
+      mockClearApiKey.mockResolvedValue({ success: true, source: 'config file' })
+      mockClearCredentials.mockResolvedValue({ success: true, source: 'keyring and config file' })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      expect(mockClearApiKey).toHaveBeenCalledOnce()
+      expect(mockClearCredentials).toHaveBeenCalledOnce()
     })
   })
 
@@ -107,6 +179,7 @@ describe('createLogoutCommand', () => {
       await expect(runCommand()).rejects.toThrow('process.exit(0)')
 
       expect(mockClearApiKey).not.toHaveBeenCalled()
+      expect(mockClearCredentials).not.toHaveBeenCalled()
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('Cancelled')
     })
@@ -118,6 +191,7 @@ describe('createLogoutCommand', () => {
       await expect(runCommand()).rejects.toThrow('process.exit(0)')
 
       expect(mockClearApiKey).toHaveBeenCalledOnce()
+      expect(mockClearCredentials).toHaveBeenCalledOnce()
     })
   })
 
@@ -131,8 +205,9 @@ describe('createLogoutCommand', () => {
       mockConfirm.mockResolvedValue(true)
     })
 
-    it('prints success message with source', async () => {
+    it('prints success message with combined sources', async () => {
       mockClearApiKey.mockResolvedValue({ success: true, source: 'config file' })
+      mockClearCredentials.mockResolvedValue({ success: true, source: 'config file' })
 
       await expect(runCommand()).rejects.toThrow('process.exit(0)')
 
@@ -158,12 +233,32 @@ describe('createLogoutCommand', () => {
         source: 'config file',
         error: 'access denied',
       })
+      mockClearCredentials.mockResolvedValue({ success: true, source: 'config file' })
 
       await expect(runCommand()).rejects.toThrow('process.exit(0)')
 
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('access denied')
       expect(output).toContain('OS keyring')
+    })
+
+    it('warns about both keyring errors when both clears partially fail', async () => {
+      mockClearApiKey.mockResolvedValue({
+        success: false,
+        source: 'config file',
+        error: 'api key keyring error',
+      })
+      mockClearCredentials.mockResolvedValue({
+        success: false,
+        source: 'config file',
+        error: 'refresh token keyring error',
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('api key keyring error')
+      expect(output).toContain('refresh token keyring error')
     })
   })
 })

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -21,9 +21,18 @@ async function logoutActionImpl(): Promise<void> {
   // 1. Check whether there is anything to remove. getAuthStatus() only sees
   // the legacy API key (SMI-2714) — a JWT session (SMI-4402) needs its own
   // check via loadCredentials(), same as login.ts does.
+  //
+  // Unlike login.ts's "Date.now() < expiresAt" freshness gate (which decides
+  // whether to skip a fresh OAuth round-trip), logout only needs to know
+  // whether a JWT credential set exists at all: an expired access token
+  // with its refresh token still on file is a session `resolveFreshAccessToken()`
+  // would silently refresh on next use, and there is no locally-checkable way
+  // to know the refresh token itself has expired — gating on access-token
+  // freshness here would report "Not authenticated" for a still-clearable,
+  // still-functionally-live session (PR review finding, SMI-6235).
   const status = await getAuthStatus()
   const jwtSession = await loadCredentials()
-  const hasJwtSession = jwtSession !== null && Date.now() < jwtSession.expiresAt
+  const hasJwtSession = jwtSession !== null
   if (!status.authenticated && !hasJwtSession) {
     console.log('Not authenticated. Nothing to log out.')
     process.exit(0)
@@ -48,7 +57,11 @@ async function logoutActionImpl(): Promise<void> {
   const results = [apiKeyResult, jwtResult]
 
   if (results.every((r) => r.success)) {
-    const sources = [...new Set(results.map((r) => r.source))].join(' and ')
+    // Each result's `source` is itself a composite string (e.g. "keyring and
+    // config file"), so deduping the two composite strings directly can
+    // produce "keyring and config file and config file" when they overlap.
+    // Flatten to individual location names first (PR review finding, SMI-6235).
+    const sources = [...new Set(results.flatMap((r) => r.source.split(' and ')))].join(' and ')
     console.log(chalk.green(`Logged out. Credentials removed from ${sources}.`))
   } else {
     console.log(chalk.yellow('Logged out (config file cleared), but with keyring warnings:'))

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,31 +1,37 @@
 /**
- * Logout Command - Remove stored Skillsmith API key
+ * Logout Command - Remove stored Skillsmith credentials
  *
  * SMI-2715: CLI Login Device Flow
  *
  * Checks authentication status, prompts for confirmation, and clears
- * the stored API key from all storage locations (keyring + config file).
+ * stored credentials from all storage locations (keyring + config file) —
+ * both the legacy API key and a JWT device-code session (SMI-4402), since
+ * `login` accepts either and this command must be able to end either.
  */
 
 import { Command } from 'commander'
 import { confirm } from '@inquirer/prompts'
 import chalk from 'chalk'
-import { clearApiKey, getAuthStatus } from '@skillsmith/core'
+import { clearApiKey, clearCredentials, getAuthStatus, loadCredentials } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 
 // SMI-5128: extracted from inline .action() closure to a named function so
 // withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
 async function logoutActionImpl(): Promise<void> {
-  // 1. Check whether there is anything to remove
+  // 1. Check whether there is anything to remove. getAuthStatus() only sees
+  // the legacy API key (SMI-2714) — a JWT session (SMI-4402) needs its own
+  // check via loadCredentials(), same as login.ts does.
   const status = await getAuthStatus()
-  if (!status.authenticated) {
+  const jwtSession = await loadCredentials()
+  const hasJwtSession = jwtSession !== null && Date.now() < jwtSession.expiresAt
+  if (!status.authenticated && !hasJwtSession) {
     console.log('Not authenticated. Nothing to log out.')
     process.exit(0)
   }
 
   // 2. Confirm before removing
   const confirmed = await confirm({
-    message: 'Log out and remove stored API key?',
+    message: 'Log out and remove stored credentials?',
     default: false,
   })
 
@@ -34,18 +40,24 @@ async function logoutActionImpl(): Promise<void> {
     process.exit(0)
   }
 
-  // 3. Clear key from all storage locations
-  const result = await clearApiKey()
+  // 3. Clear both credential stores unconditionally — matches clearApiKey()'s
+  // own "always clear, even if nothing was there" pattern, and avoids leaving
+  // a stale credential behind from whichever flow the user didn't use.
+  const apiKeyResult = await clearApiKey()
+  const jwtResult = await clearCredentials()
+  const results = [apiKeyResult, jwtResult]
 
-  if (result.success) {
-    console.log(chalk.green(`Logged out. Key removed from ${result.source}.`))
+  if (results.every((r) => r.success)) {
+    const sources = [...new Set(results.map((r) => r.source))].join(' and ')
+    console.log(chalk.green(`Logged out. Credentials removed from ${sources}.`))
   } else {
-    console.log(
-      chalk.yellow(
-        `Logged out (config file cleared), but could not remove from keyring: ${result.error}`
-      )
-    )
-    console.log(chalk.dim('The key may still be stored in your OS keyring.'))
+    console.log(chalk.yellow('Logged out (config file cleared), but with keyring warnings:'))
+    for (const result of results) {
+      if (!result.success) {
+        console.log(chalk.yellow(`  Could not remove from keyring: ${result.error}`))
+      }
+    }
+    console.log(chalk.dim('Some credentials may still be stored in your OS keyring.'))
   }
   process.exit(0)
 }
@@ -60,5 +72,7 @@ export const logoutAction = withTelemetry(logoutActionImpl, {
  * Create the `skillsmith logout` command.
  */
 export function createLogoutCommand(): Command {
-  return new Command('logout').description('Remove stored Skillsmith API key').action(logoutAction)
+  return new Command('logout')
+    .description('Remove stored Skillsmith credentials')
+    .action(logoutAction)
 }

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -2,7 +2,9 @@
  * SMI-2715: Whoami Command Tests
  *
  * Tests for `skillsmith whoami` — unauthenticated state, each source label,
- * and masked key display.
+ * masked key display, and JWT device-code session detection (SMI-4402 — the
+ * bug where `whoami`/`logout` only checked the legacy API key and missed a
+ * live JWT session that `login` itself could see).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -13,6 +15,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('@skillsmith/core', () => ({
   getAuthStatus: vi.fn(),
+  loadCredentials: vi.fn(),
 }))
 
 // ---------------------------------------------------------------------------
@@ -20,9 +23,10 @@ vi.mock('@skillsmith/core', () => ({
 // ---------------------------------------------------------------------------
 
 import { createWhoamiCommand } from './whoami.js'
-import { getAuthStatus } from '@skillsmith/core'
+import { getAuthStatus, loadCredentials } from '@skillsmith/core'
 
 const mockGetAuthStatus = vi.mocked(getAuthStatus)
+const mockLoadCredentials = vi.mocked(loadCredentials)
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -51,6 +55,10 @@ describe('createWhoamiCommand', () => {
       .mockImplementation((code?: string | number | null | undefined) => {
         throw new Error(`process.exit(${code ?? 0})`)
       })
+
+    // Default: no JWT session, so existing legacy-API-key tests exercise the
+    // getAuthStatus() path unchanged. JWT-specific tests override this.
+    mockLoadCredentials.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -81,6 +89,50 @@ describe('createWhoamiCommand', () => {
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('Not authenticated')
       expect(output).toContain('skillsmith login')
+    })
+  })
+
+  describe('JWT session state (SMI-4402 regression)', () => {
+    it('shows device-code session when a live JWT exists, even with no API key configured', async () => {
+      // Exactly the state a device-code login leaves behind: getAuthStatus()
+      // (legacy API key only) sees nothing, but a live JWT session exists.
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: false,
+        keyPrefix: null,
+        source: 'none',
+      })
+      mockLoadCredentials.mockResolvedValue({
+        accessToken: 'live-access-token',
+        refreshToken: 'live-refresh-token',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        version: 2,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).not.toContain('Not authenticated')
+      expect(output).toContain('device-code login')
+    })
+
+    it('falls through to the legacy API-key check when the JWT session is expired', async () => {
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: true,
+        keyPrefix: 'sk_live_xxxx',
+        source: 'config',
+      })
+      mockLoadCredentials.mockResolvedValue({
+        accessToken: 'expired-token',
+        refreshToken: 'refresh',
+        expiresAt: Date.now() - 1000,
+        version: 2,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).not.toContain('device-code login')
+      expect(output).toContain('sk_live_xxxx...')
     })
   })
 

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -115,7 +115,12 @@ describe('createWhoamiCommand', () => {
       expect(output).toContain('device-code login')
     })
 
-    it('falls through to the legacy API-key check when the JWT session is expired', async () => {
+    // PR review finding (SMI-6235): an expired access token with a live
+    // refresh token on file is still shown as a device-code session — it is
+    // a session resolveFreshAccessToken() refreshes transparently on next
+    // use, not one to report as absent. Distinct from the "no JWT session at
+    // all" case (loadCredentials() null), which does fall through below.
+    it('still shows device-code session when the access token has expired but a refresh token is on file', async () => {
       mockGetAuthStatus.mockResolvedValue({
         authenticated: true,
         keyPrefix: 'sk_live_xxxx',
@@ -127,6 +132,22 @@ describe('createWhoamiCommand', () => {
         expiresAt: Date.now() - 1000,
         version: 2,
       })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('device-code login')
+      expect(output).toContain('expired')
+      expect(output).not.toContain('sk_live_xxxx...')
+    })
+
+    it('falls through to the legacy API-key check when there is no JWT session at all', async () => {
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: true,
+        keyPrefix: 'sk_live_xxxx',
+        source: 'config',
+      })
+      mockLoadCredentials.mockResolvedValue(null)
 
       await expect(runCommand()).rejects.toThrow('process.exit(0)')
 

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -3,13 +3,15 @@
  *
  * SMI-2715: CLI Login Device Flow
  *
- * Displays the masked API key and the storage source so users can
- * understand where their credentials are being read from.
+ * Displays the masked API key (or JWT session expiry) and the storage
+ * source so users can understand where their credentials are being read
+ * from. Checks a JWT device-code session (SMI-4402) via loadCredentials()
+ * first — getAuthStatus() alone only sees the legacy API key.
  */
 
 import { Command } from 'commander'
 import chalk from 'chalk'
-import { getAuthStatus } from '@skillsmith/core'
+import { getAuthStatus, loadCredentials } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 
 /** Human-readable labels for each credential source */
@@ -22,6 +24,14 @@ const SOURCE_LABELS: Record<string, string> = {
 
 // SMI-5040: extracted from inline .action() closure for withTelemetry wrap.
 async function whoamiActionImpl(): Promise<void> {
+  const jwtSession = await loadCredentials()
+  if (jwtSession && Date.now() < jwtSession.expiresAt) {
+    console.log(chalk.bold('Skillsmith CLI'))
+    console.log(chalk.dim('  Session: ') + chalk.cyan('device-code login'))
+    console.log(chalk.dim('  Expires: ') + new Date(jwtSession.expiresAt).toLocaleString())
+    process.exit(0)
+  }
+
   const status = await getAuthStatus()
 
   if (!status.authenticated || !status.keyPrefix) {

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -24,11 +24,24 @@ const SOURCE_LABELS: Record<string, string> = {
 
 // SMI-5040: extracted from inline .action() closure for withTelemetry wrap.
 async function whoamiActionImpl(): Promise<void> {
+  // loadCredentials() returning non-null already means a resolvable refresh
+  // token is on file — don't additionally gate on access-token freshness
+  // (Date.now() < expiresAt): an expired access token with a live refresh
+  // token is a session resolveFreshAccessToken() refreshes transparently on
+  // next use, so reporting it as "not authenticated" here would be wrong
+  // (PR review finding, SMI-6235 — same root issue as logout.ts's gate).
   const jwtSession = await loadCredentials()
-  if (jwtSession && Date.now() < jwtSession.expiresAt) {
+  if (jwtSession) {
     console.log(chalk.bold('Skillsmith CLI'))
     console.log(chalk.dim('  Session: ') + chalk.cyan('device-code login'))
-    console.log(chalk.dim('  Expires: ') + new Date(jwtSession.expiresAt).toLocaleString())
+    const expired = Date.now() >= jwtSession.expiresAt
+    const expiresLabel = new Date(jwtSession.expiresAt).toLocaleString()
+    console.log(
+      chalk.dim('  Access token: ') +
+        (expired
+          ? chalk.yellow(`expired ${expiresLabel} (refreshes automatically on next use)`)
+          : chalk.green(`valid until ${expiresLabel}`))
+    )
     process.exit(0)
   }
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: new `clearCredentials()` export (`config/token-credentials.ts`) clears a stored
+  JWT device-code session (access/refresh token, expiry) from both the config file and the
+  OS keyring `refresh-token` entry — previously there was no way to end a JWT session at all;
+  `clearApiKey()` only ever touched the separate legacy `apiKey` field. (SMI-6235)
 - **Docs**: README's framing sentence updated from the "lifecycle layer" tagline to a plain
   descriptive sentence ("a registry for sharing, scanning, and tracking agent skills across
   teams") as part of the site-wide positioning reframe. Wording-only. (SMI-6194)

--- a/packages/core/src/config/token-credentials.test.ts
+++ b/packages/core/src/config/token-credentials.test.ts
@@ -5,6 +5,9 @@
  * TC-3: loadCredentials → returns TokenCredentials with keyring token
  * TC-4: refreshAccessToken → exchanges refresh token, returns new creds
  * TC-5: refreshAccessToken → returns null on non-2xx response
+ * TC-6: clearCredentials → deletes keyring entry + strips config fields
+ * TC-7: clearCredentials → reports partial failure on keyring error
+ * TC-8: clearCredentials → preserves apiKey and other unrelated fields
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -30,6 +33,7 @@ vi.mock('../api/utils.js', () => ({
 const keytarDefault: any = {
   setPassword: vi.fn(),
   getPassword: vi.fn(),
+  deletePassword: vi.fn(),
 }
 vi.mock('@isaacs/keytar', () => ({ default: keytarDefault }))
 
@@ -44,6 +48,7 @@ describe('token-credentials', () => {
     vi.mocked(readFileSync).mockReturnValue('{}')
     keytarDefault.setPassword.mockResolvedValue(undefined)
     keytarDefault.getPassword.mockResolvedValue(null)
+    keytarDefault.deletePassword.mockResolvedValue(true)
   })
 
   it('TC-1: storeCredentials writes version:2 schema to config file', async () => {
@@ -123,5 +128,70 @@ describe('token-credentials', () => {
     const { refreshAccessToken } = await import('./token-credentials.js')
     const result = await refreshAccessToken('expired_rt')
     expect(result).toBeNull()
+  })
+
+  it('TC-6: clearCredentials deletes keyring entry and strips config fields', async () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        accessToken: 'at_stored',
+        refreshToken: 'rt_stored',
+        expiresAt: 9999999999000,
+        version: 2,
+      })
+    )
+
+    const { clearCredentials } = await import('./token-credentials.js')
+    const result = await clearCredentials()
+
+    expect(result.success).toBe(true)
+    expect(result.source).toContain('keyring')
+    expect(result.source).toContain('config file')
+    expect(keytarDefault.deletePassword).toHaveBeenCalledWith('skillsmith-cli', 'refresh-token')
+
+    const writeCall = vi.mocked(writeFileSync).mock.calls[0]
+    const written = JSON.parse(writeCall[1] as string) as Record<string, unknown>
+    expect(written.accessToken).toBeUndefined()
+    expect(written.refreshToken).toBeUndefined()
+    expect(written.expiresAt).toBeUndefined()
+    expect(written.version).toBeUndefined()
+  })
+
+  it('TC-7: clearCredentials reports partial failure on keyring error', async () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ accessToken: 'at_stored', expiresAt: 9999999999000, version: 2 })
+    )
+    keytarDefault.deletePassword.mockRejectedValue(new Error('keyring locked'))
+
+    const { clearCredentials } = await import('./token-credentials.js')
+    const result = await clearCredentials()
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('keyring locked')
+    // Config file is still cleared even when the keyring delete fails.
+    expect(writeFileSync).toHaveBeenCalled()
+  })
+
+  it('TC-8: clearCredentials preserves apiKey and other unrelated fields', async () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        apiKey: 'sk_live_legacy',
+        accessToken: 'at_stored',
+        refreshToken: 'rt_stored',
+        expiresAt: 9999999999000,
+        version: 2,
+        someOtherField: 'keep-me',
+      })
+    )
+
+    const { clearCredentials } = await import('./token-credentials.js')
+    await clearCredentials()
+
+    const writeCall = vi.mocked(writeFileSync).mock.calls[0]
+    const written = JSON.parse(writeCall[1] as string) as Record<string, unknown>
+    expect(written.apiKey).toBe('sk_live_legacy')
+    expect(written.someOtherField).toBe('keep-me')
   })
 })

--- a/packages/core/src/config/token-credentials.test.ts
+++ b/packages/core/src/config/token-credentials.test.ts
@@ -25,6 +25,17 @@ vi.mock('os', () => ({ homedir: vi.fn(() => '/mock-home') }))
 
 vi.mock('./index.js', () => ({ ensureConfigDir: vi.fn() }))
 
+// clearCredentials() guards its config-file write with the shared
+// cross-process lock + atomic rename (SMI-5531) — mock both so tests never
+// touch the real filesystem via node:fs (a bare `vi.mock('fs', ...)` above
+// does not intercept 'node:fs' imports, which config-atomic-write.ts uses).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const configAtomicWrite: any = {
+  acquireConfigLock: vi.fn(() => vi.fn()),
+  atomicWriteFile: vi.fn(),
+}
+vi.mock('./config-atomic-write.js', () => configAtomicWrite)
+
 vi.mock('../api/utils.js', () => ({
   PRODUCTION_ANON_KEY: 'test-anon-key',
 }))
@@ -148,8 +159,12 @@ describe('token-credentials', () => {
     expect(result.source).toContain('keyring')
     expect(result.source).toContain('config file')
     expect(keytarDefault.deletePassword).toHaveBeenCalledWith('skillsmith-cli', 'refresh-token')
+    expect(configAtomicWrite.acquireConfigLock).toHaveBeenCalledOnce()
+    // The lock's release function must be called exactly once (finally block).
+    const releaseFn = configAtomicWrite.acquireConfigLock.mock.results[0].value as () => void
+    expect(releaseFn).toHaveBeenCalledOnce()
 
-    const writeCall = vi.mocked(writeFileSync).mock.calls[0]
+    const writeCall = configAtomicWrite.atomicWriteFile.mock.calls[0]
     const written = JSON.parse(writeCall[1] as string) as Record<string, unknown>
     expect(written.accessToken).toBeUndefined()
     expect(written.refreshToken).toBeUndefined()
@@ -170,7 +185,7 @@ describe('token-credentials', () => {
     expect(result.success).toBe(false)
     expect(result.error).toBe('keyring locked')
     // Config file is still cleared even when the keyring delete fails.
-    expect(writeFileSync).toHaveBeenCalled()
+    expect(configAtomicWrite.atomicWriteFile).toHaveBeenCalled()
   })
 
   it('TC-8: clearCredentials preserves apiKey and other unrelated fields', async () => {
@@ -189,7 +204,7 @@ describe('token-credentials', () => {
     const { clearCredentials } = await import('./token-credentials.js')
     await clearCredentials()
 
-    const writeCall = vi.mocked(writeFileSync).mock.calls[0]
+    const writeCall = configAtomicWrite.atomicWriteFile.mock.calls[0]
     const written = JSON.parse(writeCall[1] as string) as Record<string, unknown>
     expect(written.apiKey).toBe('sk_live_legacy')
     expect(written.someOtherField).toBe('keep-me')

--- a/packages/core/src/config/token-credentials.ts
+++ b/packages/core/src/config/token-credentials.ts
@@ -5,6 +5,7 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { existsSync, readFileSync, writeFileSync, chmodSync } from 'fs'
 import { ensureConfigDir } from './index.js'
+import { acquireConfigLock, atomicWriteFile } from './config-atomic-write.js'
 import { PRODUCTION_ANON_KEY } from '../api/utils.js'
 
 const CONFIG_DIR = '.skillsmith'
@@ -138,6 +139,12 @@ export async function loadCredentials(): Promise<TokenCredentials | null> {
  * path since the two credential schemes live in different fields/keyring
  * accounts (SMI-4402 v2 schema vs. the pre-existing apiKey flow).
  *
+ * The config-file read-modify-write is guarded by the same cross-process
+ * lock + atomic rename `saveConfig()` uses (config-atomic-write.ts,
+ * SMI-5531) — a bare readConfigFile()/writeFileSync() here could lose a
+ * concurrent writer's update between the read and the write (PR review
+ * finding, SMI-6235).
+ *
  * @returns Result indicating which storage locations were cleared and any errors
  */
 export async function clearCredentials(): Promise<{
@@ -161,12 +168,19 @@ export async function clearCredentials(): Promise<{
   }
 
   // Always clear from config file — never leave stale JWT fields behind
-  const existing = readConfigFile()
-  delete existing.accessToken
-  delete existing.refreshToken
-  delete existing.expiresAt
-  delete existing.version
-  writeConfigFile(existing)
+  const configPath = getConfigPath()
+  ensureConfigDir()
+  const release = acquireConfigLock(configPath)
+  try {
+    const existing = readConfigFile()
+    delete existing.accessToken
+    delete existing.refreshToken
+    delete existing.expiresAt
+    delete existing.version
+    atomicWriteFile(configPath, JSON.stringify(existing, null, 2), 0o600)
+  } finally {
+    release()
+  }
   sources.push('config file')
 
   if (keyringError) {

--- a/packages/core/src/config/token-credentials.ts
+++ b/packages/core/src/config/token-credentials.ts
@@ -61,17 +61,17 @@ function writeConfigFile(data: StoredConfig): void {
   }
 }
 
-async function getKeytar(): Promise<{
+interface KeytarLike {
   setPassword(s: string, a: string, p: string): Promise<void>
   getPassword(s: string, a: string): Promise<string | null>
-} | null> {
+  deletePassword(s: string, a: string): Promise<boolean>
+}
+
+async function getKeytar(): Promise<KeytarLike | null> {
   try {
     // @ts-expect-error — optional dep, no type declarations in core
     const mod = (await import('@isaacs/keytar')) as { default?: unknown }
-    return (mod.default ?? mod) as {
-      setPassword(s: string, a: string, p: string): Promise<void>
-      getPassword(s: string, a: string): Promise<string | null>
-    }
+    return (mod.default ?? mod) as KeytarLike
   } catch {
     return null
   }
@@ -128,6 +128,58 @@ export async function loadCredentials(): Promise<TokenCredentials | null> {
     expiresAt: config.expiresAt as number,
     apiKey: config.apiKey,
     version: 2,
+  }
+}
+
+/**
+ * Clear the stored JWT session (access token, refresh token, expiry) from
+ * all storage locations. Mirrors clearApiKey() in config/index.ts, which
+ * only handles the legacy apiKey field — a JWT session needs its own clear
+ * path since the two credential schemes live in different fields/keyring
+ * accounts (SMI-4402 v2 schema vs. the pre-existing apiKey flow).
+ *
+ * @returns Result indicating which storage locations were cleared and any errors
+ */
+export async function clearCredentials(): Promise<{
+  success: boolean
+  source: string
+  error?: string
+}> {
+  const sources: string[] = []
+  let keyringError: string | undefined
+
+  const keytar = await getKeytar()
+  if (keytar) {
+    try {
+      const deleted = await keytar.deletePassword(KEYTAR_SERVICE, KEYTAR_ACCOUNT_REFRESH)
+      if (deleted) {
+        sources.push('keyring')
+      }
+    } catch (err) {
+      keyringError = err instanceof Error ? err.message : String(err)
+    }
+  }
+
+  // Always clear from config file — never leave stale JWT fields behind
+  const existing = readConfigFile()
+  delete existing.accessToken
+  delete existing.refreshToken
+  delete existing.expiresAt
+  delete existing.version
+  writeConfigFile(existing)
+  sources.push('config file')
+
+  if (keyringError) {
+    return {
+      success: false,
+      source: sources.join(' and '),
+      error: keyringError,
+    }
+  }
+
+  return {
+    success: true,
+    source: sources.join(' and '),
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -292,6 +292,7 @@ export {
 export {
   storeCredentials,
   loadCredentials,
+  clearCredentials,
   refreshAccessToken,
   type TokenCredentials,
 } from './config/token-credentials.js'


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a stuck loop where `skillsmith login` said "Already authenticated" while the very next `skillsmith logout` said "Not authenticated. Nothing to log out." — with no way to actually end the session. `logout` and `whoami` now correctly detect a JWT device-code session, the same way `login` already does, and `logout` clears it.

**Quality bar:** Root cause traced by reading the actual source (not assumed), with a sibling-implementation sweep confirming no third call site shares the bug. Full `core`+`cli` test suite green (6,722 tests), including a new test that reproduces the exact reported command sequence as a regression case. Build/lint/typecheck/`audit:standards` all clean. Governance code review completed and filed.

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

**Root cause**: `login` checks `loadCredentials()` (the SMI-4402 JWT device-code schema), but `logout`/`whoami` checked only `getAuthStatus()` (the legacy SMI-2714 API-key path). A device-code login has no `apiKey` field, so `getAuthStatus()` correctly-by-its-own-logic reported unauthenticated even with a live JWT session — and even if it hadn't, `clearApiKey()` never touched the JWT fields, so there was no way to log out of one at all.

**Changes**:
- `packages/core/src/config/token-credentials.ts` — new `clearCredentials()`, symmetric with `clearApiKey()`: clears the JWT session from the config file + keyring `refresh-token` entry.
- `packages/core/src/index.ts` — exports `clearCredentials`.
- `packages/cli/src/commands/logout.ts` — checks `loadCredentials()` alongside `getAuthStatus()`; clears both credential stores on confirm.
- `packages/cli/src/commands/whoami.ts` — checks `loadCredentials()` first, reporting a live JWT session with its expiry.
- Test coverage: `token-credentials.test.ts` (TC-6/7/8), `logout.test.ts`, `whoami.test.ts` — including an explicit SMI-4402 regression case.
- `packages/core/CHANGELOG.md` / `packages/cli/CHANGELOG.md` — Unreleased entries.
- `docs/internal` — governance code review report (`docs/internal/code_review/2026-08-27-smi6235-cli-logout-jwt-session-review.md`) + index update + pointer bump.

Closes SMI-6235.