### PR TITLE
chore(security): allowlist icm-shipwright sensitive_path false positive

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -101,6 +101,15 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-08-13",
       "expiresAt": "2026-11-11"
+    },
+    {
+      "skillId": "github/binnukarunakar/icm-shipwright",
+      "findingType": "sensitive_path",
+      "messagePattern": "secrets?",
+      "reason": "Workspace-safety tool ('Make AI-agent workspaces safe to run and ship... with secret/PII guardrails and a 17-check lint'). Fetched all 33 files in the repo tree and found zero literal 'secret(s)/' matches in any file content — the only hit anywhere is the repo's own GitHub description phrase 'secret/PII guardrails', which the bare-keyword sensitive_path regex matches case-insensitively. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills (description advertises a security/credential-handling feature). Triaged 2026-08-27 under SMI-6237 — closes GH #2059 (7 consecutive Weekly Security Scan failures since 2026-07-26, all the same skill/finding).",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-08-27",
+      "expiresAt": "2026-11-25"
     }
   ]
 }

--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -105,8 +105,8 @@
     {
       "skillId": "github/binnukarunakar/icm-shipwright",
       "findingType": "sensitive_path",
-      "messagePattern": "secrets?",
-      "reason": "Workspace-safety tool ('Make AI-agent workspaces safe to run and ship... with secret/PII guardrails and a 17-check lint'). Fetched all 33 files in the repo tree and found zero literal 'secret(s)/' matches in any file content — the only hit anywhere is the repo's own GitHub description phrase 'secret/PII guardrails', which the bare-keyword sensitive_path regex matches case-insensitively. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills (description advertises a security/credential-handling feature). Triaged 2026-08-27 under SMI-6237 — closes GH #2059 (7 consecutive Weekly Security Scan failures since 2026-07-26, all the same skill/finding).",
+      "messagePattern": "secrets\\?\\\\\\/\\[a-z0-9",
+      "reason": "Workspace-safety tool ('Make AI-agent workspaces safe to run and ship... with secret/PII guardrails and a 17-check lint'). Fetched all 33 files in the repo tree and found zero literal 'secret(s)/' matches in any file content — the only hit anywhere is the repo's own GitHub description phrase 'secret/PII guardrails', which the bare-keyword sensitive_path regex matches case-insensitively. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills (description advertises a security/credential-handling feature). messagePattern is scoped to the path-form pattern's echoed source only (SENSITIVE_PATH_PATTERNS' \\bsecrets?\\/[a-z0-9_.-]+, not the sibling assignment-form \\bsecrets?\\s*[:=] — both feed sensitive_path, and a bare 'secrets?' pattern here would also suppress a real future assignment-form secret leak in this skill). Triaged 2026-08-27 under SMI-6237 — closes GH #2059 (7 consecutive Weekly Security Scan failures since 2026-07-26, all the same skill/finding).",
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-08-27",
       "expiresAt": "2026-11-25"

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -419,11 +419,16 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // (jailbreak, data_exfiltration findingTypes) since both bare-keyword
   // patterns trip on the same description line — same self-describing-
   // security-tool FP class as RENJI04/prompt-injection-auditor.
+  // SMI-6237 (2026-08-27): binnukarunakar/icm-shipwright added — workspace-
+  // safety tool whose repo description says 'secret/PII guardrails'; same
+  // description-advertises-a-security-feature FP class as skill-protocol-rs
+  // and qpay-skills. Closes GH #2059 (7 straight Weekly Security Scan
+  // failures on this exact skill/finding since 2026-07-26).
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(11)
+    expect(parsed.allowlist.length).toBe(12)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
@@ -431,6 +436,7 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
         'github/RENJI04/prompt-injection-auditor',
         'github/RobinGase/skill-protocol-rs',
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',
+        'github/binnukarunakar/icm-shipwright',
         'github/dokind/qpay-skills',
         'github/fitz2882/narthex',
         'github/fitz2882/narthex',


### PR DESCRIPTION
## Business Summary

**What shipped:** `data/skills-security-allowlist.json` now allowlists `github/binnukarunakar/icm-shipwright`'s `sensitive_path` finding — a false positive that's been failing the Weekly Security Scan gate every week for a month.

**Quality bar:** Verdict confirmed, not guessed — fetched all 33 files in the flagged skill's GitHub repo and found zero literal matches for the triggering pattern anywhere in content; the only hit is the repo's own description ("secret/PII guardrails"), the same class of false positive already covered by two existing allowlist entries. Post-commit governance review found and fixed one Medium finding: the initial `messagePattern` (matching established precedent) also matched a sibling `sensitive_path` pattern sharing the same finding type, which would have silently suppressed a real future secret leak in this skill — tightened and verified with a scripted check. `packages/core/tests/skill-scanner/allowlist.test.ts`'s manifest test updated and passing (24/24), lint/format/typecheck/security suite all green in pre-push.

**Net result:** Fully shipped. Once merged, I'll close [smith-horn/skillsmith#2059](https://github.com/smith-horn/skillsmith/issues/2059) — the tracking issue that's accumulated 7 weekly failure reports with no resolution — and confirm the next Weekly Security Scan run passes.

---

## Technical detail

- `data/skills-security-allowlist.json`: new entry, `skillId: github/binnukarunakar/icm-shipwright`, `findingType: sensitive_path`, `messagePattern` scoped to match only the path-form `SENSITIVE_PATH_PATTERNS` entry's echoed source (not the sibling assignment-form pattern that shares the same finding type), 90-day expiry per the file's own invariant (`reviewedAt: 2026-08-27`, `expiresAt: 2026-11-25`).
- `packages/core/tests/skill-scanner/allowlist.test.ts`: bumped the "ship-it sanity" manifest test's expected count (11→12) and skillId list, plus a changelog comment matching the file's existing per-entry documentation convention.
- Root cause: `SecurityScanner.scanners.ts:103` builds the finding message as `Reference to potentially sensitive path: ${pattern.source}` — it embeds the regex source, not the matched text, so I had to fetch the actual skill content via `gh api` to find what tripped it, since the CI log alone couldn't show it.
- Code review report: `docs/internal/code_review/2026-08-27-icm-shipwright-allowlist-fp.md` (merged smith-horn/skillsmith-docs#889).
- Linear: SMI-6237.

`[skip-impl-check]` — this PR is a security-allowlist data entry + its matching test-manifest update; there is no `packages/*/src/**` change to verify against the SMI reference.
