### PR TITLE
feat(cli): SMI-6272 Wave 2 -- live effective-tier display in whoami

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Feature**: `skillsmith whoami` now shows your live effective license tier (and, when the
+  live check returns one, your per-minute API rate limit) alongside the existing masked-key/
+  session display, resolved via the same credential-aware `resolveEffectiveTier()` live check
+  `audit advisories`/`diff`/`pin`/`audit-collisions` already use (SMI-6271) — previously
+  `whoami` showed no tier information at all. Reuses the existing `formatTierBadge()` tier-badge
+  formatting rather than reimplementing it. Unlike those gating commands, a transient live-check
+  failure here does not block the command (this is a display command, not a gate) — it shows a
+  "could not verify" message instead of ever displaying a fabricated tier, since a single-shot
+  CLI invocation has no cached last-known tier to fall back to (SMI-6266 Wave 2, SMI-6272)
+
 - **Fix**: `skillsmith diagnose` now checks whether your Cursor MCP registration (both the
   global `~/.cursor/mcp.json` and any project-scoped copy) is on the current, working config
   shape and tells you how to fix it if not — previously nothing detected this at all once the

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -5,6 +5,15 @@
  * masked key display, and JWT device-code session detection (SMI-4402 — the
  * bug where `whoami`/`logout` only checked the legacy API key and missed a
  * live JWT session that `login` itself could see).
+ *
+ * SMI-6266 Wave 2 (SMI-6272): live effective-tier display. Fixture matrix
+ * per the plan's Step 1: each of the four tiers, covering all three live
+ * credential sources `resolveEffectiveTier()` can resolve from (license key,
+ * API key, device session), plus the transient-failure display case. Real
+ * `formatTierBadge()` (license.ts) is used unmocked — it's a pure
+ * chalk-formatting function with no side effects, and the whole point of
+ * reusing it (per the plan) is to prove whoami's output actually comes from
+ * that shared helper, not a reimplementation.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -18,15 +27,30 @@ vi.mock('@skillsmith/core', () => ({
   loadCredentials: vi.fn(),
 }))
 
+vi.mock('../utils/require-tier.js', () => ({
+  resolveEffectiveTier: vi.fn(),
+}))
+
 // ---------------------------------------------------------------------------
 // Imports
 // ---------------------------------------------------------------------------
 
 import { createWhoamiCommand } from './whoami.js'
 import { getAuthStatus, loadCredentials } from '@skillsmith/core'
+import { resolveEffectiveTier, type EffectiveTierResult } from '../utils/require-tier.js'
+import { TIER_FEATURES } from '../utils/license-types.js'
 
 const mockGetAuthStatus = vi.mocked(getAuthStatus)
 const mockLoadCredentials = vi.mocked(loadCredentials)
