### PR TITLE
chore(release): bump core, mcp-server, cli, vscode, enterprise (patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34034,7 +34034,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -34065,8 +34065,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.12.0",
-        "@skillsmith/mcp-server": "^0.7.11",
+        "@skillsmith/core": "^0.12.1",
+        "@skillsmith/mcp-server": "^0.7.12",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -34075,7 +34075,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@smith-horn/enterprise": "^0.3.7"
+        "@smith-horn/enterprise": "^0.3.8"
       },
       "peerDependenciesMeta": {
         "@smith-horn/enterprise": {
@@ -34184,7 +34184,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34248,7 +34248,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@ruvector/core": "0.1.30",
-        "@skillsmith/core": "^0.12.0",
+        "@skillsmith/core": "^0.12.1",
         "better-sqlite3": "11.10.0",
         "glob": "11.1.0",
         "minimatch": "10.2.6",
@@ -34293,18 +34293,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-        "@skillsmith/core": "^0.12.0",
+        "@skillsmith/core": "^0.12.1",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.11",
+        "@skillsmith/mcp-server": "^0.7.12",
         "@smithy/config-resolver": "4.6.16",
         "@smithy/core": "3.31.1",
         "@smithy/middleware-endpoint": "4.6.16",
@@ -34319,7 +34319,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.11"
+        "@skillsmith/mcp-server": "^0.7.12"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34355,12 +34355,12 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.12.0",
+        "@skillsmith/core": "^0.12.1",
         "@supabase/supabase-js": "2.112.2",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
@@ -34410,7 +34410,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.8
+
+- **Fix**: logout/whoami now detect JWT device-code sessions (#2578)
 - **Fix**: `skillsmith logout` and `skillsmith whoami` now detect a JWT device-code session
   (`skillsmith login`'s default flow, SMI-4402) — previously they only checked the legacy
   API-key store, so `login` would report "Already authenticated" while `logout` immediately

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills 
 
 ## Contents
 
-- [What's New](#whats-new-in-v087)
+- [What's New](#whats-new-in-v088)
 - [Installation](#installation)
 - [Commands](#commands)
   - [inventory](#inventory)
@@ -16,7 +16,7 @@ Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills 
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.7
+## What's New in v0.8.8
 
 - **Multi-client targeting fixed across the board**: `install`, `list`, `remove`, `update`, `sync`, and `search -i`'s install action now all honor `SKILLSMITH_CLIENT`/`--client` consistently — previously several of these silently acted on the Claude Code directory regardless of the flag or env var.
 - **`update` no longer fails after a fresh install**: now resolves the installed skill's registry source from the manifest `install` already writes, instead of a dead-code path that could never find it.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
   "bin": {
@@ -39,14 +39,14 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.12.0",
-    "@skillsmith/mcp-server": "^0.7.11",
+    "@skillsmith/core": "^0.12.1",
+    "@skillsmith/mcp-server": "^0.7.12",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@smith-horn/enterprise": "^0.3.7"
+    "@smith-horn/enterprise": "^0.3.8"
   },
   "peerDependenciesMeta": {
     "@smith-horn/enterprise": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.12.1
+
+- **Fix**: logout/whoami now detect JWT device-code sessions (#2578)
 - **Fix**: new `clearCredentials()` export (`config/token-credentials.ts`) clears a stored
   JWT device-code session (access/refresh token, expiry) from both the config file and the
   OS keyring `refresh-token` entry — previously there was no way to end a JWT session at all;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,13 +6,13 @@ Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills 
 
 ## Contents
 
-- [What's New](#whats-new-in-v0120)
+- [What's New](#whats-new-in-v0121)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.12.0
+## What's New in v0.12.1
 
 - **New `resolveSessionTier` client** (`sync/license-status-client.ts`): authenticates a stored `skillsmith login` session against `/license-status` so the MCP server can resolve a real subscription tier without a separately-configured `SKILLSMITH_API_KEY`, instead of silently falling back to `community`.
 - **Scanner: bundled-file scan expanded to operational code** (Gap 8 of the ClawHavoc remediation): the indexer now reads `scripts/`, `src/`, and `bin/` alongside `SKILL.md`, closing a blind spot where a backdoor buried mid-function in working operational code was structurally invisible.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.12.0'
+export const VERSION = '0.12.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/doc-retrieval-mcp/package.json
+++ b/packages/doc-retrieval-mcp/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@ruvector/core": "0.1.30",
-    "@skillsmith/core": "^0.12.0",
+    "@skillsmith/core": "^0.12.1",
     "better-sqlite3": "11.10.0",
     "glob": "11.1.0",
     "minimatch": "10.2.6",

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.8
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.3.7).
 - **Docs**: README's framing sentence updated from "Enterprise features for Skillsmith, a
   lifecycle layer for agent skills across teams" to "...a registry for sharing, scanning, and
   tracking agent skills across teams" as part of the site-wide positioning reframe.

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-    "@skillsmith/core": "^0.12.0",
+    "@skillsmith/core": "^0.12.1",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.11",
+    "@skillsmith/mcp-server": "^0.7.12",
     "@smithy/config-resolver": "4.6.16",
     "@smithy/core": "3.31.1",
     "@smithy/middleware-endpoint": "4.6.16",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.11"
+    "@skillsmith/mcp-server": "^0.7.12"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.12
+
+- **Feature**: live RBAC service, grant-write RPCs, permission-gated website UI (SMI-6203) (#2586)
+- **Feature**: add team_permission_grants RBAC schema + widen approval-gate RLS seam (SMI-6202) (#2577)
 - **Feature**: `rbac_manage`/`rbac_assign_role`/`rbac_create_policy` are now backed by a real
   Supabase RBACService (`rbac-tools.live.ts`) instead of the in-memory stub, on the caller's own
   signed-in JWT — never the shared team license key or service-role. `list_roles`/`get_role` now

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server for agent skill publishing, installation, an
 
 Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills across teams.
 
-## What's New in v0.7.11
+## What's New in v0.7.12
 
 - **Fix: 0.7.10 was uninstallable** — it imported `@skillsmith/core` exports (`SessionTierAuthError`, `SessionTierTransientError`, `resolveSessionTier`, `getApiBaseUrl`) that only shipped in core 0.12.0, but this package's own dependency floor still allowed the older, broken-for-this-purpose 0.11.7. The `@skillsmith/core` dependency is now `^0.12.0` (SMI-6143). No other changes in this release.
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.12.0",
+    "@skillsmith/core": "^0.12.1",
     "@supabase/supabase-js": "2.112.2",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.11",
+  "version": "0.7.12",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": ["claude-code", "agent-skills", "autonomous-agents", "openclaw"]
@@ -17,7 +17,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -116,7 +116,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.11'
+const PACKAGE_VERSION = '0.7.12'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.8
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.7.7).
 - **Docs**: README's framing sentence updated from the "lifecycle layer" tagline to a plain
   descriptive sentence ("a registry for sharing, scanning, and tracking agent skills across
   teams") as part of the site-wide positioning reframe. Wording-only. (SMI-6194)

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
## Summary

Weekly-cadence release cut — `[Unreleased]` had grown large across `core` and `cli`, and the SMI-6235 login/logout fix (merged in #2578) needs to reach npm before it's usable outside this repo.

- `@skillsmith/core` 0.12.0 → 0.12.1
- `@skillsmith/mcp-server` 0.7.11 → 0.7.12
- `@skillsmith/cli` 0.8.7 → 0.8.8
- `skillsmith-vscode` 0.7.7 → 0.7.8
- `@smith-horn/enterprise` 0.3.7 → 0.3.8

Generated by `scripts/prepare-release.ts --all=patch`: version bumps, changelog entries moved out of `[Unreleased]`, README "what's new" sync.

## Test plan

- [x] `npx tsx scripts/prepare-release.ts --dry-run --all=patch` — npm collision guard passed for all 5 packages
- [x] `turbo run build --filter='!@skillsmith/website'` — all 6 publishable packages build clean on the bumped versions
- [x] `npm run lint` — clean
- [x] Pre-push hook (security, format, full test suite) — passed

## Next step

After merge: `gh workflow run publish.yml -f dry_run=false`, then watch the run and verify `@skillsmith/cli@0.8.8` on npm before the reinstall to fully close out the login/logout follow-up.
