### PR TITLE
fix(website): SMI-6252 correct RBAC owner-exemption claim

### DIFF
--- a/packages/website/src/content/blog/team-setup-architecture.md
+++ b/packages/website/src/content/blog/team-setup-architecture.md
@@ -67,7 +67,7 @@ The CLI is the terminal door, for anyone scripting or working by hand. The MCP s
 If you're the one signing off on this for your team, here's the short version of what to confirm before you call setup done:
 
 - **Tier.** A workspace itself, with membership, is Team-tier and above. Role-based permissions, private publish, and the audit log are Enterprise-tier specifically, not included at Team. A Community or Individual account can search and install, but doesn't get a workspace to manage at all.
-- **Who owns admin.** Someone on your team needs a role with `team:manage_rbac` before anyone else's permissions can be set up at all. Decide who that is before day one, not during it.
+- **Who owns admin.** Whoever's account created the workspace is its owner, and an owner already has every permission, automatically, no setup required. If you want a second person handling day-to-day approvals without owner access to everything, the owner grants them `team:manage_rbac` explicitly. Decide who the owner is before day one, since that role can't be handed off through the permission system itself.
 - **What a security reviewer will ask for.** The audit log (every approve, deprecate, and role change, timestamped) and the trust-tier legend on anything pulled from the public registry. Both exist today and neither needs to be built.
 - **What "done" looks like.** One admin logged in, a handful of teammates invited and given roles, one internally-written skill published and approved into the private registry, and everyone's laptop reporting into the same dashboard. That's a team fully set up, not a pilot.
 


### PR DESCRIPTION
## Business Summary

**What shipped:** A one-sentence correction to the just-merged team-setup-architecture blog post's evaluator checklist. It implied every permission, including the workspace owner's own, needs an explicit `team:manage_rbac` grant. In reality the owner has every permission automatically (an "owner-exemption" branch in `has_team_permission()`), and only a second person handling day-to-day approvals needs an explicit grant from the owner.

**Quality bar:** Caught during the post-merge governance retro on PR #2592, not by a reader — verified against `set_team_member_role`'s explicit "cannot change the team owner's role" guard and two migrations noting ownership transfer is a separate, not-yet-built RPC, before writing the correction.

**Net result:** Fully shipped. One-line content fix, no new scope.

---

## Technical detail

- `packages/website/src/content/blog/team-setup-architecture.md` — one paragraph corrected.
- No application source changes.

[skip-impl-check]

Content-only PR (single markdown paragraph correction) — no application source (.ts/.js) changes, so implementation-verification against SMI-6252 doesn't apply.