+const mockResolveEffectiveTier = vi.mocked(resolveEffectiveTier)
+
+/** A definitive community/'none'-source result — the harmless default for
+ * tests that don't care about tier display. */
+const COMMUNITY_NONE: EffectiveTierResult = {
+  status: { valid: true, tier: 'community', features: TIER_FEATURES.community },
+  source: 'none',
+  transient: false,
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,6 +83,11 @@ describe('createWhoamiCommand', () => {
     // Default: no JWT session, so existing legacy-API-key tests exercise the
     // getAuthStatus() path unchanged. JWT-specific tests override this.
     mockLoadCredentials.mockResolvedValue(null)
+
+    // Default: definitive community/'none' — harmless for every test that
+    // predates Wave 2 and doesn't assert on tier output. Tier-specific tests
+    // below override this per case.
+    mockResolveEffectiveTier.mockResolvedValue(COMMUNITY_NONE)
   })
 
   afterEach(() => {
@@ -235,6 +264,190 @@ describe('createWhoamiCommand', () => {
 
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('valid')
+    })
+  })
+
+  describe('live effective-tier display (SMI-6266 Wave 2)', () => {
+    // Community tier, resolved via the 'none' source (no credential of any
+    // kind) — pairs with the realistic outer "not authenticated" state.
+    it('shows the Community tier badge when no credential resolves to one', async () => {
+      mockGetAuthStatus.mockResolvedValue({ authenticated: false, keyPrefix: null, source: 'none' })
+      mockResolveEffectiveTier.mockResolvedValue(COMMUNITY_NONE)
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Not authenticated')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Community')
+      // The license-key/none paths never carry a live rate limit.
+      expect(output).not.toContain('Rate limit')
+    })
+
+    // Individual tier via SKILLSMITH_LICENSE_KEY (license-key source) — a
+    // realistic pairing is a user who only ever set the env var and never
+    // ran `skillsmith login` or configured an API key (outer state:
+    // "not authenticated" per getAuthStatus()/loadCredentials()).
+    it('shows the Individual tier badge resolved via a license key', async () => {
+      mockGetAuthStatus.mockResolvedValue({ authenticated: false, keyPrefix: null, source: 'none' })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'individual', features: TIER_FEATURES.individual },
+        source: 'license-key',
+        transient: false,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Individual')
+      expect(output).not.toContain('Rate limit')
+    })
+
+    // Team tier via a personal API key (api-key source), including the live
+    // per-minute rate limit the /license-status response carries for this
+    // path. Pairs with the outer "authenticated via legacy key" state.
+    it('shows the Team tier badge and rate limit resolved via an API key', async () => {
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: true,
+        keyPrefix: 'sk_live_xxxx',
+        source: 'config',
+      })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'team', features: TIER_FEATURES.team },
+        source: 'api-key',
+        transient: false,
+        rateLimit: 300,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      // Masked key output is unaffected by the new tier section.
+      expect(output).toContain('sk_live_xxxx...')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Team')
+      expect(output).toContain('Rate limit')
+      expect(output).toContain('300 req/min')
+    })
+
+    // Enterprise tier via a stored device-code session (session source),
+    // including its rate limit. Pairs with the outer JWT-session state.
+    it('shows the Enterprise tier badge and rate limit resolved via a device session', async () => {
+      mockLoadCredentials.mockResolvedValue({
+        accessToken: 'live-access-token',
+        refreshToken: 'live-refresh-token',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        version: 2,
+      })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'enterprise', features: TIER_FEATURES.enterprise },
+        source: 'session',
+        transient: false,
+        rateLimit: 600,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      // Device-session output is unaffected by the new tier section.
+      expect(output).toContain('device-code login')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Enterprise')
+      expect(output).toContain('600 req/min')
+    })
+
+    // PR review finding: the matrix above pairs each non-community tier with
+    // only one credential source. printTierSection() never reads
+    // `result.source` — it branches only on `transient`, `status.tier`, and
+    // whether `rateLimit` is defined — so a literal 4-tier x 3-source cross
+    // product would just re-exercise the same branches with an unread mock
+    // field. These three tests instead cover what the code actually
+    // branches on: a second source per tier, paired with the opposite
+    // rate-limit presence/absence from the case above (individual now WITH
+    // a rate limit; team and enterprise now WITHOUT one).
+    it('shows the Individual tier badge and rate limit resolved via an API key', async () => {
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: true,
+        keyPrefix: 'sk_live_xxxx',
+        source: 'config',
+      })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'individual', features: TIER_FEATURES.individual },
+        source: 'api-key',
+        transient: false,
+        rateLimit: 100,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Individual')
+      expect(output).toContain('Rate limit')
+      expect(output).toContain('100 req/min')
+    })
+
+    it('shows the Team tier badge resolved via a license key, with no rate limit line', async () => {
+      mockGetAuthStatus.mockResolvedValue({ authenticated: false, keyPrefix: null, source: 'none' })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'team', features: TIER_FEATURES.team },
+        source: 'license-key',
+        transient: false,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Team')
+      expect(output).not.toContain('Rate limit')
+    })
+
+    it('shows the Enterprise tier badge resolved via a license key, with no rate limit line', async () => {
+      mockGetAuthStatus.mockResolvedValue({ authenticated: false, keyPrefix: null, source: 'none' })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'enterprise', features: TIER_FEATURES.enterprise },
+        source: 'license-key',
+        transient: false,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Tier:')
+      expect(output).toContain('Enterprise')
+      expect(output).not.toContain('Rate limit')
+    })
+
+    // Transient failure: the live check couldn't complete. whoami is a
+    // display command, not a gate — the rest of the output (masked key,
+    // source, etc.) must still render, and the tier section must show a
+    // clear "could not verify" message WITHOUT displaying the community
+    // placeholder resolveEffectiveTier() returns internally for this case
+    // (a single-shot CLI process has no real last-known tier to fall back
+    // to, so showing "Community" here would be misleading, not helpful).
+    it('shows a "could not verify" message on a transient live-check failure, without a fabricated tier badge', async () => {
+      mockGetAuthStatus.mockResolvedValue({
+        authenticated: true,
+        keyPrefix: 'sk_live_xxxx',
+        source: 'config',
+      })
+      mockResolveEffectiveTier.mockResolvedValue({
+        status: { valid: true, tier: 'community', features: TIER_FEATURES.community },
+        source: 'api-key',
+        transient: true,
+      })
+
+      await expect(runCommand()).rejects.toThrow('process.exit(0)')
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n')
+      // The rest of the command's output still renders.
+      expect(output).toContain('sk_live_xxxx...')
+      // The tier section reports the failure, not a fabricated tier.
+      expect(output).toContain('could not verify')
+      expect(output).not.toContain('Community')
+      expect(output).not.toContain('Rate limit')
     })
   })
 })

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -2,17 +2,22 @@
  * Whoami Command - Show current authentication status
  *
  * SMI-2715: CLI Login Device Flow
