### PR TITLE
fix(core,cli): SMI-6279 Wave 9 -- fix broken Cursor MCP install path + diagnose extension

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skillsmith diagnose` now checks whether your Cursor MCP registration (both the
+  global `~/.cursor/mcp.json` and any project-scoped copy) is on the current, working config
+  shape and tells you how to fix it if not — previously nothing detected this at all once the
+  MCP server failed to even start, since the CLI's own update-nudge only fires from inside a
+  running MCP process (GH#2368, SMI-6279)
+
 - **Breaking**: `sync` (and `sync config --enable`) now require Team+ tier — Community and
   Individual tiers can no longer bulk-download the skill registry. The registry has grown far
   larger than this feature was designed for (hundreds of thousands of records, still growing),

--- a/packages/cli/src/commands/diagnose.test.ts
+++ b/packages/cli/src/commands/diagnose.test.ts
@@ -16,9 +16,42 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// SMI-6279 Wave 9: the "global" Cursor MCP config check reads
+// AGENT_MCP_TARGETS.cursor.path, which `@skillsmith/core/install` bakes in
+// at MODULE LOAD time from the REAL os.homedir() (agent-harness-targets.ts —
+// mocking `homedir()` after the fact wouldn't help, it's an already-computed
+// constant). Mock the target path itself, pointed at a real temp dir. Uses
+// `require()` (not this file's own top-level `node:fs`/`node:os`/`node:path`
+// imports) inside `vi.hoisted` — Vitest's hoist transform moves `vi.hoisted`/
+// `vi.mock` calls ABOVE the transformed import bindings too, so referencing
+// them here throws `Cannot access '...' before initialization`; `require()`
+// sidesteps that entirely (same pattern already used elsewhere in this repo,
+// e.g. packages/doc-retrieval-mcp/src/retrieval-log/writer.test.ts). Never
+// touches the real `~/.cursor/mcp.json`.
+const { globalCursorMcpPath } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- vi.hoisted runs before this file's own transformed ESM import bindings are initialized (see comment above); require() is the only way to reach node:fs/os/path from inside it.
+  const fs = require('node:fs') as typeof import('node:fs')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require('node:os') as typeof import('node:os')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require('node:path') as typeof import('node:path')
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-diagnose-global-cursor-'))
+  return { globalCursorMcpPath: path.join(dir, 'mcp.json') }
+})
+vi.mock('@skillsmith/core/install', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@skillsmith/core/install')>()
+  return {
+    ...actual,
+    AGENT_MCP_TARGETS: {
+      ...actual.AGENT_MCP_TARGETS,
+      cursor: { ...actual.AGENT_MCP_TARGETS.cursor, path: globalCursorMcpPath },
+    },
+  }
+})
 
 import { createDiagnoseCommand, runDiagnose } from './diagnose.js'
 
@@ -82,8 +115,40 @@ afterEach(() => {
 
   rmSync(tempLogDir, { recursive: true, force: true })
   rmSync(tempCwd, { recursive: true, force: true })
+  // SMI-6279 Wave 9: reset the mocked "global" Cursor MCP path between
+  // tests — the temp dir itself is shared for the whole file (created once
+  // via vi.hoisted), only the file inside it is per-test state.
+  rmSync(globalCursorMcpPath, { force: true })
   vi.restoreAllMocks()
 })
+
+const STALE_NPX_ENTRY = {
+  mcpServers: {
+    skillsmith: {
+      command: 'npx',
+      args: ['-y', '@skillsmith/mcp-server'],
+      env: { SKILLSMITH_TOOL_PROFILE: 'agent' },
+    },
+  },
+}
+
+const FRESH_BINARY_ENTRY = {
+  mcpServers: {
+    '@skillsmith/mcp-server': {
+      command: '/usr/local/bin/skillsmith-mcp',
+      env: { SKILLSMITH_TOOL_PROFILE: 'agent', SKILLSMITH_CLIENT: 'cursor' },
+    },
+  },
+}
+
+function writeProjectCursorMcpJson(content: unknown): void {
+  mkdirSync(join(tempCwd, '.cursor'), { recursive: true })
+  writeFileSync(join(tempCwd, '.cursor', 'mcp.json'), JSON.stringify(content, null, 2))
+}
+
+function writeGlobalCursorMcpJson(content: unknown): void {
+  writeFileSync(globalCursorMcpPath, JSON.stringify(content, null, 2))
+}
 
 describe('skillsmith diagnose', () => {
   it('prints a graceful "no logs found" message with zero log files, without crashing', async () => {
@@ -203,5 +268,74 @@ describe('skillsmith diagnose', () => {
     const optionNames = cmd.options.map((o) => o.long)
     expect(optionNames).toContain('--limit')
     expect(optionNames).toContain('--bundle')
+  })
+})
+
+// SMI-6279 Wave 9: GH#2368 V3's actual broken config was project-scoped —
+// nothing before this checked that location at all. Covers both required
+// cases (stale npx-form flagged, fresh binary-path form passes) plus
+// independence between the global and project-scoped locations.
+describe('skillsmith diagnose — Cursor MCP registration check', () => {
+  it('flags a stale project-scoped .cursor/mcp.json with the old npx form', async () => {
+    writeProjectCursorMcpJson(STALE_NPX_ENTRY)
+
+    const lines = captureConsole()
+    await runDiagnose({})
+    const output = lines.join('\n')
+
+    expect(output).toContain('Cursor MCP registration')
+    const projectPath = join(tempCwd, '.cursor', 'mcp.json')
+    expect(output).toContain(projectPath)
+    expect(output).toContain('STALE')
+    expect(output).toContain("npx' command form")
+    expect(output).toContain('missing SKILLSMITH_CLIENT=cursor')
+    expect(output).toContain('skillsmith agent install')
+  })
+
+  it('passes a fresh binary-path .cursor/mcp.json', async () => {
+    writeProjectCursorMcpJson(FRESH_BINARY_ENTRY)
+
+    const lines = captureConsole()
+    await runDiagnose({})
+    const output = lines.join('\n')
+
+    const projectPath = join(tempCwd, '.cursor', 'mcp.json')
+    const projectLine = output.split('\n').find((line) => line.includes(projectPath))
+    expect(projectLine).toBeDefined()
+    expect(projectLine).toContain('OK')
+    expect(projectLine).not.toContain('STALE')
+  })
+
+  it('checks the global and project-scoped locations independently', async () => {
+    writeGlobalCursorMcpJson(STALE_NPX_ENTRY)
+    writeProjectCursorMcpJson(FRESH_BINARY_ENTRY)
+
+    const lines = captureConsole()
+    await runDiagnose({})
+    const output = lines.join('\n')
+    const outputLines = output.split('\n')
+
+    const globalLine = outputLines.find((line) => line.includes(globalCursorMcpPath))
+    const projectPath = join(tempCwd, '.cursor', 'mcp.json')
+    const projectLine = outputLines.find((line) => line.includes(projectPath))
+
+    expect(globalLine).toBeDefined()
+    expect(projectLine).toBeDefined()
+    // Different files, different verdicts — proves each location is
+    // evaluated on its own content, not short-circuited by the other.
+    expect(globalLine).toContain('STALE')
+    expect(projectLine).toContain('OK')
+    expect(projectLine).not.toContain('STALE')
+  })
+
+  it('reports "(not found)" for a location with no mcp.json at all', async () => {
+    // Neither global nor project-scoped file written this test.
+    const lines = captureConsole()
+    await runDiagnose({})
+    const output = lines.join('\n')
+
+    expect(output).toContain(`${globalCursorMcpPath}: (not found)`)
+    const projectPath = join(tempCwd, '.cursor', 'mcp.json')
+    expect(output).toContain(`${projectPath}: (not found)`)
   })
 })

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -34,6 +34,8 @@ import { basename, dirname, resolve } from 'node:path'
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { withTelemetry } from '@skillsmith/core/telemetry'
+import { checkCursorMcpArtifact, type CursorMcpArtifactCheck } from '@skillsmith/core'
+import { AGENT_MCP_TARGETS } from '@skillsmith/core/install'
 import { getCliLogger } from '../cli-logger.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { VERSION } from '../version.js'
@@ -95,6 +97,42 @@ function printEnvSummary(summary: EnvSummary): void {
   console.log('')
 }
 
+/**
+ * Both locations Cursor reads MCP config from — global (`~/.cursor/mcp.json`)
+ * and project-scoped (`<cwd>/.cursor/mcp.json`). The GH#2368 V3 repro's
+ * actual broken config was project-scoped, and nothing before SMI-6279
+ * Wave 9 even looked there — checked independently, since a healthy global
+ * config says nothing about a stale project-scoped override shadowing it
+ * (Cursor merges both, project-scoped taking precedence).
+ */
+function cursorMcpArtifactPaths(): string[] {
+  return [AGENT_MCP_TARGETS.cursor.path, resolve(process.cwd(), '.cursor', 'mcp.json')]
+}
+
+function buildCursorMcpChecks(): CursorMcpArtifactCheck[] {
+  return cursorMcpArtifactPaths().map((path) => checkCursorMcpArtifact(path))
+}
+
+function formatCursorMcpCheckLine(check: CursorMcpArtifactCheck): string {
+  if (!check.exists) return `  ${check.path}: (not found)`
+  if (!check.entryFound) return `  ${check.path}: exists, no Skillsmith MCP entry`
+  if (!check.stale) return `  ${check.path}: OK`
+
+  const reasons: string[] = []
+  if (check.usesNpxForm) reasons.push("uses the broken 'npx' command form (GH#2368 C-01)")
+  if (!check.hasClientEnv) reasons.push('missing SKILLSMITH_CLIENT=cursor')
+  return `  ${check.path}: STALE — ${reasons.join('; ')}. Run \`${check.remediation}\` to fix.`
+}
+
+function printCursorMcpChecks(checks: CursorMcpArtifactCheck[]): void {
+  console.log(chalk.bold('Cursor MCP registration'))
+  for (const check of checks) {
+    const line = formatCursorMcpCheckLine(check)
+    console.log(check.stale ? chalk.yellow(line) : line)
+  }
+  console.log('')
+}
+
 function parseLimit(raw: string | undefined): number {
   const parsed = raw !== undefined ? Number.parseInt(raw, 10) : NaN
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMIT
@@ -148,6 +186,7 @@ export async function runDiagnose(options: DiagnoseCliOptions): Promise<void> {
     const logDir = resolveLogDir()
     const summary = buildEnvSummary(logDir)
     printEnvSummary(summary)
+    printCursorMcpChecks(buildCursorMcpChecks())
 
     const files = listLogFiles(logDir)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `agent install` no longer writes a broken Cursor MCP registration. Two independent
+  bugs, both from before Cursor's MCP snippet was fixed in SMI-5893: the installer still wrote
+  the `npx`-form command that reliably fails inside Cursor's bundled Node, without the
+  `SKILLSMITH_CLIENT` variable, so even the documented fix-it command (`agent install`) rewrote
+  the same broken config; and the installer's entry lived under a different JSON key than the
+  one users are told to paste from the website, so following both instructions left two
+  unreconciled server entries in the same file instead of one. Re-running `agent install` now
+  also cleans up a pre-fix install's stale entry (GH#2368, SMI-6279)
+
 - **Breaking**: `SyncEngine` now fetches via a new `registry-sync` Edge Function instead of
   abusing the public `skills-search` endpoint with 8 hardcoded broad queries — this transport
   is Team+ tier only server-side (see `@skillsmith/cli`'s changelog and ADR-136), so `SyncEngine.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -326,7 +326,10 @@ export {
   checkForUpdates,
   formatUpdateNotification,
   resolveUpdateNotificationClient,
+  agentInstallRemediationCommand,
+  checkCursorMcpArtifact,
   type VersionCheckResult,
+  type CursorMcpArtifactCheck,
 } from './utils/version-check.js'
 
 // GitHub URL Parsing (SMI-2171)

--- a/packages/core/src/install/agent-config-merge.json.ts
+++ b/packages/core/src/install/agent-config-merge.json.ts
@@ -72,18 +72,27 @@ function writeBackup(sourcePath: string, backupDir: string): string {
 }
 
 /**
- * Merge a `skillsmith` MCP server entry into a JSON config file at
+ * Merge a Skillsmith MCP server entry into a JSON config file at
  * `opts.path`, under `opts.keyPath` (e.g. `['mcpServers']`).
  *
  * Never performs a whole-file write of unrelated keys — the file is parsed,
- * exactly one nested key (`skillsmith`) is set at `[...keyPath, 'skillsmith']`,
- * and the WHOLE document (all other keys untouched) is re-serialized. A
- * missing file is treated as `{}` (created fresh).
+ * exactly one nested key (`opts.entryKey`, defaulting to `'skillsmith'` —
+ * see `MergeOptions.entryKey`) is set at `[...keyPath, entryKey]`, and the
+ * WHOLE document (all other keys untouched) is re-serialized. A missing
+ * file is treated as `{}` (created fresh).
  */
 export function mergeJsonMcpEntry(
   opts: MergeOptions & { keyPath: readonly string[] }
 ): MergeResult {
-  const { path, keyPath, entryValue, backupDir, force = false, alreadyBackedUpPaths } = opts
+  const {
+    path,
+    keyPath,
+    entryValue,
+    backupDir,
+    force = false,
+    alreadyBackedUpPaths,
+    entryKey = 'skillsmith',
+  } = opts
 
   let doc: Record<string, unknown> = {}
   let existed = false
@@ -109,7 +118,7 @@ export function mergeJsonMcpEntry(
   const container = getAtPath(doc, keyPath)
   const existingEntry =
     container && typeof container === 'object' && !Array.isArray(container)
-      ? (container as Record<string, unknown>).skillsmith
+      ? (container as Record<string, unknown>)[entryKey]
       : undefined
 
   if (existingEntry !== undefined) {
@@ -132,14 +141,14 @@ export function mergeJsonMcpEntry(
     const backupPath =
       existed && shouldBackup(path, alreadyBackedUpPaths) ? writeBackup(path, backupDir) : null
     markBackedUp(path, alreadyBackedUpPaths)
-    setAtPath(doc, keyPath, { ...(container as Record<string, unknown>), skillsmith: entryValue })
+    setAtPath(doc, keyPath, { ...(container as Record<string, unknown>), [entryKey]: entryValue })
     mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
     writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { mode: 0o600 })
     return { status: 'updated', path, backupPath }
   }
 
   // No existing entry — safe create. Still back up the FILE (not the
-  // skillsmith key, which didn't exist) so a foreign file with unrelated
+  // entryKey, which didn't exist) so a foreign file with unrelated
   // content the user cares about is always one restore away — unless an
   // earlier merge THIS RUN already captured the pre-install state.
   const backupPath =
@@ -149,7 +158,7 @@ export function mergeJsonMcpEntry(
     container && typeof container === 'object' && !Array.isArray(container)
       ? (container as Record<string, unknown>)
       : {}
-  setAtPath(doc, keyPath, { ...currentContainer, skillsmith: entryValue })
+  setAtPath(doc, keyPath, { ...currentContainer, [entryKey]: entryValue })
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
   writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { mode: 0o600 })
   return { status: 'created', path, backupPath }

--- a/packages/core/src/install/agent-config-merge.types.ts
+++ b/packages/core/src/install/agent-config-merge.types.ts
@@ -33,7 +33,7 @@ export interface MergeResult {
 
 export interface MergeOptions {
   path: string
-  /** The value to install under the `skillsmith` key. */
+  /** The value to install under `entryKey` (defaults to `'skillsmith'`). */
   entryValue: Record<string, unknown>
   /** Directory backups are written into. Caller ensures it exists. */
   backupDir: string
@@ -55,6 +55,16 @@ export interface MergeOptions {
    * backed up once per run, capturing genuine pre-install content.
    */
   alreadyBackedUpPaths?: Set<string>
+  /**
+   * JSON object key `entryValue` is installed under. Defaults to
+   * `'skillsmith'` — the key every `mergeJsonMcpEntry` caller except Cursor
+   * still uses (unchanged, out of scope for SMI-6279 Wave 9). Cursor passes
+   * `'@skillsmith/mcp-server'` instead, matching the key its own
+   * human-facing docs snippet uses — see `agent-pack-installer.entry.ts`'s
+   * `CURSOR_MCP_ENTRY_KEY` for the full rationale. Only meaningful for
+   * `mergeJsonMcpEntry` (the YAML/TOML-block merge helpers don't read it).
+   */
+  entryKey?: string
 }
 
 /**

--- a/packages/core/src/install/agent-pack-installer.cursor-mcp.test.ts
+++ b/packages/core/src/install/agent-pack-installer.cursor-mcp.test.ts
@@ -31,6 +31,23 @@ vi.mock('node:child_process', async (importOriginal) => {
   return { ...actual, execFileSync: execFileSyncMock }
 })
 
+// Defaults to the real writeFileSync so every test in this file gets real
+// disk writes unmodified; only the one PR-07-regression test below swaps in
+// a conditional throw, keyed by path so it can't accidentally intercept the
+// unrelated skill-pack-file writes installAgentPack also performs in the
+// same run (confirmed necessary: a naive call-order-based override fired on
+// one of those instead, on the first pass at writing this test).
+const { writeFileSyncMock, realWriteFileSyncRef } = vi.hoisted(() => ({
+  writeFileSyncMock: vi.fn(),
+  realWriteFileSyncRef: { current: null as null | ((...args: unknown[]) => void) },
+}))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  realWriteFileSyncRef.current = actual.writeFileSync as unknown as (...args: unknown[]) => void
+  writeFileSyncMock.mockImplementation(actual.writeFileSync)
+  return { ...actual, writeFileSync: writeFileSyncMock }
+})
+
 import { installAgentPack } from './agent-pack-installer.js'
 import { AGENT_INSTALL_DIR_ENV_VAR } from './agent-manifest.js'
 
@@ -65,6 +82,9 @@ beforeEach(() => {
   prevInstallDirEnv = process.env[AGENT_INSTALL_DIR_ENV_VAR]
   process.env[AGENT_INSTALL_DIR_ENV_VAR] = manifestDir
   execFileSyncMock.mockReset()
+  // Reset to the real passthrough (see the vi.mock('node:fs', ...) setup
+  // above) in case a prior test overrode it to simulate a write failure.
+  writeFileSyncMock.mockClear()
 })
 
 afterEach(() => {
@@ -299,5 +319,56 @@ describe('installAgentPack — cursor mcp.json stale legacy-key cleanup (SMI-627
     expect(afterSecond).toBe(afterFirst)
     const report = second.harnessReports.find((r) => r.harness === 'cursor')
     expect(report?.mcpConfig?.status).toBe('unchanged')
+  })
+
+  it('reports a cleanup write failure via report.notes instead of swallowing it as "nothing to clean up" (PR-07 finding, GPT-5.6-Sol / SMI-6279)', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+    // Seed BOTH the already-correct new entry and the stale legacy entry, so
+    // the main merge sees 'unchanged' (no write attempted there) and only
+    // the cleanup step's own write is exercised below.
+    writeFileSync(
+      mcpJsonPath(homeDir),
+      JSON.stringify(
+        {
+          mcpServers: {
+            skillsmith: {
+              command: 'npx',
+              args: ['-y', '@skillsmith/mcp-server'],
+              env: { SKILLSMITH_TOOL_PROFILE: 'agent' },
+            },
+            '@skillsmith/mcp-server': {
+              command: RESOLVED_BIN_PATH,
+              env: { SKILLSMITH_TOOL_PROFILE: 'agent', SKILLSMITH_CLIENT: 'cursor' },
+            },
+          },
+        },
+        null,
+        2
+      )
+    )
+
+    // Target only the cleanup's write to THIS file — installAgentPack also
+    // writes several unrelated skill-pack files earlier in the same run, and
+    // must keep writing those for real.
+    const targetPath = mcpJsonPath(homeDir)
+    writeFileSyncMock.mockImplementation((...args: unknown[]) => {
+      if (args[0] === targetPath) {
+        throw new Error('EACCES: permission denied (simulated)')
+      }
+
+      return realWriteFileSyncRef.current!(...args)
+    })
+
+    const result = installAgentPack({ homeDir })
+
+    // The legacy key must still be on disk — the failed write must not have
+    // corrupted or partially applied the delete.
+    const doc = readCursorMcpJson(homeDir)
+    expect(doc.mcpServers.skillsmith).toBeDefined()
+
+    const report = result.harnessReports.find((r) => r.harness === 'cursor')
+    expect(report?.notes.some((n) => n.includes('could not remove it'))).toBe(true)
+    expect(report?.notes.some((n) => n.includes('EACCES'))).toBe(true)
   })
 })

--- a/packages/core/src/install/agent-pack-installer.cursor-mcp.test.ts
+++ b/packages/core/src/install/agent-pack-installer.cursor-mcp.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Cursor `mcp.json` entry-shape + key-alignment regression coverage
+ * (SMI-6279 Wave 9, GH#2368 V3).
+ *
+ * Split from agent-pack-installer.test.ts, mirroring the existing
+ * agent-pack-installer.cursor-hooks.test.ts split (same temp-HOME +
+ * manifest-env fixture shape). Covers the two independent things
+ * `agent-pack-installer.cursor-mcp.ts` fixes:
+ *   1. Entry SHAPE: a resolved `skillsmith-mcp` binary path (or the
+ *      documented paste-here placeholder when resolution fails) instead of
+ *      the `npx`/`args` form two live UAT passes proved ENOENTs inside
+ *      Cursor's bundled Node, plus `SKILLSMITH_CLIENT=cursor`.
+ *   2. Entry KEY: `@skillsmith/mcp-server` (matching the website/CLI docs
+ *      snippet) instead of `skillsmith`, with a legacy-key cleanup step for
+ *      a pre-fix install that still has the old key.
+ *
+ * `node:child_process`'s `execFileSync` is mocked so `resolveSkillsmithMcpBinPath`
+ * never depends on whether `skillsmith-mcp` happens to be on the test
+ * runner's real PATH.
+ *
+ * @module @skillsmith/core/install/agent-pack-installer.cursor-mcp.test
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }))
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, execFileSync: execFileSyncMock }
+})
+
+import { installAgentPack } from './agent-pack-installer.js'
+import { AGENT_INSTALL_DIR_ENV_VAR } from './agent-manifest.js'
+
+let homeDir: string
+let manifestDir: string
+let prevInstallDirEnv: string | undefined
+
+const RESOLVED_BIN_PATH = '/usr/local/bin/skillsmith-mcp'
+
+function mcpJsonPath(home: string): string {
+  return join(home, '.cursor', 'mcp.json')
+}
+
+interface CursorMcpDoc {
+  mcpServers: Record<
+    string,
+    { command: string; args?: string[]; env?: Record<string, string> } | undefined
+  >
+}
+
+function readCursorMcpJson(home: string): CursorMcpDoc {
+  return JSON.parse(readFileSync(mcpJsonPath(home), 'utf-8')) as CursorMcpDoc
+}
+
+function seedCursorPresent(): void {
+  mkdirSync(join(homeDir, '.cursor', 'skills'), { recursive: true })
+}
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(tmpdir(), 'skillsmith-agent-install-home-'))
+  manifestDir = mkdtempSync(join(tmpdir(), 'skillsmith-agent-install-manifest-'))
+  prevInstallDirEnv = process.env[AGENT_INSTALL_DIR_ENV_VAR]
+  process.env[AGENT_INSTALL_DIR_ENV_VAR] = manifestDir
+  execFileSyncMock.mockReset()
+})
+
+afterEach(() => {
+  rmSync(homeDir, { recursive: true, force: true })
+  rmSync(manifestDir, { recursive: true, force: true })
+  if (prevInstallDirEnv !== undefined) process.env[AGENT_INSTALL_DIR_ENV_VAR] = prevInstallDirEnv
+  else delete process.env[AGENT_INSTALL_DIR_ENV_VAR]
+  vi.restoreAllMocks()
+})
+
+describe('installAgentPack — cursor mcp.json entry shape (SMI-6279 Wave 9)', () => {
+  it('writes the entry under the @skillsmith/mcp-server key with a resolved binary path + SKILLSMITH_CLIENT=cursor', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+
+    const result = installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    const entry = doc.mcpServers['@skillsmith/mcp-server']
+    expect(entry?.command).toBe(RESOLVED_BIN_PATH)
+    expect(entry?.env?.SKILLSMITH_CLIENT).toBe('cursor')
+    expect(entry?.env?.SKILLSMITH_TOOL_PROFILE).toBe('agent')
+    // No `args` — unlike the broken npx form, Cursor's entry invokes the
+    // resolved binary directly.
+    expect(entry?.args).toBeUndefined()
+    // No stray legacy key on a first-ever install.
+    expect(doc.mcpServers.skillsmith).toBeUndefined()
+
+    const report = result.harnessReports.find((r) => r.harness === 'cursor')
+    expect(report?.mcpConfig?.status).toBe('created')
+  })
+
+  it('falls back to the documented paste-here placeholder when the binary cannot be resolved', () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('not found')
+    })
+    seedCursorPresent()
+
+    installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    const entry = doc.mcpServers['@skillsmith/mcp-server']
+    expect(entry?.command).toContain('which skillsmith-mcp')
+    expect(entry?.command).toContain('where skillsmith-mcp')
+  })
+
+  it('falls back to the placeholder (never hangs) when the which/where lookup times out — code-review finding, GPT-5.6-Sol / SMI-6279', () => {
+    // execFileSync throws a synchronous ETIMEDOUT-shaped error when its own
+    // `timeout` option elapses — the existing blanket catch already handles
+    // this the same as "not found", so simulating that error is sufficient
+    // to prove the timeout-case fallback without an actual hung process.
+    const timeoutError = Object.assign(new Error('spawnSync which ETIMEDOUT'), {
+      code: 'ETIMEDOUT',
+      killed: true,
+      signal: 'SIGTERM',
+    })
+    execFileSyncMock.mockImplementation(() => {
+      throw timeoutError
+    })
+    seedCursorPresent()
+
+    installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    const entry = doc.mcpServers['@skillsmith/mcp-server']
+    expect(entry?.command).toContain('which skillsmith-mcp')
+
+    // And the bound is actually wired to the real execFileSync call, not
+    // just documented — a `timeout` option keeps a hung/substituted
+    // which/where from blocking `agent install` indefinitely.
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      expect.any(String),
+      ['skillsmith-mcp'],
+      expect.objectContaining({ timeout: expect.any(Number) })
+    )
+    const [, , options] = execFileSyncMock.mock.calls[0] as [string, string[], { timeout: number }]
+    expect(options.timeout).toBeGreaterThan(0)
+    // A few seconds is plenty for a local PATH lookup — not a network call.
+    expect(options.timeout).toBeLessThanOrEqual(5000)
+  })
+
+  it('does not regress claude-code’s own entry — still the npx form under the "skillsmith" key', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+
+    installAgentPack({ homeDir })
+
+    const claudeDoc = JSON.parse(
+      readFileSync(join(homeDir, '.claude', 'settings.json'), 'utf-8')
+    ) as CursorMcpDoc
+    expect(claudeDoc.mcpServers.skillsmith?.command).toBe('npx')
+    expect(claudeDoc.mcpServers.skillsmith?.env?.SKILLSMITH_TOOL_PROFILE).toBe('agent')
+    expect(claudeDoc.mcpServers.skillsmith?.env?.SKILLSMITH_CLIENT).toBeUndefined()
+  })
+})
+
+describe('installAgentPack — cursor mcp.json idempotency (SMI-6279 Wave 9)', () => {
+  it('re-install does not create a duplicate second server entry', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+
+    installAgentPack({ homeDir })
+    const second = installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    expect(Object.keys(doc.mcpServers)).toEqual(['@skillsmith/mcp-server'])
+
+    const report = second.harnessReports.find((r) => r.harness === 'cursor')
+    expect(report?.mcpConfig?.status).toBe('unchanged')
+  })
+})
+
+describe('installAgentPack — cursor mcp.json stale legacy-key cleanup (SMI-6279 Wave 9)', () => {
+  it('removes a stale "skillsmith"-keyed entry from a pre-fix install, leaving exactly one entry', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+    writeFileSync(
+      mcpJsonPath(homeDir),
+      JSON.stringify(
+        {
+          mcpServers: {
+            skillsmith: {
+              command: 'npx',
+              args: ['-y', '@skillsmith/mcp-server'],
+              env: { SKILLSMITH_TOOL_PROFILE: 'agent' },
+            },
+          },
+        },
+        null,
+        2
+      )
+    )
+
+    installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    expect(doc.mcpServers.skillsmith).toBeUndefined()
+    expect(doc.mcpServers['@skillsmith/mcp-server']?.command).toBe(RESOLVED_BIN_PATH)
+    expect(Object.keys(doc.mcpServers)).toEqual(['@skillsmith/mcp-server'])
+  })
+
+  it('preserves a foreign entry under the legacy "skillsmith" key — never deletes a user-owned unrelated entry', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+    const foreignEntry = { command: 'some-other-tool', args: ['--flag'] }
+    writeFileSync(
+      mcpJsonPath(homeDir),
+      JSON.stringify({ mcpServers: { skillsmith: foreignEntry } }, null, 2)
+    )
+
+    installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    expect(doc.mcpServers.skillsmith).toEqual(foreignEntry)
+    expect(doc.mcpServers['@skillsmith/mcp-server']?.command).toBe(RESOLVED_BIN_PATH)
+  })
+
+  it('preserves a near-miss entry that references the package name in an extra description field (code-review finding, GPT-5.6-Sol / SMI-6279)', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+    // Structurally close to our own legacy shape (same command/args/env
+    // value) but NOT byte-identical — one extra key. The old loose
+    // `looksLikeOurMcpEntry` heuristic (substring-matches args, checks only
+    // key presence) would have matched this and deleted it; the tightened
+    // exact-shape check must not.
+    const nearMissEntry = {
+      command: 'npx',
+      args: ['-y', '@skillsmith/mcp-server'],
+      env: { SKILLSMITH_TOOL_PROFILE: 'agent' },
+      description: 'Custom wrapper — see @skillsmith/mcp-server docs for context',
+    }
+    writeFileSync(
+      mcpJsonPath(homeDir),
+      JSON.stringify({ mcpServers: { skillsmith: nearMissEntry } }, null, 2)
+    )
+
+    installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    expect(doc.mcpServers.skillsmith).toEqual(nearMissEntry)
+    expect(doc.mcpServers['@skillsmith/mcp-server']?.command).toBe(RESOLVED_BIN_PATH)
+  })
+
+  it('preserves a near-miss "skillsmith"-keyed entry whose SKILLSMITH_TOOL_PROFILE value differs from what we would have written (code-review finding, GPT-5.6-Sol / SMI-6279)', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+    // Same command/args/key SET as our legacy shape, but a different env
+    // VALUE — the old loose heuristic only checked key presence, not value,
+    // and would have matched+deleted this too.
+    const nearMissEntry = {
+      command: 'npx',
+      args: ['-y', '@skillsmith/mcp-server'],
+      env: { SKILLSMITH_TOOL_PROFILE: 'debug' },
+    }
+    writeFileSync(
+      mcpJsonPath(homeDir),
+      JSON.stringify({ mcpServers: { skillsmith: nearMissEntry } }, null, 2)
+    )
+
+    installAgentPack({ homeDir })
+
+    const doc = readCursorMcpJson(homeDir)
+    expect(doc.mcpServers.skillsmith).toEqual(nearMissEntry)
+    expect(doc.mcpServers['@skillsmith/mcp-server']?.command).toBe(RESOLVED_BIN_PATH)
+  })
+
+  it('is idempotent: a second install run on an already-migrated file makes no further legacy-key change', () => {
+    execFileSyncMock.mockReturnValue(`${RESOLVED_BIN_PATH}\n`)
+    seedCursorPresent()
+    writeFileSync(
+      mcpJsonPath(homeDir),
+      JSON.stringify(
+        {
+          mcpServers: {
+            skillsmith: {
+              command: 'npx',
+              args: ['-y', '@skillsmith/mcp-server'],
+              env: { SKILLSMITH_TOOL_PROFILE: 'agent' },
+            },
+          },
+        },
+        null,
+        2
+      )
+    )
+
+    installAgentPack({ homeDir }) // first run: writes the new key, cleans the legacy one
+    const afterFirst = readFileSync(mcpJsonPath(homeDir), 'utf-8')
+    const second = installAgentPack({ homeDir }) // second run: nothing left to clean
+    const afterSecond = readFileSync(mcpJsonPath(homeDir), 'utf-8')
+
+    expect(afterSecond).toBe(afterFirst)
+    const report = second.harnessReports.find((r) => r.harness === 'cursor')
+    expect(report?.mcpConfig?.status).toBe('unchanged')
+  })
+})

--- a/packages/core/src/install/agent-pack-installer.cursor-mcp.ts
+++ b/packages/core/src/install/agent-pack-installer.cursor-mcp.ts
@@ -108,6 +108,11 @@ export function installCursorMcpConfig(ctx: HarnessInstallCtx, report: HarnessIn
       `Removed stale legacy '${LEGACY_MCP_ENTRY_KEY}' MCP entry at ${path} — superseded by '${CURSOR_MCP_ENTRY_KEY}' (aligns with the website/CLI docs snippet key, SMI-6279 Wave 9).`
     )
   }
+  if (cleanup?.status === 'error') {
+    report.notes.push(
+      `Found a stale legacy '${LEGACY_MCP_ENTRY_KEY}' MCP entry at ${path} but could not remove it: ${cleanup.errorMessage}. The new '${CURSOR_MCP_ENTRY_KEY}' entry above was written successfully; the stale entry was left in place — remove it manually.`
+    )
+  }
 
   if (mergeSucceeded(result.status) || cleanup?.status === 'updated') {
     ctx.entries.push({
@@ -162,11 +167,17 @@ function looksLikeExactLegacyNpxEntry(value: unknown): boolean {
  * every other key in the file (including the entry this function's caller
  * just wrote under `CURSOR_MCP_ENTRY_KEY`) is preserved byte-for-byte.
  *
- * @returns `null` when there's nothing to clean up (file missing/unparsable,
+ * @returns `null` when there's genuinely nothing to clean up (file missing,
  *   no `mcpServers` object, no legacy key, or the legacy key isn't an EXACT
- *   match for our own legacy shape) — a genuine no-op, not surfaced as a
- *   report entry. A `MergeResult` with `status: 'updated'` when the legacy
- *   key was removed.
+ *   match for our own legacy shape) — a real no-op, not surfaced as a report
+ *   entry. A `MergeResult` with `status: 'updated'` when the legacy key was
+ *   removed, or `status: 'error'` when a match WAS found but reading,
+ *   backing up, or writing the file failed — this must reach the caller as
+ *   a reported failure, not collapse into the same `null` "nothing to do"
+ *   return as the routine no-match case (PR-07 finding, GPT-5.6-Sol /
+ *   SMI-6279): a swallowed write failure here would silently leave a
+ *   confirmed-stale, confirmed-broken legacy entry in place with no
+ *   indication anything went wrong.
  */
 function stripStaleLegacyMcpKey(
   path: string,
@@ -181,6 +192,9 @@ function stripStaleLegacyMcpKey(
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
     doc = parsed as Record<string, unknown>
   } catch {
+    // Unparsable/unreadable — not a match we can act on either way; the
+    // main merge above already succeeded reading+writing this same file
+    // moments earlier, so this is a genuine no-op, not a swallowed failure.
     return null
   }
 
@@ -195,9 +209,22 @@ function stripStaleLegacyMcpKey(
   // Foreign OR near-miss — never touch, even if named 'skillsmith'.
   if (!looksLikeExactLegacyNpxEntry(legacyEntry)) return null
 
-  delete containerObj[LEGACY_MCP_ENTRY_KEY]
-  const backupPath = shouldBackup(path, ctx.backedUpPaths) ? writeBackup(path, ctx.backupDir) : null
-  markBackedUp(path, ctx.backedUpPaths)
-  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { mode: 0o600 })
-  return { status: 'updated', path, backupPath }
+  // Past this point we've confirmed a real match to delete — any failure
+  // from here on is a genuine error, not a no-op, and must be reported.
+  try {
+    delete containerObj[LEGACY_MCP_ENTRY_KEY]
+    const backupPath = shouldBackup(path, ctx.backedUpPaths)
+      ? writeBackup(path, ctx.backupDir)
+      : null
+    markBackedUp(path, ctx.backedUpPaths)
+    writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { mode: 0o600 })
+    return { status: 'updated', path, backupPath }
+  } catch (error) {
+    return {
+      status: 'error',
+      path,
+      backupPath: null,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    }
+  }
 }

--- a/packages/core/src/install/agent-pack-installer.cursor-mcp.ts
+++ b/packages/core/src/install/agent-pack-installer.cursor-mcp.ts
@@ -1,0 +1,203 @@
+/**
+ * Cursor-specific MCP registration step for `sklx agent install`
+ * (SMI-6279 Wave 9).
+ *
+ * Split out of `agent-pack-installer.harness.ts`'s generic `installMcpConfig`
+ * — mirrors the existing `agent-pack-installer.cursor-hooks.ts` split
+ * (SMI-5893 Wave 8a) for the same reason: Cursor's on-disk shape/resolution
+ * needs diverge structurally from the other 6 MCP-capable harnesses, so
+ * folding cursor-only logic into the shared function would either bloat it
+ * past the 500-line gate or force every other harness through cursor-only
+ * branches it doesn't need.
+ *
+ * Two independent, confirmed-broken things this fixes (GH#2368 V3 repro —
+ * see the SMI-6266 Wave 9 plan doc):
+ *   1. `buildAgentMcpEntryValue()` wrote the `npx`/`args` form into Cursor's
+ *      `mcp.json` — the exact shape two live UAT passes proved ENOENTs
+ *      inside Cursor's bundled Node (GH#2368 C-01) — and never set
+ *      `SKILLSMITH_CLIENT`, so re-running `agent install` (the very
+ *      remediation `formatUpdateNotification()` tells a user to run)
+ *      silently rewrote the SAME broken entry, even after the website docs
+ *      snippet was corrected (SMI-5893 Wave 11). {@link installCursorMcpConfig}
+ *      now writes `buildCursorMcpEntryValue()` instead — resolved binary
+ *      path (or the documented paste-here placeholder) plus
+ *      `SKILLSMITH_CLIENT=cursor`.
+ *   2. The installer wrote its entry under the JSON key `skillsmith`, while
+ *      the website/CLI-template docs snippet (which users are told to
+ *      hand-paste) uses the package-scoped key `@skillsmith/mcp-server` — a
+ *      user who did both ended up with TWO different server entries
+ *      coexisting in the same file, neither ever recognized as "the
+ *      other's" by the installer's own conflict-detection (which matches
+ *      purely on key). {@link installCursorMcpConfig} now writes under
+ *      `CURSOR_MCP_ENTRY_KEY` (`'@skillsmith/mcp-server'`) so a docs-paste
+ *      and an `agent install` reconcile as ONE entry, and
+ *      {@link stripStaleLegacyMcpKey} removes a pre-fix install's stale
+ *      `'skillsmith'`-keyed entry (mirroring the cursor-hooks legacy-key
+ *      cleanup precedent) so a re-install doesn't leave both keys present.
+ *
+ * Scoped to Cursor ONLY — `mergeJsonMcpEntry`'s default `entryKey`
+ * (`'skillsmith'`) and `buildAgentMcpEntryValue()`'s `npx` form are
+ * UNCHANGED for claude-code/copilot/windsurf/opencode/codex/hermes; nothing
+ * in this module is reachable from any other harness's install path.
+ *
+ * @module @skillsmith/core/install/agent-pack-installer.cursor-mcp
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+import { AGENT_MCP_TARGETS } from './agent-harness-targets.js'
+import { mergeJsonMcpEntry } from './agent-config-merge.json.js'
+import { writeBackup } from './agent-config-merge.json-array.js'
+import { deepEqualJson, markBackedUp, shouldBackup } from './agent-config-merge.types.js'
+import {
+  CURSOR_MCP_ENTRY_KEY,
+  LEGACY_MCP_ENTRY_KEY,
+  buildAgentMcpEntryValue,
+  buildCursorMcpEntryValue,
+} from './agent-pack-installer.entry.js'
+import { relocateUnderHome } from './agent-home-relocate.js'
+import type { HarnessInstallCtx } from './agent-pack-installer.harness.js'
+import type { HarnessInstallReport } from './agent-pack-installer.types.js'
+import type { MergeResult } from './agent-config-merge.types.js'
+
+/** Same predicate as `agent-pack-installer.harness.ts`'s private `mergeSucceeded` — duplicated rather than exported to keep that module's helper private. */
+function mergeSucceeded(status: MergeResult['status']): boolean {
+  return status === 'created' || status === 'updated' || status === 'unchanged'
+}
+
+/**
+ * Merge Cursor's `skillsmith` MCP server registration into `~/.cursor/mcp.json`
+ * under {@link CURSOR_MCP_ENTRY_KEY}, then clean up a stale legacy-keyed
+ * entry from a pre-SMI-6279 install (see module header).
+ */
+export function installCursorMcpConfig(ctx: HarnessInstallCtx, report: HarnessInstallReport): void {
+  const target = AGENT_MCP_TARGETS.cursor
+  const path = relocateUnderHome(target.path, ctx.homeDir)
+  const entryValue = buildCursorMcpEntryValue()
+
+  const result = mergeJsonMcpEntry({
+    path,
+    keyPath: target.keyPath,
+    entryKey: CURSOR_MCP_ENTRY_KEY,
+    entryValue,
+    backupDir: ctx.backupDir,
+    force: ctx.force,
+    alreadyBackedUpPaths: ctx.backedUpPaths,
+  })
+
+  report.mcpConfig = result
+  if (result.status === 'conflict') {
+    report.notes.push(
+      `MCP config at ${path} already has a '${CURSOR_MCP_ENTRY_KEY}' entry that doesn't look like ours — left untouched. Re-run with --force to overwrite, or edit ${path} manually.`
+    )
+  }
+  if (result.status === 'error') {
+    report.notes.push(`MCP config merge failed at ${path}: ${result.errorMessage}`)
+  }
+
+  // Only attempt the legacy-key cleanup once our own write succeeded (or was
+  // already correct) — same data-loss guard as the cursor-hooks precedent:
+  // a 'conflict'/'error' write means we deliberately left the file alone (or
+  // couldn't touch it), so removing the legacy key too would still mutate a
+  // file the real merge just refused to touch.
+  const cleanup = mergeSucceeded(result.status)
+    ? stripStaleLegacyMcpKey(path, target.keyPath, ctx)
+    : null
+  if (cleanup?.status === 'updated') {
+    report.notes.push(
+      `Removed stale legacy '${LEGACY_MCP_ENTRY_KEY}' MCP entry at ${path} — superseded by '${CURSOR_MCP_ENTRY_KEY}' (aligns with the website/CLI docs snippet key, SMI-6279 Wave 9).`
+    )
+  }
+
+  if (mergeSucceeded(result.status) || cleanup?.status === 'updated') {
+    ctx.entries.push({
+      path,
+      kind: 'mcp-config',
+      harness: 'cursor',
+      backupPath: result.backupPath ?? cleanup?.backupPath ?? null,
+      executable: false,
+    })
+  }
+}
+
+/**
+ * Strict, purpose-built ownership fingerprint for the destructive delete in
+ * {@link stripStaleLegacyMcpKey} — deliberately NOT the shared
+ * `looksLikeOurMcpEntry` heuristic (`agent-config-merge.types.ts`).
+ *
+ * `looksLikeOurMcpEntry` is intentionally loose (substring-matches an
+ * `args` element, or merely checks a `SKILLSMITH_TOOL_PROFILE` key is
+ * PRESENT regardless of its value) because its only job is gating a
+ * same-key OVERWRITE — a false positive there is non-destructive, the
+ * entry we'd write next replaces whatever was there either way. Deleting a
+ * DIFFERENT key entirely (this function) is a strictly higher-risk
+ * operation: a false positive here permanently removes a user's config
+ * with nothing to replace it — e.g. a custom wrapper script whose `args`
+ * happen to reference the package name in one element among several, or a
+ * user's own hand-authored `skillsmith`-keyed entry that happens to set a
+ * `SKILLSMITH_TOOL_PROFILE` env var with a DIFFERENT value for unrelated
+ * reasons (code-review finding, GPT-5.6-Sol / SMI-6279).
+ *
+ * The bar here is "structurally identical to exactly what
+ * `buildAgentMcpEntryValue()` itself would have written" — checked via
+ * `deepEqualJson` against that function's actual return value (not a
+ * hand-duplicated literal, so this can never drift out of sync with the
+ * real shape): exact `command`, exact `args` sequence (not "contains"),
+ * exact `env` key SET (not just key presence) and exact value.
+ */
+function looksLikeExactLegacyNpxEntry(value: unknown): boolean {
+  return deepEqualJson(value, buildAgentMcpEntryValue())
+}
+
+/**
+ * Remove a stale `LEGACY_MCP_ENTRY_KEY` (`'skillsmith'`)-keyed MCP entry
+ * left behind by a pre-SMI-6279 `agent install` run, but ONLY when it is
+ * structurally IDENTICAL to what that installer itself would have written
+ * (`looksLikeExactLegacyNpxEntry` above). A user's own hand-written
+ * `skillsmith`-named entry — even one that superficially resembles ours —
+ * is left completely untouched — this never silently deletes a foreign or
+ * near-miss entry just because it shares the old key name.
+ *
+ * Read-modify-write is scoped to exactly the `mcpServers.skillsmith` key —
+ * every other key in the file (including the entry this function's caller
+ * just wrote under `CURSOR_MCP_ENTRY_KEY`) is preserved byte-for-byte.
+ *
+ * @returns `null` when there's nothing to clean up (file missing/unparsable,
+ *   no `mcpServers` object, no legacy key, or the legacy key isn't an EXACT
+ *   match for our own legacy shape) — a genuine no-op, not surfaced as a
+ *   report entry. A `MergeResult` with `status: 'updated'` when the legacy
+ *   key was removed.
+ */
+function stripStaleLegacyMcpKey(
+  path: string,
+  keyPath: readonly string[],
+  ctx: HarnessInstallCtx
+): MergeResult | null {
+  if (!existsSync(path)) return null
+
+  let doc: Record<string, unknown>
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    doc = parsed as Record<string, unknown>
+  } catch {
+    return null
+  }
+
+  const containerKey = keyPath[0]
+  if (containerKey === undefined) return null
+  const container = doc[containerKey]
+  if (!container || typeof container !== 'object' || Array.isArray(container)) return null
+  const containerObj = container as Record<string, unknown>
+
+  const legacyEntry = containerObj[LEGACY_MCP_ENTRY_KEY]
+  if (legacyEntry === undefined) return null
+  // Foreign OR near-miss — never touch, even if named 'skillsmith'.
+  if (!looksLikeExactLegacyNpxEntry(legacyEntry)) return null
+
+  delete containerObj[LEGACY_MCP_ENTRY_KEY]
+  const backupPath = shouldBackup(path, ctx.backedUpPaths) ? writeBackup(path, ctx.backupDir) : null
+  markBackedUp(path, ctx.backedUpPaths)
+  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { mode: 0o600 })
+  return { status: 'updated', path, backupPath }
+}

--- a/packages/core/src/install/agent-pack-installer.entry.ts
+++ b/packages/core/src/install/agent-pack-installer.entry.ts
@@ -9,6 +9,8 @@
  * @module @skillsmith/core/install/agent-pack-installer.entry
  */
 
+import { execFileSync } from 'node:child_process'
+
 import {
   AGENT_TOOL_PROFILE_ENV_VAR,
   AGENT_TOOL_PROFILE_VALUE,
@@ -16,9 +18,15 @@ import {
 
 /**
  * The `skillsmith` MCP server registration value for `mcpServers`-convention
- * harnesses (claude-code, cursor, copilot, windsurf; hermes uses the same
- * field names under YAML). OpenCode does NOT use this shape — see
- * {@link buildOpenCodeMcpEntryValue}.
+ * harnesses (claude-code, copilot, windsurf; hermes uses the same field
+ * names under YAML). OpenCode does NOT use this shape — see
+ * {@link buildOpenCodeMcpEntryValue}. Cursor ALSO does not use this shape —
+ * see {@link buildCursorMcpEntryValue} (SMI-6279 Wave 9): two independent
+ * live UAT passes proved the `npx`/`args` form here ENOENTs inside Cursor's
+ * bundled Node (GH#2368 C-01), which is why the website/CLI-template docs
+ * snippet was corrected to a resolved-binary-path form back in SMI-5893
+ * Wave 11 — this function stayed on the broken form for every OTHER
+ * harness it's still correct for, so it is deliberately left unchanged here.
  */
 export function buildAgentMcpEntryValue(): Record<string, unknown> {
   return {
@@ -26,6 +34,128 @@ export function buildAgentMcpEntryValue(): Record<string, unknown> {
     args: ['-y', '@skillsmith/mcp-server'],
     env: {
       [AGENT_TOOL_PROFILE_ENV_VAR]: AGENT_TOOL_PROFILE_VALUE,
+    },
+  }
+}
+
+/**
+ * JSON key Cursor's MCP entry is installed under (SMI-6279 Wave 9).
+ *
+ * Every OTHER `mcpServers`-convention harness still uses the literal
+ * `'skillsmith'` key (hardcoded as `mergeJsonMcpEntry`'s default `entryKey`
+ * — deliberately NOT changed here, out of scope for this fix). Cursor is
+ * the one client with a human-facing docs snippet
+ * (`packages/website/src/lib/mcp-client-snippets.ts` /
+ * `packages/cli/src/templates/mcp-server.template.snippets.ts`) that tells a
+ * user to hand-paste an entry under the PACKAGE-scoped key
+ * `@skillsmith/mcp-server` instead — a mismatch that let a user who both
+ * pasted the docs snippet AND ran `sklx agent install` end up with two
+ * different server entries coexisting in the same `mcp.json`, neither ever
+ * recognized as "the other's" by the installer's own conflict-detection
+ * (which matches purely on key). Aligning the installer's key to the docs
+ * snippet's key here means a docs-paste and an `agent install` reconcile as
+ * ONE entry: either recognized as ours and updated in place, or correctly
+ * detected as foreign (conflict) and left alone — never silently
+ * duplicated. See `agent-pack-installer.cursor-mcp.ts` for the write path
+ * (including the legacy-key cleanup for a pre-fix install that still has
+ * the old `'skillsmith'`-keyed entry) and `version-check.ts`'s
+ * `checkCursorMcpArtifact` for the read-side (`skillsmith diagnose`) use.
+ */
+export const CURSOR_MCP_ENTRY_KEY = '@skillsmith/mcp-server'
+
+/**
+ * The JSON key every pre-SMI-6279 `sklx agent install` run wrote Cursor's
+ * MCP entry under — kept as a named constant (not a bare literal) so the
+ * legacy-key cleanup step and the `diagnose` staleness check can both point
+ * at the exact same "this is the OLD key" definition instead of drifting.
+ */
+export const LEGACY_MCP_ENTRY_KEY = 'skillsmith'
+
+/**
+ * Placeholder command text shown when {@link resolveSkillsmithMcpBinPath}
+ * can't resolve a real path — byte-identical to the human-facing
+ * instruction already shipped in the website/CLI-template Cursor snippets
+ * (SMI-5893 Wave 11), so a user who runs `agent install` before the resolve
+ * step succeeds sees the exact same next action the docs already describe.
+ */
+export const CURSOR_MCP_COMMAND_PLACEHOLDER =
+  '<paste output of: which skillsmith-mcp (macOS/Linux) or where skillsmith-mcp (Windows)>'
+
+/**
+ * Bound on {@link resolveSkillsmithMcpBinPath}'s `which`/`where` call
+ * (code-review finding, GPT-5.6-Sol / SMI-6279: the call previously had no
+ * `timeout`, so a hung or substituted `which`/`where` executable could block
+ * `agent install` indefinitely). This is a local PATH lookup, not a network
+ * call — 3s is generous headroom, not a tight budget. `execFileSync` throws
+ * `ETIMEDOUT` when this elapses, which the existing blanket `catch` below
+ * already turns into the same "not found" fallback as a missing binary — no
+ * separate timeout-handling branch needed.
+ */
+const BIN_RESOLVE_TIMEOUT_MS = 3000
+
+/**
+ * Resolve the on-disk path of the globally-installed `skillsmith-mcp`
+ * binary by shelling out to the exact command the docs already tell a
+ * human to run by hand — `which` on macOS/Linux, `where` on Windows
+ * (SMI-6279 Wave 9).
+ *
+ * There is no reliable programmatic equivalent that doesn't shell out:
+ * `@skillsmith/mcp-server` is a SEPARATE npm package from `@skillsmith/cli`
+ * (the package this code runs inside of) and is commonly NOT installed yet
+ * when `agent install` runs — it is a peer install the docs tell the user
+ * to do themselves (`npm install -g @skillsmith/mcp-server`). Node module
+ * resolution (`require.resolve`) only finds an already-installed package's
+ * importable entry point, not a DIFFERENT package's globally-linked `bin`
+ * symlink, and `process.execPath` is the Node binary running THIS process,
+ * not `skillsmith-mcp`'s location — neither is a substitute. `which`/`where`
+ * against the global npm bin directory (already on PATH for any shell the
+ * user installed from) is the SAME resolution the docs snippet instructs a
+ * human to do; this automates exactly that step rather than inventing a new
+ * one.
+ *
+ * Never throws and never hangs — returns `undefined` when the binary isn't
+ * found (an `agent install` run commonly happens BEFORE
+ * `@skillsmith/mcp-server` is installed; that is an expected outcome here,
+ * not an exceptional one) or when the lookup exceeds
+ * {@link BIN_RESOLVE_TIMEOUT_MS}.
+ */
+export function resolveSkillsmithMcpBinPath(): string | undefined {
+  try {
+    const finder = process.platform === 'win32' ? 'where' : 'which'
+    const output = execFileSync(finder, ['skillsmith-mcp'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: BIN_RESOLVE_TIMEOUT_MS,
+    })
+    return output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Cursor's own MCP server registration value (SMI-6279 Wave 9) — structurally
+ * different from {@link buildAgentMcpEntryValue} in two ways confirmed
+ * broken by the GH#2368 V3 repro:
+ *   1. `command` is a resolved binary path (or the documented paste-here
+ *      placeholder when resolution fails), never `npx` — two independent
+ *      live UAT passes proved `npx` ENOENTs inside Cursor's bundled Node.
+ *   2. `env.SKILLSMITH_CLIENT` is always set to `'cursor'` — without it,
+ *      Cursor installs silently land in the default `~/.claude/skills`
+ *      instead of `~/.cursor/skills` (SMI-5894 Wave 1 Step 7).
+ * `SKILLSMITH_TOOL_PROFILE` is unchanged from the generic builder — this is
+ * still the curated agent-pack registration, not a general-purpose one.
+ */
+export function buildCursorMcpEntryValue(): Record<string, unknown> {
+  const resolvedPath = resolveSkillsmithMcpBinPath()
+  return {
+    command: resolvedPath ?? CURSOR_MCP_COMMAND_PLACEHOLDER,
+    env: {
+      [AGENT_TOOL_PROFILE_ENV_VAR]: AGENT_TOOL_PROFILE_VALUE,
+      SKILLSMITH_CLIENT: 'cursor',
     },
   }
 }

--- a/packages/core/src/install/agent-pack-installer.ts
+++ b/packages/core/src/install/agent-pack-installer.ts
@@ -59,6 +59,7 @@ import {
   type HarnessInstallCtx,
 } from './agent-pack-installer.harness.js'
 import { installCursorHooks } from './agent-pack-installer.cursor-hooks.js'
+import { installCursorMcpConfig } from './agent-pack-installer.cursor-mcp.js'
 import {
   HARNESS_SUPPORT_TIER,
   type AgentInstallOptions,
@@ -265,9 +266,15 @@ export function installAgentPack(opts: AgentInstallOptions = {}): AgentInstallRe
         )
         installCodexAgentsShim(shimByHarness.get('codex'), ctx, report)
       }
-      // `harnessIds` is exactly the 7-member McpHarnessId union (all harnesses
-      // considered here support MCP registration) — safe direct cast.
-      installMcpConfig(harness, ctx, report)
+      if (harness === 'cursor') {
+        // Cursor's MCP entry shape/key diverge from every other harness
+        // (SMI-6279 Wave 9) — see agent-pack-installer.cursor-mcp.ts.
+        installCursorMcpConfig(ctx, report)
+      } else {
+        // `harnessIds` is exactly the 7-member McpHarnessId union (all harnesses
+        // considered here support MCP registration) — safe direct cast.
+        installMcpConfig(harness, ctx, report)
+      }
     }
 
     reports.push(report)

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,7 +17,10 @@ export {
 export {
   checkForUpdates,
   formatUpdateNotification,
+  agentInstallRemediationCommand,
+  checkCursorMcpArtifact,
   type VersionCheckResult,
+  type CursorMcpArtifactCheck,
 } from './version-check.js'
 
 // SMI-2171: GitHub URL parsing utilities

--- a/packages/core/src/utils/version-check.test.ts
+++ b/packages/core/src/utils/version-check.test.ts
@@ -3,10 +3,15 @@
  * @see SMI-1952: Add auto-update check to MCP server startup
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   checkForUpdates,
   formatUpdateNotification,
   resolveUpdateNotificationClient,
+  agentInstallRemediationCommand,
+  checkCursorMcpArtifact,
   type VersionCheckResult,
 } from './version-check.js'
 
@@ -198,6 +203,155 @@ describe('version-check', () => {
     it('returns undefined (never throws) for an invalid client value', () => {
       expect(() => resolveUpdateNotificationClient('totally-bogus-client')).not.toThrow()
       expect(resolveUpdateNotificationClient('totally-bogus-client')).toBeUndefined()
+    })
+  })
+
+  describe('agentInstallRemediationCommand (SMI-6279 Wave 9)', () => {
+    it('returns the exact command formatUpdateNotification embeds', () => {
+      expect(agentInstallRemediationCommand()).toBe('skillsmith agent install')
+    })
+  })
+
+  describe('checkCursorMcpArtifact (SMI-6279 Wave 9)', () => {
+    let tempDir: string
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), 'skillsmith-cursor-mcp-check-'))
+    })
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true })
+    })
+
+    function mcpJsonPath(): string {
+      return join(tempDir, 'mcp.json')
+    }
+
+    function write(content: unknown): void {
+      writeFileSync(mcpJsonPath(), JSON.stringify(content, null, 2))
+    }
+
+    it('reports not-stale, entry-not-found for a missing file', () => {
+      const result = checkCursorMcpArtifact(mcpJsonPath())
+      expect(result).toEqual({
+        path: mcpJsonPath(),
+        exists: false,
+        entryFound: false,
+        usesNpxForm: false,
+        hasClientEnv: false,
+        stale: false,
+      })
+    })
+
+    it('flags the broken npx form (missing SKILLSMITH_CLIENT) as stale with the shared remediation command', () => {
+      write({
+        mcpServers: {
+          skillsmith: {
+            command: 'npx',
+            args: ['-y', '@skillsmith/mcp-server'],
+            env: { SKILLSMITH_TOOL_PROFILE: 'agent' },
+          },
+        },
+      })
+
+      const result = checkCursorMcpArtifact(mcpJsonPath())
+
+      expect(result.exists).toBe(true)
+      expect(result.entryFound).toBe(true)
+      expect(result.entryKey).toBe('skillsmith')
+      expect(result.usesNpxForm).toBe(true)
+      expect(result.hasClientEnv).toBe(false)
+      expect(result.stale).toBe(true)
+      expect(result.remediation).toBe(agentInstallRemediationCommand())
+    })
+
+    it('passes a fresh resolved-binary-path entry under the @skillsmith/mcp-server key', () => {
+      write({
+        mcpServers: {
+          '@skillsmith/mcp-server': {
+            command: '/usr/local/bin/skillsmith-mcp',
+            env: { SKILLSMITH_TOOL_PROFILE: 'agent', SKILLSMITH_CLIENT: 'cursor' },
+          },
+        },
+      })
+
+      const result = checkCursorMcpArtifact(mcpJsonPath())
+
+      expect(result.exists).toBe(true)
+      expect(result.entryFound).toBe(true)
+      expect(result.entryKey).toBe('@skillsmith/mcp-server')
+      expect(result.usesNpxForm).toBe(false)
+      expect(result.hasClientEnv).toBe(true)
+      expect(result.stale).toBe(false)
+      expect(result.remediation).toBeUndefined()
+    })
+
+    it('flags an entry that has SKILLSMITH_CLIENT but is still on the npx form', () => {
+      write({
+        mcpServers: {
+          '@skillsmith/mcp-server': {
+            command: 'npx',
+            args: ['-y', '@skillsmith/mcp-server'],
+            env: { SKILLSMITH_CLIENT: 'cursor' },
+          },
+        },
+      })
+
+      const result = checkCursorMcpArtifact(mcpJsonPath())
+      expect(result.usesNpxForm).toBe(true)
+      expect(result.hasClientEnv).toBe(true)
+      expect(result.stale).toBe(true)
+    })
+
+    it('does not flag staleness when the file exists but has no Skillsmith entry at all', () => {
+      write({ mcpServers: { 'some-other-tool': { command: 'foo' } } })
+
+      const result = checkCursorMcpArtifact(mcpJsonPath())
+      expect(result.exists).toBe(true)
+      expect(result.entryFound).toBe(false)
+      expect(result.stale).toBe(false)
+    })
+
+    it('does not throw and reports not-found for an unparsable file', () => {
+      writeFileSync(mcpJsonPath(), '{not valid json')
+      expect(() => checkCursorMcpArtifact(mcpJsonPath())).not.toThrow()
+      const result = checkCursorMcpArtifact(mcpJsonPath())
+      expect(result.exists).toBe(true)
+      expect(result.entryFound).toBe(false)
+      expect(result.stale).toBe(false)
+    })
+
+    it('checks an arbitrary independent path — proving global vs project-scoped are evaluated separately', () => {
+      const otherDir = mkdtempSync(join(tmpdir(), 'skillsmith-cursor-mcp-check-other-'))
+      try {
+        mkdirSync(otherDir, { recursive: true })
+        const otherPath = join(otherDir, 'mcp.json')
+        writeFileSync(
+          otherPath,
+          JSON.stringify({
+            mcpServers: {
+              '@skillsmith/mcp-server': {
+                command: '/usr/local/bin/skillsmith-mcp',
+                env: { SKILLSMITH_TOOL_PROFILE: 'agent', SKILLSMITH_CLIENT: 'cursor' },
+              },
+            },
+          })
+        )
+        write({
+          mcpServers: {
+            skillsmith: { command: 'npx', args: ['-y', '@skillsmith/mcp-server'], env: {} },
+          },
+        })
+
+        const freshResult = checkCursorMcpArtifact(otherPath)
+        const staleResult = checkCursorMcpArtifact(mcpJsonPath())
+
+        expect(freshResult.stale).toBe(false)
+        expect(staleResult.stale).toBe(true)
+        expect(existsSync(otherPath)).toBe(true)
+      } finally {
+        rmSync(otherDir, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/packages/core/src/utils/version-check.ts
+++ b/packages/core/src/utils/version-check.ts
@@ -2,7 +2,13 @@
  * Version check utility for auto-update notifications
  * @see SMI-1952: Add auto-update check to MCP server startup
  */
+import { existsSync, readFileSync } from 'node:fs'
+
 import { resolveClientId } from '../install/paths.js'
+import {
+  CURSOR_MCP_ENTRY_KEY,
+  LEGACY_MCP_ENTRY_KEY,
+} from '../install/agent-pack-installer.entry.js'
 
 /**
  * Result of a version check against npm registry
@@ -115,8 +121,23 @@ export function formatUpdateNotification(result: VersionCheckResult, client?: st
     `Run \`${result.updateCommand}\` to use the new version.\n` +
     `Note: upgrading does not refresh onboarding artifacts already on disk —\n` +
     `run \`skillsmith setup --force${clientFlag}\` to refresh the bundled skill, and\n` +
-    `\`skillsmith agent install\` to refresh hooks/MCP registration.`
+    `\`${agentInstallRemediationCommand()}\` to refresh hooks/MCP registration.`
   )
+}
+
+/**
+ * Canonical "refresh hooks/MCP registration" remediation command — the
+ * single source of truth for this exact string, shared by
+ * {@link formatUpdateNotification} (version-bump-triggered, fires only
+ * inside a running MCP server — structurally unreachable when the server
+ * never spawns at all, e.g. GH#2368 V3's "zero MCP tools" report) and
+ * {@link checkCursorMcpArtifact} (on-disk-content-triggered, SMI-6279
+ * Wave 9 — reachable from `skillsmith diagnose` even when no server is
+ * running) so the two never drift into differently-worded instructions for
+ * the same underlying fix.
+ */
+export function agentInstallRemediationCommand(): string {
+  return 'skillsmith agent install'
 }
 
 /**
@@ -150,5 +171,108 @@ export function resolveUpdateNotificationClient(raw: string | undefined): string
     return resolveClientId(raw)
   } catch {
     return undefined
+  }
+}
+
+/**
+ * Result of inspecting one `.cursor/mcp.json` file for the GH#2368 V3
+ * staleness signature (SMI-6279 Wave 9).
+ */
+export interface CursorMcpArtifactCheck {
+  /** Absolute path checked. */
+  path: string
+  /** Whether the file exists on disk at all. */
+  exists: boolean
+  /**
+   * A Skillsmith MCP server entry was found under either the current key
+   * (`CURSOR_MCP_ENTRY_KEY`) or the pre-SMI-6279 legacy key
+   * (`LEGACY_MCP_ENTRY_KEY`) — see `agent-pack-installer.entry.ts`.
+   */
+  entryFound: boolean
+  /** The JSON key the entry was found under, when `entryFound` is true. */
+  entryKey?: string
+  /**
+   * True when the entry's `command` is the broken `npx` form
+   * (`buildAgentMcpEntryValue()`'s shape) — two independent live UAT passes
+   * proved this ENOENTs inside Cursor's bundled Node (GH#2368 C-01).
+   */
+  usesNpxForm: boolean
+  /** True when `env.SKILLSMITH_CLIENT === 'cursor'` is present on the entry. */
+  hasClientEnv: boolean
+  /**
+   * True when this artifact needs a `agent install` refresh — an entry was
+   * found and either `usesNpxForm` or NOT `hasClientEnv` (or both; the
+   * GH#2368 V3 repro found the real broken installer output had both
+   * problems at once). `false` when no entry was found at all — Cursor
+   * simply not being configured yet is not a staleness signal.
+   */
+  stale: boolean
+  /** Present only when `stale` is true — the exact remediation command. */
+  remediation?: string
+}
+
+function notFoundResult(path: string, exists: boolean): CursorMcpArtifactCheck {
+  return { path, exists, entryFound: false, usesNpxForm: false, hasClientEnv: false, stale: false }
+}
+
+/**
+ * Inspect one `.cursor/mcp.json` file (global `~/.cursor/mcp.json` or a
+ * project-scoped `<workspace>/.cursor/mcp.json` — the GH#2368 V3 tester's
+ * actual broken config was project-scoped, and nothing before this checked
+ * that location at all) for the exact staleness signature
+ * {@link agentInstallRemediationCommand} fixes: the `npx` command form, and/or
+ * a missing `SKILLSMITH_CLIENT` env var.
+ *
+ * Read-only, never throws — an unreadable or unparsable file is reported as
+ * "not found" (nothing we can confidently flag) rather than surfaced as an
+ * error; `skillsmith diagnose` is a best-effort diagnostic, not a validator.
+ */
+export function checkCursorMcpArtifact(path: string): CursorMcpArtifactCheck {
+  if (!existsSync(path)) return notFoundResult(path, false)
+
+  let doc: unknown
+  try {
+    doc = JSON.parse(readFileSync(path, 'utf-8'))
+  } catch {
+    return notFoundResult(path, true)
+  }
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return notFoundResult(path, true)
+
+  const servers = (doc as Record<string, unknown>).mcpServers
+  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) {
+    return notFoundResult(path, true)
+  }
+  const serversObj = servers as Record<string, unknown>
+
+  const entryKey =
+    CURSOR_MCP_ENTRY_KEY in serversObj
+      ? CURSOR_MCP_ENTRY_KEY
+      : LEGACY_MCP_ENTRY_KEY in serversObj
+        ? LEGACY_MCP_ENTRY_KEY
+        : undefined
+  if (!entryKey) return notFoundResult(path, true)
+
+  const entry = serversObj[entryKey]
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return notFoundResult(path, true)
+  const entryObj = entry as Record<string, unknown>
+
+  const usesNpxForm = entryObj.command === 'npx'
+  const env = entryObj.env
+  const hasClientEnv =
+    !!env &&
+    typeof env === 'object' &&
+    !Array.isArray(env) &&
+    (env as Record<string, unknown>).SKILLSMITH_CLIENT === 'cursor'
+  const stale = usesNpxForm || !hasClientEnv
+
+  return {
+    path,
+    exists: true,
+    entryFound: true,
+    entryKey,
+    usesNpxForm,
+    hasClientEnv,
+    stale,
+    remediation: stale ? agentInstallRemediationCommand() : undefined,
   }
 }


### PR DESCRIPTION
## Business Summary

**What shipped:** Cursor users who ran `skillsmith agent install` were still getting a broken MCP connection, even after an earlier fix landed for this. Turned out that fix only touched the copy-paste instructions on the website -- the CLI's own installer never got the same fix, so it kept writing the exact broken configuration that fails inside Cursor. Running the installer again (which is literally what the CLI tells you to do to fix a stale setup) just wrote the same broken config back. This PR fixes the installer itself, and adds a `skillsmith diagnose` check that can now actually detect this class of problem instead of the system staying silent about it.

**Quality bar:** A dedicated investigation reproduced the actual failure live (not assumed from the bug report) before any code was written, then implementation plus two rounds of GPT-5.6-Sol cross-model review. The review caught a real data-loss risk: the cleanup logic for a pre-fix broken config was originally loose enough that it could have deleted a user's own unrelated configuration under the right circumstances -- tightened to an exact structural match before merge.

**Net result:** Fully shipped. Scoped to Cursor only -- the same installer for the other 6 supported editors is untouched, since only Cursor was confirmed broken.

---

## Technical detail

- New `packages/core/src/install/agent-pack-installer.cursor-mcp.ts` (mirrors the existing `agent-pack-installer.cursor-hooks.ts` split): `installCursorMcpConfig()` writes the correct binary-path form + `SKILLSMITH_CLIENT=cursor`, under the same JSON key (`@skillsmith/mcp-server`) the website docs snippet uses (previously a mismatched key, `skillsmith`, meant a docs-paste and an `agent install` never reconciled into one entry). `stripStaleLegacyMcpKey()` cleans up a pre-fix install's stale entry via an exact `deepEqualJson` structural match against the real builder output -- not a loose substring check, per GPT-5.6-Sol's review.
- `resolveSkillsmithMcpBinPath()` shells out to `which`/`where` (array-arg `execFileSync`, 3s bounded timeout, never throws) to resolve the real binary path; falls back to the same paste-here placeholder the docs already use if resolution fails.
- `diagnose.ts` + `version-check.ts`: new artifact-staleness check for both global (`~/.cursor/mcp.json`) and project-scoped (`<cwd>/.cursor/mcp.json`) Cursor MCP config, sharing one remediation-mapping function with the existing MCP-server-side update nudge instead of duplicating it.
- `packages/core/src` + `packages/cli/src`: 113 files / 1803 tests passing. `typecheck`/`lint`/`audit:standards` clean.
- SMI-6279 (Wave 9 of SMI-6266's plan: `docs/internal/implementation/cursor-antigravity-tier-parity-plan.md`).