### PR TITLE
chore(security): renew D1DX/secret-capture-skill allowlist entry (SMI-6288)

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -70,10 +70,10 @@
       "skillId": "github/D1DX/secret-capture-skill",
       "findingType": "sensitive_path",
       "messagePattern": "\\.env",
-      "reason": "Secret-routing utility (analogous to Varlock) that captures credentials via a hidden-input dialog and routes them to vaults/stores without the value appearing in any tool result, log, or transcript. The env-file adapter writes to a local .env (0600) as one of eight routing destinations; the bare-keyword sensitive_path regex fires on the repo description's mention of '.env file' as a destination. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills. Triaged 2026-05-31 under SMI-5206 — Wave 2 sensitive_path tightening (require assignment/path context) will eliminate this class of false positive. Closes GH #1343.",
+      "reason": "Secret-routing utility (analogous to Varlock) that captures credentials via a hidden-input dialog and routes them to vaults/stores without the value appearing in any tool result, log, or transcript. The env-file adapter writes to a local .env (0600) as one of eight routing destinations; the bare-keyword sensitive_path regex fires on the repo description's mention of '.env file' as a destination. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills. Triaged 2026-05-31 under SMI-5206 — Wave 2 sensitive_path tightening (require assignment/path context) will eliminate this class of false positive. Closes GH #1343. Proactively renewed 2026-08-29 (routine expiry renewal, no new findings) before expiry.",
       "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-05-31",
-      "expiresAt": "2026-08-29"
+      "reviewedAt": "2026-08-29",
+      "expiresAt": "2026-11-27"
     },
     {
       "skillId": "github/leksman/ai-security-guard",


### PR DESCRIPTION
## Business Summary

A security-allowlist entry for a known false positive (`github/D1DX/secret-capture-skill`, a secret-routing utility whose repo description mentions `.env` and trips a bare-keyword scanner rule) expired today, 2026-08-29 — before the weekly Sunday 2026-08-30 00:00 UTC security scan runs. Without renewal, that scan would re-quarantine a skill already confirmed safe back in May. This PR extends the entry another 90 days, matching every other entry's renewal cadence. No new findings; routine renewal, not a new triage decision.

## Changes

- `data/skills-security-allowlist.json`: `github/D1DX/secret-capture-skill` — `reviewedAt` 2026-05-31 → 2026-08-29, `expiresAt` 2026-08-29 → 2026-11-27.

## Test plan

- [x] `allowlist.test.ts` (24/24 passing) confirms the entry still parses and its expiry window (90 days) satisfies the 1-365 day bound.
- [x] `npm run audit:standards` — 0 failed, warnings unrelated to this change.
- [x] Pre-push security/format/test checks passed.

Part of SMI-6282 (CI-failure remediation cluster) / SMI-6288 (Area 6 security triage).

[skip-impl-check]

This PR is a single-value data-file renewal (`data/skills-security-allowlist.json`) with no source code changes — no `packages/**/src/` implementation to verify against the referenced SMI issues.