+ * SMI-6266 Wave 2 (SMI-6272): live entitlement display
  *
- * Displays the masked API key (or JWT session expiry) and the storage
- * source so users can understand where their credentials are being read
- * from. Checks a JWT device-code session (SMI-4402) via loadCredentials()
- * first — getAuthStatus() alone only sees the legacy API key.
+ * Displays the masked API key (or JWT session expiry), the storage source,
+ * and — new in Wave 2 — the caller's live effective tier (and per-minute
+ * rate limit, when the live check returns one) via `resolveEffectiveTier()`
+ * (Wave 1, SMI-6271). Checks a JWT device-code session (SMI-4402) via
+ * loadCredentials() first — getAuthStatus() alone only sees the legacy API
+ * key.
  */
 
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { getAuthStatus, loadCredentials } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
+import { resolveEffectiveTier, type EffectiveTierResult } from '../utils/require-tier.js'
+import { formatTierBadge } from '../utils/license.js'
 
 /** Human-readable labels for each credential source */
 const SOURCE_LABELS: Record<string, string> = {
@@ -22,8 +27,46 @@ const SOURCE_LABELS: Record<string, string> = {
   none: 'none',
 }
 
+/**
+ * Print the caller's live effective tier, reusing `formatTierBadge()`
+ * (license.ts) rather than reimplementing tier-badge formatting.
+ *
+ * `whoami` is a display command, not a gate — unlike `requireTier()`'s
+ * fail-closed throw on a transient live-check failure, blocking the entire
+ * command here would be wrong (the rest of `whoami`'s output, e.g. the
+ * masked key, is still valid and useful even when the live tier check
+ * fails). But a CLI invocation is a single short-lived process with no
+ * cross-call cache (see require-tier.ts's own doc comment on
+ * `resolveViaApiKey()`), so there is no real "last-known" tier to fall back
+ * to here — showing the `communityStatus()` placeholder `resolveEffectiveTier()`
+ * returns on a transient failure would be actively misleading (it could
+ * silently under-report a real paying customer as Community). So on
+ * `transient: true` this prints an explicit "could not verify" line and
+ * deliberately omits any tier badge, rather than displaying unverified
+ * placeholder data as if it were real.
+ */
+function printTierSection(result: EffectiveTierResult): void {
+  console.log()
+  if (result.transient) {
+    console.log(
+      chalk.dim('  Tier:   ') +
+        chalk.yellow('could not verify (live check failed — try again in a moment)')
+    )
+    return
+  }
+
+  console.log(chalk.dim('  Tier:   ') + formatTierBadge(result.status.tier))
+  if (result.rateLimit !== undefined) {
+    console.log(chalk.dim('  Rate limit: ') + chalk.cyan(`${result.rateLimit} req/min`))
+  }
+}
+
 // SMI-5040: extracted from inline .action() closure for withTelemetry wrap.
 async function whoamiActionImpl(): Promise<void> {
+  // Kicked off up front so it runs concurrently with the credential checks
+  // below rather than adding its own latency serially after them.
+  const tierResultPromise = resolveEffectiveTier()
+
   // loadCredentials() returning non-null already means a resolvable refresh
   // token is on file — don't additionally gate on access-token freshness
   // (Date.now() < expiresAt): an expired access token with a live refresh
@@ -42,6 +85,7 @@ async function whoamiActionImpl(): Promise<void> {
           ? chalk.yellow(`expired ${expiresLabel} (refreshes automatically on next use)`)
           : chalk.green(`valid until ${expiresLabel}`))
     )
+    printTierSection(await tierResultPromise)
     process.exit(0)
   }
 
@@ -49,6 +93,7 @@ async function whoamiActionImpl(): Promise<void> {
 
   if (!status.authenticated || !status.keyPrefix) {
     console.log(`Not authenticated. Run ${chalk.cyan('`skillsmith login`')} to authenticate.`)
+    printTierSection(await tierResultPromise)
     process.exit(0)
   }
 
@@ -72,6 +117,7 @@ async function whoamiActionImpl(): Promise<void> {
     )
   }
 
+  printTierSection(await tierResultPromise)
   process.exit(0)
 }
 

--- a/packages/cli/src/utils/require-tier.test.ts
+++ b/packages/cli/src/utils/require-tier.test.ts
@@ -178,6 +178,25 @@ describe('resolveEffectiveTier / requireTier (SMI-6271)', () => {
       await expect(requireTier('team')).resolves.toBeUndefined()
     })
 
+    // SMI-6266 Wave 2 (`skillsmith whoami`): rateLimit is plumbed through
+    // from the live response (previously discarded) so whoami has something
+    // to display beyond the bare tier badge — see require-tier.ts's
+    // EffectiveTierResult doc comment for why this isn't an edge-function
+    // contract change (the field was already on the wire).
+    it('plumbs rateLimit through from a live api-key response that includes it', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ data: { authenticated: true, tier: 'enterprise', rateLimit: 600 } }),
+            { status: 200 }
+          )
+        )
+
+      const result = await resolveEffectiveTier()
+      expect(result.rateLimit).toBe(600)
+    })
+
     it('an unauthenticated (bad/revoked) key resolves definitively to community', async () => {
       // mockImplementation (not mockResolvedValue) so each of the two calls
       // below gets its own Response instance — a Response body can only be
@@ -244,6 +263,10 @@ describe('resolveEffectiveTier / requireTier (SMI-6271)', () => {
         source: 'session',
         transient: false,
         status: { valid: true, tier: 'team', features: TIER_FEATURES.team },
+        // SMI-6266 Wave 2: rateLimit is plumbed through from
+        // resolveSessionTier()'s SessionTierResult (previously discarded) —
+        // matches the `rateLimit: 100` in this describe block's own mock.
+        rateLimit: 100,
       })
     })
 

--- a/packages/cli/src/utils/require-tier.ts
+++ b/packages/cli/src/utils/require-tier.ts
@@ -81,19 +81,38 @@ export type EffectiveTierSource = 'license-key' | 'api-key' | 'session' | 'none'
  * fail-closed caller (e.g. `requireTier()`) must refuse to trust `status` and
  * report a "could not verify" error rather than silently pass or silently
  * downgrade a real paying customer.
+ *
+ * `rateLimit` (SMI-6266 Wave 2, `skillsmith whoami`): the caller's per-minute
+ * API rate-limit ceiling, straight from the live `/license-status` response
+ * (`SessionTierResult.rateLimit` / the API-key path's identical `data.rateLimit`
+ * field — see `RATE_LIMITS_BY_TIER` in `supabase/functions/_shared/license.ts`,
+ * the single source of truth both auth paths already read from). It is a
+ * static function of tier, not a live usage counter — distinct from the
+ * monthly-quota/usage data Step 0 of the Wave 2 plan deliberately left out
+ * (that would require extending the edge function's response contract; this
+ * does not, since the field is already present on the wire and was
+ * previously just discarded here). Only ever set for the two LIVE paths
+ * (`api-key`, `session`) — the offline license-key path and the no-credential
+ * community default have no live rate-limit figure to report, so this stays
+ * `undefined` for those.
  */
 export interface EffectiveTierResult {
   status: LicenseStatus
   source: EffectiveTierSource
   transient: boolean
+  rateLimit?: number
 }
 
 function communityStatus(): LicenseStatus {
   return { valid: true, tier: 'community', features: TIER_FEATURES.community }
 }
 
-function definitiveResult(source: EffectiveTierSource, status: LicenseStatus): EffectiveTierResult {
-  return { status, source, transient: false }
+function definitiveResult(
+  source: EffectiveTierSource,
+  status: LicenseStatus,
+  rateLimit?: number
+): EffectiveTierResult {
+  return { status, source, transient: false, ...(rateLimit !== undefined && { rateLimit }) }
 }
 
 function transientResult(source: EffectiveTierSource): EffectiveTierResult {
@@ -119,6 +138,7 @@ interface LicenseStatusResponse {
   data?: {
     authenticated?: boolean
     tier?: string
+    rateLimit?: number
   }
 }
 
@@ -162,7 +182,11 @@ async function resolveViaApiKey(apiKey: string): Promise<EffectiveTierResult> {
     // DEFINITIVE: authenticated with a recognized tier.
     if (response.ok && data?.authenticated === true && data.tier && KNOWN_TIERS.has(data.tier)) {
       const tier = data.tier as LicenseTier
-      return definitiveResult('api-key', { valid: true, tier, features: TIER_FEATURES[tier] })
+      return definitiveResult(
+        'api-key',
+        { valid: true, tier, features: TIER_FEATURES[tier] },
+        data.rateLimit
+      )
     }
 
     // DEFINITIVE: bad/expired/revoked/missing key — stable "not authenticated".
@@ -199,7 +223,11 @@ async function resolveViaSession(): Promise<EffectiveTierResult> {
     // verified user who genuinely has no paid entitlement (community).
     if (result.authenticated && result.tier && KNOWN_TIERS.has(result.tier)) {
       const tier = result.tier as LicenseTier
-      return definitiveResult('session', { valid: true, tier, features: TIER_FEATURES[tier] })
+      return definitiveResult(
+        'session',
+        { valid: true, tier, features: TIER_FEATURES[tier] },
+        result.rateLimit
+      )
     }
 
     // DEFINITIVE: the server verified the JWT and found no session — a


### PR DESCRIPTION
## Business Summary

**What shipped:** `skillsmith whoami` now shows your live effective license tier, and your per-minute API rate limit when the live check returns one — previously it showed no tier information at all. This closes the second half of the gap external tester hytonylee's UAT rounds exposed: `whoami` was the one CLI command left still blind to a real Enterprise/Team subscription, even after Wave 1 (SMI-6271) gave every gating command that live check.

**Quality bar:** Full test suite (1067+ tests across `packages/cli`), lint, typecheck, and format all clean. GPT-5.6-Sol code-reviewed the diff via NEEDLE (ADR-128) — verdict PASS-WITH-CONCERNS, no production defects found. Its one note (test coverage paired each tier with only one credential source) led to three added tests, chosen to cover what the display code actually branches on — tier value, rate-limit presence, and the transient-failure path — rather than combinations the code never reads.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

- `packages/cli/src/commands/whoami.ts` — new `printTierSection()` prints `Tier:` (via the existing `formatTierBadge()` from `license.ts` — no reimplementation) and, when present, `Rate limit: N req/min`. On `resolveEffectiveTier()` returning `transient: true`, prints an explicit "could not verify (live check failed — try again in a moment)" line and omits the tier badge entirely — `whoami` is a display command, not a gate, so it doesn't fail closed like `requireTier()`'s callers do, but a single-shot CLI process also has no cached last-known tier, so showing the `community` placeholder `resolveEffectiveTier()` returns internally for a transient failure would misrepresent a real paying customer as free-tier.
- `packages/cli/src/utils/require-tier.ts` — `EffectiveTierResult` gains an optional `rateLimit?: number`, sourced from the API-key and session live-check response paths; left `undefined` when the resolved path (license-key, community) never carries one. Grepped for other `resolveEffectiveTier()`/`EffectiveTierResult` consumers — none besides `require-tier.ts` itself and `whoami.ts` — so the additive optional field changes no existing caller's behavior.
- `packages/cli/src/commands/whoami.test.ts` — 8 new tests: the 4-tier display matrix (Community/none, Individual/license-key, Team/api-key+rate-limit, Enterprise/session+rate-limit), the transient-failure "could not verify" case (asserts the tier badge is absent, not just that some message appears), and three tests along the rate-limit-presence/second-source axis (Individual+api-key+rate-limit, Team+license-key+no-rate-limit, Enterprise+license-key+no-rate-limit).
- `packages/cli/CHANGELOG.md` — `[Unreleased]` entry added.

SMI-6266 (Wave 2), SMI-6272.
