### PR TITLE
feat(core): SMI-6275 Wave 5 -- agent install AntiGravity harness support

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Feature**: `sklx agent install` now supports AntiGravity as a harness (`@skillsmith/core/install`,
+  SMI-6275 Wave 5, closing the last unshipped ask of GH#2166). `HarnessId` gains `'antigravity'`,
+  but — unlike every other MCP-capable harness — it is deliberately excluded from `McpHarnessId`
+  and has no entry in `AGENT_MCP_TARGETS`: AntiGravity's MCP config is WORKSPACE-anchored
+  (`.agents/mcp_config.json`, verified live against antigravity.google/docs/ide/mcp/ and
+  antigravity.google/docs/cli/mcp/ — same standard `mcpServers`-keyed JSON shape as
+  claude-code/copilot/windsurf, registered under the package-scoped key `@skillsmith/mcp-server`
+  to match AntiGravity's own docs snippet, the same key-alignment fix SMI-6279 made for Cursor),
+  not home-anchored like the shared `Record`'s other entries. New
+  `agent-pack-installer.antigravity-mcp.ts` (mirroring the Cursor split) owns its path resolution
+  + entry-value shape entirely; only the entry-value builder is genuinely new code, reusing
+  `mergeJsonMcpEntry()` for the actual write. `installAgentPack` now resolves AntiGravity's scope
+  on every run (not just `--scope workspace`) — a bare `agent install` auto-detects an
+  already-existing `.agents/` marker (ADR-139 point 2 rank 4) and configures it, while
+  `--scope workspace` remains the only path that can CREATE one (ADR-139 point 5); AntiGravity now
+  always gets a report row (`detected: false` with an explanatory note when its workspace scope
+  doesn't resolve), matching every other harness's reporting shape instead of Wave 4's
+  row-omission. Support tier 3 (MCP config only) — no hooks (no documented AntiGravity hook
+  system found) and no named-agent shim this wave, both stated decisions. `agent-manifest-path-guard.ts`
+  gains a second, WORKSPACE-relative allowlist (alongside the existing home-relative one) so
+  `uninstallAgentPack` can actually remove AntiGravity's two workspace-scoped artifacts instead of
+  silently rejecting them as outside every known install target — closes a latent gap in Wave 4's
+  own skill-pack-only implementation, caught while extending the same guard for the MCP config file.
+
 - **Feature**: ADR-139 global-vs-workspace install scope resolution (`@skillsmith/core/install`,
   SMI-6274 Wave 4). New `resolveSkillScope()`/`resolveScopedSkillsDir()` resolve whether an
   install/list/update/remove targets a client's global directory (`CLIENT_NATIVE_PATHS`) or a

--- a/packages/core/src/install/agent-harness-targets.ts
+++ b/packages/core/src/install/agent-harness-targets.ts
@@ -44,6 +44,17 @@
  *     `agent-pack-installer.entry.ts`). Agent markdown lives at
  *     `~/.config/opencode/agents/` — plural (opencode.ai/docs/agents/; the
  *     earlier singular `agent/` guess was wrong).
+ *   - antigravity (SMI-6275 Wave 5): HIGH — `.agents/mcp_config.json`,
+ *     standard `mcpServers` object shape, verified 2026-08-30 via live web
+ *     search against antigravity.google/docs/ide/mcp/ and
+ *     antigravity.google/docs/cli/mcp/ (both explicitly document the
+ *     workspace-local path and the shared global sibling
+ *     `~/.gemini/config/mcp_config.json`, corroborated by two independent
+ *     third-party sources — Google Cloud Community/Medium and a Composio
+ *     how-to). NOT listed in {@link AGENT_MCP_TARGETS} below, unlike every
+ *     other row in this list — see `McpHarnessId`'s own doc comment for why,
+ *     and `agent-pack-installer.antigravity-mcp.ts` for the dedicated
+ *     writer this wave adds instead.
  */
 
 import { homedir } from 'node:os'
@@ -51,8 +62,25 @@ import { join } from 'node:path'
 
 import type { HarnessId } from '../services/agent-pack/index.js'
 
-/** Harnesses that can receive an MCP server registration (all 7 targets). */
-export type McpHarnessId = HarnessId | 'windsurf' | 'hermes'
+/**
+ * Harnesses that can receive an MCP server registration via
+ * {@link AGENT_MCP_TARGETS}'s HOME-anchored `Record` shape (7 targets).
+ *
+ * `antigravity` is EXCLUDED here (SMI-6275 Wave 5) even though it is a
+ * {@link HarnessId} member — its `.agents/mcp_config.json` is
+ * WORKSPACE-anchored (relative to the workspace root Wave 4's
+ * `resolveScopedSkillsDir()` resolves), not home-anchored like every other
+ * `McpConfigTarget.path` in this file, so it structurally cannot be a value
+ * in a `Record<McpHarnessId, McpConfigTarget>` whose every consumer
+ * (`relocateUnderHome`, `agent-manifest-path-guard.ts`'s home-relative
+ * suffix computation) assumes a home-anchored path. This is the same
+ * structural reason Cursor got its own dedicated installer split
+ * (`agent-pack-installer.cursor-mcp.ts`, SMI-6279 Wave 9) rather than a
+ * generic-path `AGENT_MCP_TARGETS` entry — AntiGravity gets the same
+ * treatment: `agent-pack-installer.antigravity-mcp.ts` owns its path
+ * resolution + entry-value shape entirely outside this table.
+ */
+export type McpHarnessId = Exclude<HarnessId, 'antigravity'> | 'windsurf' | 'hermes'
 
 /** Config-file format the merge helper must speak for a given target. */
 export type ConfigFormat = 'json' | 'yaml' | 'toml-block'
@@ -172,6 +200,12 @@ export const AGENT_SHIM_TARGETS: Readonly<Record<HarnessId, ShimTarget | null>> 
   // ~/.codex/config.toml, not a standalone file — see AGENT_MCP_TARGETS.codex
   // and agent-config-merge.toml-block.ts. No separate ShimTarget.
   codex: null,
+  // SMI-6275 Wave 5 decision (stated, not an oversight): no named-agent shim
+  // for AntiGravity this wave — no verified evidence of a shim/companion-file
+  // convention distinct from `.agents/mcp_config.json` turned up during this
+  // wave's research. See HOOK_HARNESSES's doc comment (services/agent-pack/types.ts)
+  // for the parallel hooks decision.
+  antigravity: null,
 }
 
 /** Hook install targets — only harnesses with a real SessionStart hook (HOOK_HARNESSES). */

--- a/packages/core/src/install/agent-manifest-path-guard.test.ts
+++ b/packages/core/src/install/agent-manifest-path-guard.test.ts
@@ -3,7 +3,7 @@
  *               (SMI-5456 governance follow-up, code review 2026-07-01).
  * @module @skillsmith/core/install/agent-manifest-path-guard.test
  */
-import { homedir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
@@ -57,6 +57,54 @@ describe('isAllowedManifestEntryPath', () => {
 
   it('rejects a bare directory that only partially matches (no filename)', () => {
     expect(isAllowedManifestEntryPath(join(homedir(), '.claude', 'skills'))).toBe(false)
+  })
+
+  // SMI-6275 Wave 5: AntiGravity's two artifacts are WORKSPACE-relative, not
+  // HOME-relative — a separate allowlist branch (module header addendum).
+  describe('AntiGravity workspace-relative artifacts (SMI-6275 Wave 5)', () => {
+    const workspaceRoot = join(tmpdir(), 'skillsmith-guard-test-workspace')
+
+    it('allows the workspace-scoped skill pack path under ANY workspace root', () => {
+      expect(
+        isAllowedManifestEntryPath(
+          join(workspaceRoot, '.agents', 'skills', 'skillsmith-agent', 'SKILL.md')
+        )
+      ).toBe(true)
+      // A DIFFERENT workspace root — the check is deliberately root-agnostic
+      // (any file literally named this way, per any workspace), not tied to
+      // one specific resolved root (module header explains why).
+      expect(
+        isAllowedManifestEntryPath(
+          join(tmpdir(), 'another-workspace', '.agents', 'skills', 'skillsmith-agent', 'SKILL.md')
+        )
+      ).toBe(true)
+    })
+
+    it('allows the workspace-scoped mcp_config.json path under any workspace root', () => {
+      expect(isAllowedManifestEntryPath(join(workspaceRoot, '.agents', 'mcp_config.json'))).toBe(
+        true
+      )
+    })
+
+    it('rejects a path that merely CONTAINS the mcp_config.json suffix as a substring, not a true path segment', () => {
+      expect(
+        isAllowedManifestEntryPath(join(workspaceRoot, 'evil.agents', 'mcp_config.json'))
+      ).toBe(false)
+      expect(
+        isAllowedManifestEntryPath(join(workspaceRoot, '.agents', 'evil-mcp_config.json'))
+      ).toBe(false)
+    })
+
+    it('rejects a hand-edited traversal string escaping the intended tail', () => {
+      expect(
+        isAllowedManifestEntryPath(`${workspaceRoot}/.agents/mcp_config.json/../../../etc/passwd`)
+      ).toBe(false)
+    })
+
+    it('still rejects an arbitrary sensitive path — the workspace-relative branch does not widen the home-relative rejections', () => {
+      expect(isAllowedManifestEntryPath('/etc/passwd')).toBe(false)
+      expect(isAllowedManifestEntryPath(join(homedir(), '.ssh', 'id_rsa'))).toBe(false)
+    })
   })
 })
 

--- a/packages/core/src/install/agent-manifest-path-guard.ts
+++ b/packages/core/src/install/agent-manifest-path-guard.ts
@@ -37,6 +37,27 @@
  * with one of a dozen known per-harness relative locations" — a tampered
  * manifest can no longer name `/etc/passwd` or `~/.ssh/id_rsa`.
  *
+ * SMI-6275 Wave 5 addendum — a SECOND, WORKSPACE-relative allowlist. Every
+ * suffix above is relative to `os.homedir()`, which is correct for every
+ * OTHER installer target but not for AntiGravity's two workspace-scoped
+ * artifacts (the `.agents/skills/skillsmith-agent/SKILL.md` pack copy, ADR-139
+ * / SMI-6274 Wave 4, and `.agents/mcp_config.json`, this wave) — both are
+ * relative to a WORKSPACE root, which is any directory a user ran
+ * `agent install --scope workspace` from, not a statically enumerable set
+ * the way `CLIENT_NATIVE_PATHS` is. There is deliberately no attempt to
+ * validate "is this THE workspace root this manifest entry was actually
+ * written under" (that would require persisting and trusting the workspace
+ * root itself, which is exactly the kind of manifest-supplied data this
+ * guard exists to NOT trust) — instead the check narrows to the fixed
+ * RELATIVE suffix each artifact is known to end with, the same "shrink the
+ * blast radius to a known relative location" philosophy as the home-relative
+ * check above, applied to a workspace base instead of a home base. This
+ * still cannot match `/etc/passwd` or `~/.ssh/id_rsa`; it CAN match any file
+ * on disk literally named `.agents/mcp_config.json` (or the SKILL.md pack
+ * path) regardless of which workspace — a real but bounded reduction from
+ * "any file the process can write," consistent with this module's existing
+ * standard.
+ *
  * @module @skillsmith/core/install/agent-manifest-path-guard
  */
 
@@ -50,7 +71,9 @@ import {
   AGENT_SHIM_TARGETS,
 } from './agent-harness-targets.js'
 import { getAgentInstallBackupsDir } from './agent-manifest.js'
+import { ANTIGRAVITY_MCP_CONFIG_RELATIVE_SEGMENTS } from './agent-pack-installer.antigravity-mcp.js'
 import { CLIENT_NATIVE_PATHS } from './paths.js'
+import { CLIENT_WORKSPACE_SEGMENTS } from './workspace-scope.js'
 
 /** Relative-to-`os.homedir()` suffix for every path the installer can ever write. */
 function computeAllowedPathSuffixes(): ReadonlySet<string> {
@@ -93,15 +116,50 @@ function allowedPathSuffixes(): ReadonlySet<string> {
 }
 
 /**
+ * Relative-to-WORKSPACE-ROOT suffix for AntiGravity's two workspace-scoped
+ * artifacts (SMI-6275 Wave 5 addendum — see module header). Both segments
+ * are sourced from the same constants the writers themselves use
+ * (`CLIENT_WORKSPACE_SEGMENTS.antigravity`, `AGENT_PACK_SKILL_NAME`,
+ * `ANTIGRAVITY_MCP_CONFIG_RELATIVE_SEGMENTS`) rather than hand-duplicated
+ * literals, so this allowlist can never silently drift from what
+ * `installAgentPack` actually writes.
+ */
+function computeAllowedWorkspaceRelativeSuffixes(): ReadonlySet<string> {
+  const suffixes = new Set<string>()
+  const antigravitySkillsSegments = CLIENT_WORKSPACE_SEGMENTS.antigravity
+  if (antigravitySkillsSegments) {
+    suffixes.add(join(...antigravitySkillsSegments, AGENT_PACK_SKILL_NAME, 'SKILL.md'))
+  }
+  suffixes.add(join(...ANTIGRAVITY_MCP_CONFIG_RELATIVE_SEGMENTS))
+  return suffixes
+}
+
+let cachedWorkspaceRelativeSuffixes: ReadonlySet<string> | null = null
+
+function allowedWorkspaceRelativeSuffixes(): ReadonlySet<string> {
+  if (!cachedWorkspaceRelativeSuffixes) {
+    cachedWorkspaceRelativeSuffixes = computeAllowedWorkspaceRelativeSuffixes()
+  }
+  return cachedWorkspaceRelativeSuffixes
+}
+
+/**
  * True when `path` structurally matches one of the installer's known
- * relative target locations (see module header). Normalizes via
- * `path.resolve` first so a `..`-laden path can't dodge the suffix check by
- * embedding traversal segments before the matched tail.
+ * relative target locations (see module header) — either HOME-relative
+ * (every non-AntiGravity target, plus AntiGravity's own global skills dir
+ * entry in `CLIENT_NATIVE_PATHS`) or, per the SMI-6275 Wave 5 addendum,
+ * WORKSPACE-relative (AntiGravity's `.agents/`-scoped skill pack and MCP
+ * config). Normalizes via `path.resolve` first so a `..`-laden path can't
+ * dodge either suffix check by embedding traversal segments before the
+ * matched tail.
  */
 export function isAllowedManifestEntryPath(path: string): boolean {
   const normalized = resolve(path)
   for (const suffix of allowedPathSuffixes()) {
     if (normalized.endsWith(sep + suffix) || normalized === suffix) return true
+  }
+  for (const suffix of allowedWorkspaceRelativeSuffixes()) {
+    if (normalized.endsWith(sep + suffix)) return true
   }
   return false
 }

--- a/packages/core/src/install/agent-pack-installer.antigravity-mcp.test.ts
+++ b/packages/core/src/install/agent-pack-installer.antigravity-mcp.test.ts
@@ -1,0 +1,205 @@
+/**
+ * AntiGravity `.agents/mcp_config.json` entry-shape + lifecycle coverage
+ * (SMI-6275 Wave 5, GH#2166 ask 3).
+ *
+ * Split from the sibling `agent-pack-installer.workspace-scope.test.ts`
+ * (which covers detection/scope-resolution behavior) and
+ * `agent-pack-installer.test.ts`/`agent-manifest-path-guard.test.ts`,
+ * mirroring this file family's existing `.cursor-mcp.test.ts` sibling
+ * convention. Covers the four things Wave 5's own required test names:
+ *   1. Entry shape — `@skillsmith/mcp-server` key, `npx` form,
+ *      `SKILLSMITH_CLIENT=antigravity` + `SKILLSMITH_TOOL_PROFILE=agent`.
+ *   2. Idempotency — re-install does not duplicate or corrupt the entry.
+ *   3. Conflict/force — a foreign entry at the same key is preserved unless
+ *      `--force` is passed.
+ *   4. Uninstall — removes only Skillsmith-owned keys, restoring any
+ *      hand-added sibling key untouched (also the regression test for the
+ *      `agent-manifest-path-guard.ts` workspace-relative allowlist fix this
+ *      wave adds — without it, `uninstallAgentPack` would silently REJECT
+ *      every AntiGravity manifest entry as "outside known install targets").
+ *
+ * @module @skillsmith/core/install/agent-pack-installer.antigravity-mcp.test
+ */
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { installAgentPack } from './agent-pack-installer.js'
+import { uninstallAgentPack } from './agent-pack-uninstaller.js'
+import { AGENT_INSTALL_DIR_ENV_VAR } from './agent-manifest.js'
+
+let homeDir: string
+let workspaceDir: string
+let manifestDir: string
+let prevInstallDirEnv: string | undefined
+
+interface AntigravityMcpDoc {
+  mcpServers: Record<
+    string,
+    { command: string; args?: string[]; env?: Record<string, string> } | undefined
+  >
+}
+
+function mcpConfigPath(workspace: string): string {
+  return join(workspace, '.agents', 'mcp_config.json')
+}
+
+function readAntigravityMcpJson(workspace: string): AntigravityMcpDoc {
+  return JSON.parse(readFileSync(mcpConfigPath(workspace), 'utf-8')) as AntigravityMcpDoc
+}
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(tmpdir(), 'skillsmith-agent-install-home-'))
+  workspaceDir = mkdtempSync(join(tmpdir(), 'skillsmith-agent-install-workspace-'))
+  mkdirSync(join(workspaceDir, '.git'), { recursive: true })
+  manifestDir = mkdtempSync(join(tmpdir(), 'skillsmith-agent-install-manifest-'))
+  prevInstallDirEnv = process.env[AGENT_INSTALL_DIR_ENV_VAR]
+  process.env[AGENT_INSTALL_DIR_ENV_VAR] = manifestDir
+})
+
+afterEach(() => {
+  rmSync(homeDir, { recursive: true, force: true })
+  rmSync(workspaceDir, { recursive: true, force: true })
+  rmSync(manifestDir, { recursive: true, force: true })
+  if (prevInstallDirEnv !== undefined) process.env[AGENT_INSTALL_DIR_ENV_VAR] = prevInstallDirEnv
+  else delete process.env[AGENT_INSTALL_DIR_ENV_VAR]
+})
+
+describe('installAgentPack — AntiGravity mcp_config.json entry shape (SMI-6275 Wave 5)', () => {
+  it('writes the entry under the @skillsmith/mcp-server key with the npx form + SKILLSMITH_CLIENT=antigravity', () => {
+    const result = installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+
+    const doc = readAntigravityMcpJson(workspaceDir)
+    const entry = doc.mcpServers['@skillsmith/mcp-server']
+    expect(entry?.command).toBe('npx')
+    expect(entry?.args).toEqual(['-y', '@skillsmith/mcp-server'])
+    expect(entry?.env?.SKILLSMITH_CLIENT).toBe('antigravity')
+    expect(entry?.env?.SKILLSMITH_TOOL_PROFILE).toBe('agent')
+    // No stray legacy 'skillsmith'-keyed entry — this is a first-ever
+    // implementation, nothing to migrate away from.
+    expect(doc.mcpServers.skillsmith).toBeUndefined()
+
+    const report = result.harnessReports.find((r) => r.harness === 'antigravity')
+    expect(report?.mcpConfig?.status).toBe('created')
+  })
+
+  it('does not regress claude-code’s own entry — still the npx form under the "skillsmith" key, no SKILLSMITH_CLIENT', () => {
+    installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+
+    const claudeDoc = JSON.parse(
+      readFileSync(join(homeDir, '.claude', 'settings.json'), 'utf-8')
+    ) as AntigravityMcpDoc
+    expect(claudeDoc.mcpServers.skillsmith?.command).toBe('npx')
+    expect(claudeDoc.mcpServers.skillsmith?.env?.SKILLSMITH_TOOL_PROFILE).toBe('agent')
+    expect(claudeDoc.mcpServers.skillsmith?.env?.SKILLSMITH_CLIENT).toBeUndefined()
+  })
+})
+
+describe('installAgentPack — AntiGravity mcp_config.json idempotency (SMI-6275 Wave 5)', () => {
+  it('re-install does not create a duplicate second server entry', () => {
+    installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+    const second = installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+
+    const doc = readAntigravityMcpJson(workspaceDir)
+    expect(Object.keys(doc.mcpServers)).toEqual(['@skillsmith/mcp-server'])
+
+    const report = second.harnessReports.find((r) => r.harness === 'antigravity')
+    expect(report?.mcpConfig?.status).toBe('unchanged')
+  })
+
+  it('a second install run leaves the file byte-identical', () => {
+    installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+    const afterFirst = readFileSync(mcpConfigPath(workspaceDir), 'utf-8')
+    installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+    const afterSecond = readFileSync(mcpConfigPath(workspaceDir), 'utf-8')
+
+    expect(afterSecond).toBe(afterFirst)
+  })
+})
+
+describe('installAgentPack — AntiGravity mcp_config.json conflict + --force (SMI-6275 Wave 5)', () => {
+  it('leaves a foreign entry at the same key untouched, reporting a conflict', () => {
+    mkdirSync(join(workspaceDir, '.agents'), { recursive: true })
+    const foreignEntry = { command: 'some-other-tool', args: ['--flag'] }
+    writeFileSync(
+      mcpConfigPath(workspaceDir),
+      JSON.stringify({ mcpServers: { '@skillsmith/mcp-server': foreignEntry } }, null, 2)
+    )
+
+    const result = installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+
+    const doc = readAntigravityMcpJson(workspaceDir)
+    expect(doc.mcpServers['@skillsmith/mcp-server']).toEqual(foreignEntry)
+
+    const report = result.harnessReports.find((r) => r.harness === 'antigravity')
+    expect(report?.mcpConfig?.status).toBe('conflict')
+    expect(report?.notes.some((n) => n.includes('--force'))).toBe(true)
+  })
+
+  it('--force overwrites a foreign entry at the same key', () => {
+    mkdirSync(join(workspaceDir, '.agents'), { recursive: true })
+    writeFileSync(
+      mcpConfigPath(workspaceDir),
+      JSON.stringify(
+        { mcpServers: { '@skillsmith/mcp-server': { command: 'some-other-tool' } } },
+        null,
+        2
+      )
+    )
+
+    const result = installAgentPack({
+      homeDir,
+      cwd: workspaceDir,
+      scope: 'workspace',
+      force: true,
+    })
+
+    const doc = readAntigravityMcpJson(workspaceDir)
+    expect(doc.mcpServers['@skillsmith/mcp-server']?.command).toBe('npx')
+    const report = result.harnessReports.find((r) => r.harness === 'antigravity')
+    expect(report?.mcpConfig?.status).toBe('updated')
+  })
+})
+
+describe('installAgentPack + uninstallAgentPack — AntiGravity workspace artifacts (SMI-6275 Wave 5)', () => {
+  it('uninstall removes the freshly-created skill pack AND mcp_config.json entirely (no manifest-guard rejection)', () => {
+    installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+    const skillPackPath = join(workspaceDir, '.agents', 'skills', 'skillsmith-agent', 'SKILL.md')
+    expect(existsSync(skillPackPath)).toBe(true)
+    expect(existsSync(mcpConfigPath(workspaceDir))).toBe(true)
+
+    const result = uninstallAgentPack({ homeDir })
+
+    // The regression this test guards: without the agent-manifest-path-guard.ts
+    // workspace-relative allowlist fix, both paths would land in `rejected`
+    // (outside the guard's home-relative-only allowlist) and never actually
+    // be deleted.
+    expect(result.rejected).toEqual([])
+    expect(result.removed).toContain(skillPackPath)
+    expect(result.removed).toContain(mcpConfigPath(workspaceDir))
+    expect(existsSync(skillPackPath)).toBe(false)
+    expect(existsSync(mcpConfigPath(workspaceDir))).toBe(false)
+  })
+
+  it('uninstall restores a hand-added sibling key in mcp_config.json untouched, removing only our own key', () => {
+    mkdirSync(join(workspaceDir, '.agents'), { recursive: true })
+    const siblingDoc = { mcpServers: { 'my-other-tool': { command: 'foo', args: ['bar'] } } }
+    writeFileSync(mcpConfigPath(workspaceDir), JSON.stringify(siblingDoc, null, 2))
+
+    installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
+    const afterInstall = readAntigravityMcpJson(workspaceDir)
+    expect(afterInstall.mcpServers['my-other-tool']).toEqual(siblingDoc.mcpServers['my-other-tool'])
+    expect(afterInstall.mcpServers['@skillsmith/mcp-server']).toBeDefined()
+
+    const result = uninstallAgentPack({ homeDir })
+    expect(result.rejected).toEqual([])
+    expect(result.restored).toContain(mcpConfigPath(workspaceDir))
+
+    const afterUninstall = readAntigravityMcpJson(workspaceDir)
+    expect(afterUninstall.mcpServers['my-other-tool']).toEqual(
+      siblingDoc.mcpServers['my-other-tool']
+    )
+    expect(afterUninstall.mcpServers['@skillsmith/mcp-server']).toBeUndefined()
+  })
+})

--- a/packages/core/src/install/agent-pack-installer.antigravity-mcp.ts
+++ b/packages/core/src/install/agent-pack-installer.antigravity-mcp.ts
@@ -1,0 +1,124 @@
+/**
+ * AntiGravity-specific MCP registration step for `sklx agent install`
+ * (SMI-6275 Wave 5, closing the last unshipped ask of GH#2166).
+ *
+ * Split out of `agent-pack-installer.harness.ts`'s generic `installMcpConfig`
+ * for a STRUCTURAL reason (not just a per-harness-quirk reason like Cursor's
+ * split): every other MCP-capable harness's config path is HOME-anchored
+ * (`AGENT_MCP_TARGETS`, `agent-harness-targets.ts`) and resolved via
+ * `relocateUnderHome()`. AntiGravity's `.agents/mcp_config.json` is
+ * WORKSPACE-anchored — relative to the workspace root Wave 4
+ * (`workspace-scope.ts`, ADR-139) resolves — so it cannot live in that
+ * HOME-anchored `Record` at all, and never goes through `relocateUnderHome()`.
+ * This module owns AntiGravity's path resolution + entry-value shape
+ * entirely outside that table, mirroring the Cursor precedent
+ * (`agent-pack-installer.cursor-mcp.ts`, SMI-6279 Wave 9) for the "give it
+ * its own file" convention while differing in WHY: Cursor's shape/key both
+ * diverge from the shared convention; AntiGravity's shape and key both MATCH
+ * the shared convention (see {@link ANTIGRAVITY_MCP_ENTRY_KEY} and
+ * `buildAntigravityMcpEntryValue()` in `agent-pack-installer.entry.ts}) — only
+ * its PATH RESOLUTION diverges structurally.
+ *
+ * ## Schema verification (SMI-6275 Wave 5 Step 2 point 5)
+ *
+ * Confidence: **HIGH**. Verified 2026-08-30 via live web search against two
+ * canonical Google sources (antigravity.google/docs/ide/mcp/ and
+ * antigravity.google/docs/cli/mcp/), corroborated by two independent
+ * third-party write-ups (a Google Cloud Community/Medium walkthrough and a
+ * Composio how-to guide):
+ *   - Path: `.agents/mcp_config.json`, workspace-local, discovered
+ *     automatically by "the SDK" (AntiGravity's own phrasing) — sibling to
+ *     the GLOBAL `~/.gemini/config/mcp_config.json` (itself a sibling of
+ *     `CLIENT_NATIVE_PATHS.antigravity`'s `~/.gemini/config/skills`, `paths.ts`).
+ *     Matches `docs/internal/research/smi-5386-opencode-antigravity-skill-dirs.md`'s
+ *     already-verified `.agents/skills/` sibling convention for the same
+ *     workspace root.
+ *   - Schema: a single top-level `mcpServers` object — the SAME
+ *     `mcpServers`-keyed convention claude-code/copilot/windsurf/hermes
+ *     already use (NOT OpenCode's distinct `local|remote`-typed shape, NOT
+ *     Codex's TOML block, NOT Cursor's resolved-binary-path form). Local/
+ *     command-based servers are defined with `command` + `args` + optional
+ *     `env` — exactly {@link buildAgentMcpEntryValue}'s existing shape, so
+ *     `buildAntigravityMcpEntryValue()` composes over it rather than
+ *     reinventing it.
+ *   - This is reused, not novel: `mergeJsonMcpEntry()` (`agent-config-merge.json.ts`)
+ *     already speaks this exact shape for four other harnesses — only the
+ *     PATH (workspace-anchored) and the entry KEY (package-scoped, matching
+ *     AntiGravity's own docs snippet — see `ANTIGRAVITY_MCP_ENTRY_KEY`) are
+ *     new to this wave.
+ *
+ * @module @skillsmith/core/install/agent-pack-installer.antigravity-mcp
+ */
+
+import { join } from 'node:path'
+
+import { mergeJsonMcpEntry } from './agent-config-merge.json.js'
+import {
+  ANTIGRAVITY_MCP_ENTRY_KEY,
+  buildAntigravityMcpEntryValue,
+} from './agent-pack-installer.entry.js'
+import type { HarnessInstallCtx } from './agent-pack-installer.harness.js'
+import type { HarnessInstallReport } from './agent-pack-installer.types.js'
+import type { MergeResult } from './agent-config-merge.types.js'
+
+/** Same predicate as `agent-pack-installer.harness.ts`'s private `mergeSucceeded` — duplicated rather than exported to keep that module's helper private. */
+function mergeSucceeded(status: MergeResult['status']): boolean {
+  return status === 'created' || status === 'updated' || status === 'unchanged'
+}
+
+/**
+ * Relative path segments (from the resolved workspace root) to AntiGravity's
+ * MCP config file. Exported as a fixed constant — not a hand-duplicated
+ * string literal — so `agent-manifest-path-guard.ts`'s uninstall-time
+ * allowlist check can validate against the EXACT same shape this module
+ * writes, rather than an independently-maintained copy that could drift.
+ */
+export const ANTIGRAVITY_MCP_CONFIG_RELATIVE_SEGMENTS = ['.agents', 'mcp_config.json'] as const
+
+/**
+ * Merge AntiGravity's MCP server registration into
+ * `<workspaceRoot>/.agents/mcp_config.json` under
+ * {@link ANTIGRAVITY_MCP_ENTRY_KEY}.
+ *
+ * Caller (`agent-pack-installer.ts`) is responsible for having already
+ * confirmed `workspaceRoot` is a genuinely resolved AntiGravity workspace
+ * scope (via `resolveScopedSkillsDir()`) — this function does no scope
+ * resolution or detection of its own, per the "reuse Wave 4's resolver,
+ * don't reimplement detection" requirement.
+ */
+export function installAntigravityMcpConfig(
+  workspaceRoot: string,
+  ctx: HarnessInstallCtx,
+  report: HarnessInstallReport
+): void {
+  const path = join(workspaceRoot, ...ANTIGRAVITY_MCP_CONFIG_RELATIVE_SEGMENTS)
+
+  const result = mergeJsonMcpEntry({
+    path,
+    keyPath: ['mcpServers'],
+    entryKey: ANTIGRAVITY_MCP_ENTRY_KEY,
+    entryValue: buildAntigravityMcpEntryValue(),
+    backupDir: ctx.backupDir,
+    force: ctx.force,
+    alreadyBackedUpPaths: ctx.backedUpPaths,
+  })
+
+  report.mcpConfig = result
+  if (result.status === 'conflict') {
+    report.notes.push(
+      `MCP config at ${path} already has a '${ANTIGRAVITY_MCP_ENTRY_KEY}' entry that doesn't look like ours — left untouched. Re-run with --force to overwrite, or edit ${path} manually.`
+    )
+  }
+  if (result.status === 'error') {
+    report.notes.push(`MCP config merge failed at ${path}: ${result.errorMessage}`)
+  }
+  if (mergeSucceeded(result.status)) {
+    ctx.entries.push({
+      path,
+      kind: 'mcp-config',
+      harness: 'antigravity',
+      backupPath: result.backupPath,
+      executable: false,
+    })
+  }
+}

--- a/packages/core/src/install/agent-pack-installer.entry.ts
+++ b/packages/core/src/install/agent-pack-installer.entry.ts
@@ -178,6 +178,48 @@ export function buildOpenCodeMcpEntryValue(): Record<string, unknown> {
   }
 }
 
+/**
+ * AntiGravity's own MCP server registration value (SMI-6275 Wave 5).
+ *
+ * Unlike Cursor, there is no verified evidence of an `npx`-inside-bundled-Node
+ * failure for AntiGravity (Wave 7 of the SMI-6266 plan makes the same call
+ * for the website/CLI docs snippet) — so this stays on the plain `npx` form,
+ * composed directly over {@link buildAgentMcpEntryValue} rather than
+ * reimplementing it. The one addition is `env.SKILLSMITH_CLIENT = 'antigravity'`,
+ * for the same reason Cursor's builder sets it (SMI-5894 Wave 1 Step 7):
+ * without it, an MCP server spawned from THIS entry would default to
+ * `~/.claude/skills` (`resolveClientPath()`'s fallback) instead of
+ * AntiGravity's own directories.
+ */
+export function buildAntigravityMcpEntryValue(): Record<string, unknown> {
+  const base = buildAgentMcpEntryValue()
+  return {
+    ...base,
+    env: {
+      ...(base.env as Record<string, unknown>),
+      SKILLSMITH_CLIENT: 'antigravity',
+    },
+  }
+}
+
+/**
+ * JSON key AntiGravity's `.agents/mcp_config.json` entry is installed under
+ * (SMI-6275 Wave 5) — deliberately the SAME value as {@link CURSOR_MCP_ENTRY_KEY},
+ * not the legacy `'skillsmith'` key every other non-Cursor harness's
+ * installer entry still uses. AntiGravity's OWN human-facing docs snippets
+ * (`packages/website/src/lib/mcp-client-snippets.ts`'s `STANDARD_JSON_BODY`
+ * and the CLI template's antigravity entry, both verified live 2026-08-30)
+ * already use the package-scoped key `@skillsmith/mcp-server` — aligning the
+ * installer's key here avoids the exact key-mismatch class of bug SMI-6279
+ * fixed for Cursor (a user who both pastes the docs snippet AND runs
+ * `agent install` ending up with two divergent, mutually-unrecognized
+ * entries). Unlike Cursor, AntiGravity has no PRE-EXISTING `agent install`
+ * writer to migrate away from — this is its first-ever implementation — so
+ * there is no legacy-keyed entry to clean up here (contrast
+ * `agent-pack-installer.cursor-mcp.ts`'s `stripStaleLegacyMcpKey`).
+ */
+export const ANTIGRAVITY_MCP_ENTRY_KEY = CURSOR_MCP_ENTRY_KEY
+
 /** Codex `[mcp_servers.skillsmith]` TOML block (text between our markers). */
 export function buildCodexMcpTomlBlock(): string {
   return [

--- a/packages/core/src/install/agent-pack-installer.ts
+++ b/packages/core/src/install/agent-pack-installer.ts
@@ -24,6 +24,14 @@
  *   - The `skillsmith` MCP server registration (`SKILLSMITH_TOOL_PROFILE=agent`)
  *     for every detected MCP-capable harness (all 7), backup-first,
  *     idempotent, preserve-and-prompt on a foreign entry.
+ *   - AntiGravity (SMI-6275 Wave 5): a workspace-scoped 8th target, handled
+ *     OUTSIDE the 7-harness loop above — see the `antigravity` block near
+ *     the end of `installAgentPack`. Whenever its workspace scope resolves
+ *     (an existing `.agents/` marker auto-detects, or `--scope workspace`
+ *     creates one), writes the skill pack AND `.agents/mcp_config.json`
+ *     (`installAntigravityMcpConfig`, `agent-pack-installer.antigravity-mcp.ts`)
+ *     — MCP config only, no hooks/shim this wave (stated decision, see
+ *     `HOOK_HARNESSES`'s doc comment in `services/agent-pack/types.ts`).
  *
  * Every write funnels through `writeOwnedArtifactFile` (owned files) or the
  * `agent-config-merge.*` helpers (shared config files), both of which record
@@ -61,6 +69,7 @@ import {
 } from './agent-pack-installer.harness.js'
 import { installCursorHooks } from './agent-pack-installer.cursor-hooks.js'
 import { installCursorMcpConfig } from './agent-pack-installer.cursor-mcp.js'
+import { installAntigravityMcpConfig } from './agent-pack-installer.antigravity-mcp.js'
 import {
   HARNESS_SUPPORT_TIER,
   type AgentInstallOptions,
@@ -289,27 +298,59 @@ export function installAgentPack(opts: AgentInstallOptions = {}): AgentInstallRe
     writeSkillPackFor(CLIENT_NATIVE_PATHS.agents, skillArtifact.content, ctx, 'agents')
   }
 
-  // ADR-139 (SMI-6274 Wave 4, point 5's Wave 5 bootstrap requirement):
-  // `--scope workspace` is the ONLY path that may create AntiGravity's
-  // `.agents/skills` workspace directory — bare `agent install` never
-  // touches it, matching every other harness's detection-only default.
-  // This is deliberately NOT the full AntiGravity harness (MCP config,
-  // hooks, shim) — that is Wave 5's (SMI-6275) own scope; this wave only
-  // guarantees the plumbing (the resolver call + create-permission) Wave 5
-  // needs is reachable, per the ADR's explicit statement that Wave 4 must
-  // not have to build Wave 5's own harness logic.
-  if (opts.scope === 'workspace' && skillArtifact) {
+  // ADR-139 (SMI-6274 Wave 4, point 5's Wave 5 bootstrap requirement) +
+  // SMI-6275 Wave 5: AntiGravity is a valid `agent install` target whenever
+  // its WORKSPACE scope resolves — either because `--scope workspace` was
+  // passed explicitly (the only path allowed to CREATE `.agents/`, ADR-139
+  // point 5), or because an EXISTING `.agents/` marker auto-detects
+  // (ADR-139 point 2 rank 4 — a read-only check `resolveScopedSkillsDir`
+  // already performs on its own when `explicitScope` is omitted; this
+  // function never reimplements that detection). `envScope`/
+  // `configDefaultScope` are pinned to "no value" here rather than left to
+  // read the REAL `SKILLSMITH_SCOPE` env var / `~/.skillsmith/config.json`:
+  // `agent install`'s own CLI surface exposes only `--scope`, no separate
+  // env/config channel for THIS command, and leaving them unpinned would
+  // make a bare `agent install` run's AntiGravity detection depend on
+  // whatever unrelated scope state happens to exist on the invoking
+  // machine — the same test-isolation seam `ResolveScopeParams` documents
+  // its `configDefaultScope: null` value for.
+  //
+  // AntiGravity ALWAYS gets a report row now, whether or not its workspace
+  // scope resolves — matching every OTHER harness's reporting shape
+  // (`newReport()` + a `detected` badge in the CLI table, `agent.action.ts`).
+  // Wave 4 omitted the row entirely for the undetected case; Wave 5 corrects
+  // that for reporting consistency, per its own required test ("no `.agents/`
+  // directory and no `--scope workspace` → clear message, no silent no-op —
+  // match whatever 'not detected' reporting shape other undetected harnesses
+  // already use").
+  if (skillArtifact) {
     const scopeTarget = resolveScopedSkillsDir({
       client: 'antigravity',
       cwd: opts.cwd ?? process.cwd(),
-      explicitScope: 'workspace',
+      explicitScope: opts.scope === 'workspace' ? 'workspace' : undefined,
+      envScope: '',
+      configDefaultScope: null,
     })
     const antigravityReport = newReport('antigravity')
-    antigravityReport.detected = true
-    writeSkillPackFor(scopeTarget.dir, skillArtifact.content, ctx, 'antigravity')
-    antigravityReport.skillPackWritten = true
-    if (scopeTarget.created) {
-      antigravityReport.notes.push(`Created workspace skills directory: ${scopeTarget.dir}`)
+    // `scopeTarget.workspaceRoot` is only ever set when `scope === 'workspace'`
+    // (`ResolvedSkillScope`'s own contract) — narrowing through a single local
+    // avoids re-deriving that condition twice across the branches below.
+    const workspaceRoot = scopeTarget.scope === 'workspace' ? scopeTarget.workspaceRoot : undefined
+    antigravityReport.detected = Boolean(workspaceRoot)
+
+    if (workspaceRoot) {
+      writeSkillPackFor(scopeTarget.dir, skillArtifact.content, ctx, 'antigravity')
+      antigravityReport.skillPackWritten = true
+      if (scopeTarget.created) {
+        antigravityReport.notes.push(`Created workspace skills directory: ${scopeTarget.dir}`)
+      }
+      installAntigravityMcpConfig(workspaceRoot, ctx, antigravityReport)
+    } else {
+      antigravityReport.notes.push(
+        'No .agents/ workspace directory found at or above the current directory, and ' +
+          '--scope workspace was not passed — AntiGravity was not configured. Run ' +
+          '`agent install --scope workspace` from inside your repository to create it.'
+      )
     }
     reports.push(antigravityReport)
   }

--- a/packages/core/src/install/agent-pack-installer.ts
+++ b/packages/core/src/install/agent-pack-installer.ts
@@ -49,7 +49,7 @@ import { join } from 'node:path'
 import { AGENT_PACK_SKILL_NAME, generateAgentPack } from '../services/agent-pack/index.js'
 import { AGENT_TOOL_PROFILE_NAMES } from '../services/agent-tool-profile.js'
 import { CLIENT_NATIVE_PATHS } from './paths.js'
-import { resolveScopedSkillsDir } from './workspace-scope.js'
+import { UnsatisfiableWorkspaceScopeError, resolveScopedSkillsDir } from './workspace-scope.js'
 import { relocateUnderHome } from './agent-home-relocate.js'
 import { writeOwnedArtifactFile } from './agent-pack-installer.fs-helpers.js'
 import {
@@ -324,28 +324,50 @@ export function installAgentPack(opts: AgentInstallOptions = {}): AgentInstallRe
   // match whatever 'not detected' reporting shape other undetected harnesses
   // already use").
   if (skillArtifact) {
-    const scopeTarget = resolveScopedSkillsDir({
-      client: 'antigravity',
-      cwd: opts.cwd ?? process.cwd(),
-      explicitScope: opts.scope === 'workspace' ? 'workspace' : undefined,
-      envScope: '',
-      configDefaultScope: null,
-    })
     const antigravityReport = newReport('antigravity')
-    // `scopeTarget.workspaceRoot` is only ever set when `scope === 'workspace'`
-    // (`ResolvedSkillScope`'s own contract) — narrowing through a single local
-    // avoids re-deriving that condition twice across the branches below.
-    const workspaceRoot = scopeTarget.scope === 'workspace' ? scopeTarget.workspaceRoot : undefined
+    // GPT-5.6-Sol pr-reviewer finding (SMI-6275 Wave 5): resolveScopedSkillsDir()
+    // THROWS UnsatisfiableWorkspaceScopeError when `--scope workspace` was
+    // requested but can't be satisfied (no .agents/ marker and no ancestor
+    // .git). Left uncaught, that throw propagates out of installAgentPack()
+    // ENTIRELY — skipping saveAgentManifest() below, which is the ONLY place
+    // every other harness's already-written entries (lines 228-299 above)
+    // get persisted. The result: real files on disk for claude-code/cursor/
+    // etc, with zero manifest record of them — permanently unreachable by
+    // `agent uninstall`, and silently dropped by a subsequent re-install's
+    // carryForwardPriorBackups(). This is expected, narrow failure (a scope
+    // request AntiGravity specifically can't satisfy), not a programming
+    // bug, so it degrades to a normal not-detected report row instead of
+    // aborting the run; any OTHER error still propagates unchanged.
+    let workspaceRoot: string | undefined
+    let scopeTarget: ReturnType<typeof resolveScopedSkillsDir> | undefined
+    try {
+      scopeTarget = resolveScopedSkillsDir({
+        client: 'antigravity',
+        cwd: opts.cwd ?? process.cwd(),
+        explicitScope: opts.scope === 'workspace' ? 'workspace' : undefined,
+        envScope: '',
+        configDefaultScope: null,
+      })
+      // `scopeTarget.workspaceRoot` is only ever set when `scope === 'workspace'`
+      // (`ResolvedSkillScope`'s own contract) — narrowing through a single
+      // local avoids re-deriving that condition twice across the branches below.
+      workspaceRoot = scopeTarget.scope === 'workspace' ? scopeTarget.workspaceRoot : undefined
+    } catch (err) {
+      if (!(err instanceof UnsatisfiableWorkspaceScopeError)) throw err
+      antigravityReport.notes.push(
+        `AntiGravity workspace scope could not be resolved: ${err.message}`
+      )
+    }
     antigravityReport.detected = Boolean(workspaceRoot)
 
-    if (workspaceRoot) {
+    if (workspaceRoot && scopeTarget) {
       writeSkillPackFor(scopeTarget.dir, skillArtifact.content, ctx, 'antigravity')
       antigravityReport.skillPackWritten = true
       if (scopeTarget.created) {
         antigravityReport.notes.push(`Created workspace skills directory: ${scopeTarget.dir}`)
       }
       installAntigravityMcpConfig(workspaceRoot, ctx, antigravityReport)
-    } else {
+    } else if (antigravityReport.notes.length === 0) {
       antigravityReport.notes.push(
         'No .agents/ workspace directory found at or above the current directory, and ' +
           '--scope workspace was not passed — AntiGravity was not configured. Run ' +

--- a/packages/core/src/install/agent-pack-installer.types.ts
+++ b/packages/core/src/install/agent-pack-installer.types.ts
@@ -18,6 +18,12 @@ export const HARNESS_SUPPORT_TIER: Readonly<Record<string, SupportTier>> = {
   opencode: 2,
   hermes: 2,
   windsurf: 3,
+  // SMI-6275 Wave 5: MCP config only (no shim, no hooks) — same reduced
+  // profile as windsurf, stated explicitly per the wave's own "support tier"
+  // decision requirement (see HOOK_HARNESSES's doc comment,
+  // services/agent-pack/types.ts, and AGENT_SHIM_TARGETS.antigravity,
+  // agent-harness-targets.ts).
+  antigravity: 3,
 }
 
 export interface HarnessInstallReport {
@@ -40,12 +46,22 @@ export interface AgentInstallOptions {
   /**
    * ADR-139 (SMI-6274 Wave 4, point 5's Wave 5 bootstrap requirement):
    * `'workspace'` bootstraps AntiGravity as a target by resolving (and, if
-   * necessary, CREATING) its workspace-scoped `.agents/skills` directory
-   * via `resolveScopedSkillsDir()`, then writing the skill pack there —
-   * this is the ONLY path that may create `.agents/` (bare `agent install`
-   * with no `scope` never touches AntiGravity at all, matching every other
-   * harness's detection-only default). Omitted/`'global'` preserves
-   * today's exact behavior.
+   * necessary, CREATING) its workspace-scoped `.agents/` directory via
+   * `resolveScopedSkillsDir()`, then writing the skill pack AND
+   * `.agents/mcp_config.json` there (SMI-6275 Wave 5 adds the latter) —
+   * this is the ONLY path that may CREATE `.agents/`.
+   *
+   * Omitted/`'global'` does NOT mean "AntiGravity untouched," despite the
+   * name — bare `agent install` still AUTO-DETECTS an already-EXISTING
+   * `.agents/` marker at or above `cwd` (ADR-139 point 2 rank 4, a
+   * read-only check that never creates anything) and, when found, installs
+   * the same skill pack + MCP config there. AntiGravity is only skipped
+   * entirely (reported `detected: false`, with a note — never a silent
+   * omission) when NO `.agents/` marker exists anywhere in the ancestry AND
+   * `scope` wasn't explicitly `'workspace'`. This auto-detect behavior is
+   * new in SMI-6275 Wave 5 — Wave 4 gated the skill-pack write on an
+   * explicit `'workspace'` value ONLY (see git history if comparing against
+   * that wave's own tests).
    */
   scope?: 'global' | 'workspace'
   /**

--- a/packages/core/src/install/agent-pack-installer.workspace-scope.test.ts
+++ b/packages/core/src/install/agent-pack-installer.workspace-scope.test.ts
@@ -27,7 +27,10 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { installAgentPack } from './agent-pack-installer.js'
+import { uninstallAgentPack } from './agent-pack-uninstaller.js'
 import { AGENT_INSTALL_DIR_ENV_VAR } from './agent-manifest.js'
+import { CLIENT_NATIVE_PATHS } from './paths.js'
+import { relocateUnderHome } from './agent-home-relocate.js'
 
 let homeDir: string
 let workspaceDir: string
@@ -114,6 +117,52 @@ describe('installAgentPack --scope workspace (ADR-139 point 5, required test 15)
     const antigravityReport = result.harnessReports.find((r) => r.harness === 'antigravity')
     expect(antigravityReport?.skillPackWritten).toBe(true)
     expect(antigravityReport?.notes.some((n) => n.includes('Created workspace'))).toBe(false)
+  })
+
+  // GPT-5.6-Sol pr-reviewer finding (SMI-6275 Wave 5): resolveScopedSkillsDir()
+  // throws UnsatisfiableWorkspaceScopeError when `--scope workspace` can't be
+  // satisfied (no .agents/ marker AND no ancestor .git). Before the fix, that
+  // throw propagated out of installAgentPack() entirely, skipping
+  // saveAgentManifest() and losing every OTHER harness's already-written
+  // entries — real files on disk with no manifest record, unreachable by
+  // `agent uninstall`.
+  it('`--scope workspace` outside any workspace (no .agents/, no ancestor .git) does not throw, reports antigravity as not detected with the resolver error, and still persists every other harness to the manifest', () => {
+    const bareDir = mkdtempSync(join(tmpdir(), 'skillsmith-agent-install-bare-'))
+    try {
+      let result: ReturnType<typeof installAgentPack> | undefined
+      expect(() => {
+        result = installAgentPack({ homeDir, cwd: bareDir, scope: 'workspace' })
+      }).not.toThrow()
+
+      const antigravityReport = result?.harnessReports.find((r) => r.harness === 'antigravity')
+      expect(antigravityReport?.detected).toBe(false)
+      expect(antigravityReport?.skillPackWritten).toBe(false)
+      expect(
+        antigravityReport?.notes.some((n) => n.includes('workspace scope could not be resolved'))
+      ).toBe(true)
+
+      // Proof the manifest actually recorded every other harness's writes
+      // (not just that the files exist on disk, which would be true even
+      // with the bug — the bug was the MANIFEST being skipped): a real
+      // installer-written file from a harness untouched by this failure
+      // must still exist...
+      const claudeSkillPath = join(
+        relocateUnderHome(CLIENT_NATIVE_PATHS['claude-code'], homeDir),
+        'skillsmith-agent',
+        'SKILL.md'
+      )
+      expect(existsSync(claudeSkillPath)).toBe(true)
+
+      // ...and uninstallAgentPack (which replays ONLY the manifest, never
+      // re-deriving "what the generator would currently produce") must be
+      // able to find and remove it — impossible unless saveAgentManifest()
+      // was actually reached despite the AntiGravity resolver's throw.
+      const uninstallResult = uninstallAgentPack()
+      expect(uninstallResult.removed).toContain(claudeSkillPath)
+      expect(existsSync(claudeSkillPath)).toBe(false)
+    } finally {
+      rmSync(bareDir, { recursive: true, force: true })
+    }
   })
 
   it('every other harness report is unaffected by --scope workspace', () => {

--- a/packages/core/src/install/agent-pack-installer.workspace-scope.test.ts
+++ b/packages/core/src/install/agent-pack-installer.workspace-scope.test.ts
@@ -1,11 +1,23 @@
 /**
  * @fileoverview ADR-139 (SMI-6274 Wave 4) point 5's Wave 5 bootstrap
  *   requirement — `installAgentPack({ scope: 'workspace' })` must be the
- *   ONLY thing that can bootstrap AntiGravity as a target (creating
- *   `.agents/skills` if it doesn't exist yet). Split from the sibling
- *   `agent-pack-installer.test.ts` (already at the 500-line gate) following
- *   this file family's existing `.cursor-hooks.test.ts`/`.cursor-mcp.test.ts`
- *   sibling convention.
+ *   ONLY thing that can CREATE `.agents/skills` when it doesn't exist yet.
+ *   Split from the sibling `agent-pack-installer.test.ts` (already at the
+ *   500-line gate) following this file family's existing
+ *   `.cursor-hooks.test.ts`/`.cursor-mcp.test.ts` sibling convention.
+ *
+ *   SMI-6275 Wave 5 correction to this file's own original assertions: Wave
+ *   4 omitted the `antigravity` report row entirely when no workspace scope
+ *   resolved — this test file originally asserted exactly that omission.
+ *   Wave 5's own required test ("no `.agents/` directory and no `--scope
+ *   workspace` → clear message, no silent no-op — match whatever 'not
+ *   detected' reporting shape other undetected harnesses already use")
+ *   corrects that: AntiGravity now ALWAYS gets a row, `detected: false`
+ *   with an explanatory note when its workspace scope doesn't resolve,
+ *   matching every other harness's reporting shape. The first test below is
+ *   updated accordingly. MCP-config-specific coverage (schema, idempotency,
+ *   conflict/force, uninstall) lives in the sibling
+ *   `agent-pack-installer.antigravity-mcp.test.ts`.
  * @module @skillsmith/core/install/agent-pack-installer.workspace-scope.test
  * @see ADR-139 required test 15.
  */
@@ -40,14 +52,42 @@ afterEach(() => {
 })
 
 describe('installAgentPack --scope workspace (ADR-139 point 5, required test 15)', () => {
-  it('bare `agent install` (no scope) never creates .agents/skills, and reports no antigravity row', () => {
+  it('bare `agent install` (no scope, no existing .agents/) never creates .agents/skills, and reports antigravity as not detected — SMI-6275 Wave 5 correction: a row is now ALWAYS present, matching every other harness', () => {
     const result = installAgentPack({ homeDir, cwd: workspaceDir })
 
     expect(existsSync(join(workspaceDir, '.agents', 'skills'))).toBe(false)
-    expect(result.harnessReports.find((r) => r.harness === 'antigravity')).toBeUndefined()
+    const antigravityReport = result.harnessReports.find((r) => r.harness === 'antigravity')
+    expect(antigravityReport).toBeDefined()
+    expect(antigravityReport?.detected).toBe(false)
+    expect(antigravityReport?.skillPackWritten).toBe(false)
+    expect(antigravityReport?.mcpConfig).toBeNull()
+    // Clear message, not a silent no-op (SMI-6275 Wave 5 required test).
+    expect(
+      antigravityReport?.notes.some(
+        (n) => n.includes('No .agents/') && n.includes('--scope workspace')
+      )
+    ).toBe(true)
   })
 
-  it('`--scope workspace` in a repository with no .agents/ creates it and registers antigravity as a target', () => {
+  it('bare `agent install` (no scope) AUTO-DETECTS an already-existing .agents/skills marker and configures AntiGravity — SMI-6275 Wave 5', () => {
+    mkdirSync(join(workspaceDir, '.agents', 'skills'), { recursive: true })
+
+    const result = installAgentPack({ homeDir, cwd: workspaceDir })
+
+    const skillPackPath = join(workspaceDir, '.agents', 'skills', 'skillsmith-agent', 'SKILL.md')
+    expect(existsSync(skillPackPath)).toBe(true)
+    const mcpConfigPath = join(workspaceDir, '.agents', 'mcp_config.json')
+    expect(existsSync(mcpConfigPath)).toBe(true)
+
+    const antigravityReport = result.harnessReports.find((r) => r.harness === 'antigravity')
+    expect(antigravityReport?.detected).toBe(true)
+    expect(antigravityReport?.skillPackWritten).toBe(true)
+    expect(antigravityReport?.mcpConfig?.status).toBe('created')
+    // Auto-detect never creates — the marker already existed.
+    expect(antigravityReport?.notes.some((n) => n.includes('Created workspace'))).toBe(false)
+  })
+
+  it('`--scope workspace` in a repository with no .agents/ creates it and registers antigravity as a target, writing both the skill pack and mcp_config.json', () => {
     expect(existsSync(join(workspaceDir, '.agents'))).toBe(false)
 
     const result = installAgentPack({ homeDir, cwd: workspaceDir, scope: 'workspace' })
@@ -55,11 +95,14 @@ describe('installAgentPack --scope workspace (ADR-139 point 5, required test 15)
     const skillPackPath = join(workspaceDir, '.agents', 'skills', 'skillsmith-agent', 'SKILL.md')
     expect(existsSync(skillPackPath)).toBe(true)
     expect(readFileSync(skillPackPath, 'utf-8').length).toBeGreaterThan(0)
+    const mcpConfigPath = join(workspaceDir, '.agents', 'mcp_config.json')
+    expect(existsSync(mcpConfigPath)).toBe(true)
 
     const antigravityReport = result.harnessReports.find((r) => r.harness === 'antigravity')
     expect(antigravityReport).toBeDefined()
     expect(antigravityReport?.detected).toBe(true)
     expect(antigravityReport?.skillPackWritten).toBe(true)
+    expect(antigravityReport?.mcpConfig?.status).toBe('created')
     expect(antigravityReport?.notes.some((n) => n.includes('Created workspace'))).toBe(true)
   })
 

--- a/packages/core/src/install/agent-pack-uninstaller.test.ts
+++ b/packages/core/src/install/agent-pack-uninstaller.test.ts
@@ -169,6 +169,55 @@ describe('uninstallAgentPack — exact reversal', () => {
     expect(result.removed).not.toContain(settingsPath)
   })
 
+  // GPT-5.6-Sol pr-reviewer round-2 confirmation finding: round 1's fix only
+  // lstat'd the LEAF path for isSymbolicLink() — a symlinked ANCESTOR
+  // directory still slipped through, since lstat doesn't dereference parent
+  // components. The realpathSync()-based fix must catch this too.
+  it('refuses to restore into (or delete) a manifest entry whose path is reached through a symlinked ANCESTOR directory', () => {
+    // A real, non-symlinked ".claude" directory holding the victim...
+    const realClaudeDir = join(homeDir, 'real-claude-target')
+    mkdirSync(realClaudeDir, { recursive: true })
+    const victimPath = join(realClaudeDir, 'settings.json')
+    writeFileSync(victimPath, 'victim original content')
+
+    // ...and a manifest entry whose path is reached via a SYMLINKED
+    // ".claude" directory (the parent, not the leaf) pointing at it — the
+    // leaf component itself ("settings.json") is not a symlink at all.
+    const claudeSymlinkPath = join(homeDir, '.claude')
+    symlinkSync(realClaudeDir, claudeSymlinkPath)
+    const entryPath = join(claudeSymlinkPath, 'settings.json')
+
+    const manifestPath = getAgentManifestPath()
+    writeFileSync(
+      manifestPath,
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          installedAt: new Date().toISOString(),
+          packSchemaVersion: 1,
+          entries: [
+            {
+              path: entryPath,
+              kind: 'mcp-config',
+              harness: 'claude-code',
+              backupPath: null,
+              executable: false,
+            },
+          ],
+        },
+        null,
+        2
+      )
+    )
+
+    const result = uninstallAgentPack()
+
+    // The victim file must be untouched.
+    expect(readFileSync(victimPath, 'utf-8')).toBe('victim original content')
+    expect(result.rejected).toContain(entryPath)
+    expect(result.removed).not.toContain(entryPath)
+  })
+
   it('refuses to restore from a backupPath outside the manifest backups directory', () => {
     mkdirSync(join(homeDir, '.claude'), { recursive: true })
     const settingsPath = join(homeDir, '.claude', 'settings.json')

--- a/packages/core/src/install/agent-pack-uninstaller.test.ts
+++ b/packages/core/src/install/agent-pack-uninstaller.test.ts
@@ -6,7 +6,15 @@
  *               the governance manifest-path-guard security tests.
  * @module @skillsmith/core/install/agent-pack-uninstaller.test
  */
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -116,6 +124,49 @@ describe('uninstallAgentPack — exact reversal', () => {
     // ...and is reported as rejected, not silently dropped or counted as removed.
     expect(result.rejected).toContain(sensitivePath)
     expect(result.removed).not.toContain(sensitivePath)
+  })
+
+  // GPT-5.6-Sol pr-reviewer finding (SMI-6275 Wave 5): isAllowedManifestEntryPath
+  // proves entry.path structurally LOOKS like a known installer target — it
+  // says nothing about whether the filesystem node there is the plain file
+  // the installer wrote, versus a symlink (e.g. content already present at
+  // that exact path before Skillsmith ever ran). Without a symlink check,
+  // the restore branch's `writeFileSync` follows the link and overwrites
+  // whatever it points at, even though `entry.path` and `entry.backupPath`
+  // both pass every existing validation.
+  it('refuses to restore into (or delete) a manifest entry whose path is a symlink, even with a legitimate backupPath', () => {
+    mkdirSync(join(homeDir, '.claude'), { recursive: true })
+    const settingsPath = join(homeDir, '.claude', 'settings.json')
+    writeFileSync(settingsPath, JSON.stringify({ someOtherKey: true }, null, 2))
+
+    installAgentPack({ homeDir })
+    const manifestPath = getAgentManifestPath()
+    const manifestAfterInstall = JSON.parse(readFileSync(manifestPath, 'utf-8')) as {
+      entries: Array<{ path: string; backupPath: string | null }>
+    }
+    const settingsEntry = manifestAfterInstall.entries.find((e) => e.path === settingsPath)
+    // A REAL, trusted backup from the real install run — proves the symlink
+    // check is what blocks this, not the pre-existing backupPath validation.
+    expect(settingsEntry?.backupPath).toBeTruthy()
+
+    // Replace the real settings.json with a symlink to an unrelated victim
+    // file OUTSIDE any installer target, simulating content that already
+    // occupied this exact allowed-suffix path before Skillsmith ran.
+    rmSync(settingsPath)
+    const victimPath = join(homeDir, 'victim.txt')
+    writeFileSync(victimPath, 'victim original content')
+    symlinkSync(victimPath, settingsPath)
+
+    const result = uninstallAgentPack()
+
+    // The victim file must be untouched — restore-from-backup must NOT
+    // follow the symlink and overwrite its target.
+    expect(readFileSync(victimPath, 'utf-8')).toBe('victim original content')
+    // The symlink itself is left alone too (rejected, not replaced/deleted).
+    expect(existsSync(settingsPath)).toBe(true)
+    expect(result.rejected).toContain(settingsPath)
+    expect(result.restored).not.toContain(settingsPath)
+    expect(result.removed).not.toContain(settingsPath)
   })
 
   it('refuses to restore from a backupPath outside the manifest backups directory', () => {

--- a/packages/core/src/install/agent-pack-uninstaller.ts
+++ b/packages/core/src/install/agent-pack-uninstaller.ts
@@ -15,16 +15,22 @@
  *   - A path already missing on disk (user deleted it manually) is a no-op,
  *     not an error.
  *
- * SECURITY (governance follow-up, 2026-07-01): before touching the
+ * SECURITY (governance follow-up, 2026-07-01; symlink check added SMI-6275
+ * Wave 5 per a GPT-5.6-Sol pr-reviewer finding): before touching the
  * filesystem, every entry's `path` is checked against
  * {@link isAllowedManifestEntryPath} (must structurally match one of the
- * installer's known per-harness target locations) and, when `backupPath` is
- * set, {@link isAllowedManifestBackupPath} (must resolve under this run's
- * manifest backups directory). The manifest is an ordinary user-writable
- * JSON file, not a signed record — a corrupted or tampered manifest must
- * never become an arbitrary-file-delete/overwrite primitive. An entry
- * failing either check is skipped entirely (added to `result.rejected`,
- * counted toward neither `removed` nor `restored`) rather than acted on.
+ * installer's known per-harness target locations), that it is not itself a
+ * SYMLINK (`lstatSync(...).isSymbolicLink()` — a matching suffix proves the
+ * path LOOKS right, not that the node there is the plain file the installer
+ * actually wrote; a symlink at that path would make the restore branch's
+ * `writeFileSync` follow it and overwrite the link's target instead), and,
+ * when `backupPath` is set, {@link isAllowedManifestBackupPath} (must
+ * resolve under this run's manifest backups directory). The manifest is an
+ * ordinary user-writable JSON file, not a signed record — a corrupted or
+ * tampered manifest must never become an arbitrary-file-delete/overwrite
+ * primitive. An entry failing any check is skipped entirely (added to
+ * `result.rejected`, counted toward neither `removed` nor `restored`)
+ * rather than acted on.
  *
  * After removing all installer-created files, now-empty directories we
  * likely created (the parents of removed paths) are cleaned up bottom-up —
@@ -40,7 +46,7 @@
  */
 
 import { dirname } from 'node:path'
-import { existsSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, lstatSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from 'node:fs'
 
 import { loadAgentManifest, saveAgentManifest } from './agent-manifest.js'
 import {
@@ -72,6 +78,25 @@ export function uninstallAgentPack(_opts: AgentUninstallOptions = {}): AgentUnin
     }
     if (!existsSync(entry.path)) {
       alreadyGone.push(entry.path)
+      continue
+    }
+    // GPT-5.6-Sol pr-reviewer finding (SMI-6275 Wave 5): passing
+    // isAllowedManifestEntryPath's structural suffix check proves entry.path
+    // LOOKS like one of the installer's known targets — it does not prove
+    // the filesystem node there is the plain file/directory this installer
+    // actually wrote. If it's a SYMLINK (e.g. planted by unrelated content
+    // already present at that path before Skillsmith ever ran — a real risk
+    // for the workspace-relative allowlist added this wave, since a
+    // workspace root is far more likely to contain untrusted pre-existing
+    // content than $HOME), the writeFileSync restore branch below follows
+    // it and overwrites the LINK TARGET, not the manifest-declared path —
+    // defeating the entire suffix allowlist and turning a tampered manifest
+    // into a write-anywhere-the-symlink-points primitive, the exact
+    // "arbitrary-file-overwrite" this guard's own module header says must
+    // never be possible. A legitimate installer-written artifact is never a
+    // symlink, so reject unconditionally rather than resolve-and-compare.
+    if (lstatSync(entry.path).isSymbolicLink()) {
+      rejected.push(entry.path)
       continue
     }
     touchedDirs.add(dirname(entry.path))

--- a/packages/core/src/install/agent-pack-uninstaller.ts
+++ b/packages/core/src/install/agent-pack-uninstaller.ts
@@ -16,20 +16,25 @@
  *     not an error.
  *
  * SECURITY (governance follow-up, 2026-07-01; symlink check added SMI-6275
- * Wave 5 per a GPT-5.6-Sol pr-reviewer finding): before touching the
- * filesystem, every entry's `path` is checked against
- * {@link isAllowedManifestEntryPath} (must structurally match one of the
- * installer's known per-harness target locations), that it is not itself a
- * SYMLINK (`lstatSync(...).isSymbolicLink()` — a matching suffix proves the
- * path LOOKS right, not that the node there is the plain file the installer
- * actually wrote; a symlink at that path would make the restore branch's
- * `writeFileSync` follow it and overwrite the link's target instead), and,
- * when `backupPath` is set, {@link isAllowedManifestBackupPath} (must
- * resolve under this run's manifest backups directory). The manifest is an
- * ordinary user-writable JSON file, not a signed record — a corrupted or
- * tampered manifest must never become an arbitrary-file-delete/overwrite
- * primitive. An entry failing any check is skipped entirely (added to
- * `result.rejected`, counted toward neither `removed` nor `restored`)
+ * Wave 5 per two rounds of GPT-5.6-Sol pr-reviewer findings — round 1 caught
+ * a symlinked LEAF, round 2 caught round 1's own fix still missing a
+ * symlinked ANCESTOR directory): before touching the filesystem, every
+ * entry's `path` is checked against {@link isAllowedManifestEntryPath} (must
+ * structurally match one of the installer's known per-harness target
+ * locations), that `realpathSync()`'s fully-resolved form of the path
+ * (dereferencing EVERY symlink in the chain, leaf and ancestors alike)
+ * equals its own plain `path.resolve()` (a matching suffix proves the path
+ * LOOKS right, not that every component of the actual filesystem node
+ * reached by that path is a plain, non-symlinked directory/file the
+ * installer actually wrote — a link anywhere in the chain would make the
+ * restore branch's `writeFileSync` follow it and overwrite whatever is at
+ * the far end instead), and, when `backupPath` is set,
+ * {@link isAllowedManifestBackupPath} (must resolve under this run's
+ * manifest backups directory). The manifest is an ordinary user-writable
+ * JSON file, not a signed record — a corrupted or tampered manifest must
+ * never become an arbitrary-file-delete/overwrite primitive. An entry
+ * failing any check is skipped entirely (added to `result.rejected`,
+ * counted toward neither `removed` nor `restored`)
  * rather than acted on.
  *
  * After removing all installer-created files, now-empty directories we
@@ -45,8 +50,15 @@
  * @module @skillsmith/core/install/agent-pack-uninstaller
  */
 
-import { dirname } from 'node:path'
-import { existsSync, lstatSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 
 import { loadAgentManifest, saveAgentManifest } from './agent-manifest.js'
 import {
@@ -80,22 +92,37 @@ export function uninstallAgentPack(_opts: AgentUninstallOptions = {}): AgentUnin
       alreadyGone.push(entry.path)
       continue
     }
-    // GPT-5.6-Sol pr-reviewer finding (SMI-6275 Wave 5): passing
+    // GPT-5.6-Sol pr-reviewer finding (SMI-6275 Wave 5), round 2: passing
     // isAllowedManifestEntryPath's structural suffix check proves entry.path
     // LOOKS like one of the installer's known targets — it does not prove
     // the filesystem node there is the plain file/directory this installer
-    // actually wrote. If it's a SYMLINK (e.g. planted by unrelated content
-    // already present at that path before Skillsmith ever ran — a real risk
-    // for the workspace-relative allowlist added this wave, since a
-    // workspace root is far more likely to contain untrusted pre-existing
-    // content than $HOME), the writeFileSync restore branch below follows
-    // it and overwrites the LINK TARGET, not the manifest-declared path —
-    // defeating the entire suffix allowlist and turning a tampered manifest
-    // into a write-anywhere-the-symlink-points primitive, the exact
-    // "arbitrary-file-overwrite" this guard's own module header says must
-    // never be possible. A legitimate installer-written artifact is never a
-    // symlink, so reject unconditionally rather than resolve-and-compare.
-    if (lstatSync(entry.path).isSymbolicLink()) {
+    // actually wrote. Round 1 of this fix only lstat'd the LEAF (entry.path
+    // itself) for isSymbolicLink() — round 2's confirmation pass correctly
+    // flagged that as incomplete: lstat does not dereference PARENT path
+    // components, so a symlinked ancestor directory (e.g. `.agents` itself
+    // being a symlink — a real risk for the workspace-relative allowlist
+    // added this wave, since a workspace root is far more likely to contain
+    // untrusted pre-existing content than $HOME) would still let the leaf
+    // check pass while writeFileSync's restore branch below resolves
+    // through that ancestor link and overwrites content OUTSIDE the
+    // manifest-declared path entirely. realpathSync() resolves EVERY
+    // symlink in the full chain (leaf and every ancestor); comparing its
+    // result against the plain, non-dereferencing path.resolve() of the
+    // same input catches a link anywhere in that chain in one check — this
+    // supersedes (not supplements) the leaf-only lstatSync check.
+    const resolvedPath = resolve(entry.path)
+    let realEntryPath: string
+    try {
+      realEntryPath = realpathSync(resolvedPath)
+    } catch {
+      // existsSync() above passed, but the path vanished (or a component
+      // became unreadable) before realpathSync ran — a race, not proof of
+      // safety. Reject rather than fall through to alreadyGone, which
+      // would silently skip cleanup of what could be a real artifact.
+      rejected.push(entry.path)
+      continue
+    }
+    if (realEntryPath !== resolvedPath) {
       rejected.push(entry.path)
       continue
     }

--- a/packages/core/src/install/agent-pack-uninstaller.ts
+++ b/packages/core/src/install/agent-pack-uninstaller.ts
@@ -122,6 +122,10 @@ export function uninstallAgentPack(_opts: AgentUninstallOptions = {}): AgentUnin
       rejected.push(entry.path)
       continue
     }
+    // audit-allow:realpath-asymmetry — both sides derive from the SAME
+    // input (entry.path); the divergence itself is the detection signal
+    // (see the fuller comment above), not the SMI-4688/4692 bug this check
+    // targets (two independently-derived paths, only one realpath'd).
     if (realEntryPath !== resolvedPath) {
       rejected.push(entry.path)
       continue

--- a/packages/core/src/services/agent-pack/types.ts
+++ b/packages/core/src/services/agent-pack/types.ts
@@ -57,8 +57,19 @@ export const AGENT_PACK_COMPATIBILITY: readonly string[] = [
   'windsurf',
 ]
 
-/** Harness identifiers the pack targets. */
-export type HarnessId = 'claude-code' | 'cursor' | 'codex' | 'copilot' | 'opencode'
+/**
+ * Harness identifiers the pack targets. `antigravity` added SMI-6275 Wave 5
+ * (closing the last unshipped ask of GH#2166): `agent install` can now
+ * target AntiGravity's WORKSPACE-scoped `.agents/mcp_config.json` (see
+ * `agent-pack-installer.antigravity-mcp.ts`) — the same recency precedent
+ * `cursor` set as this enum's most-recently-added member before it. Note
+ * AntiGravity does NOT get an entry in `AGENT_MCP_TARGETS`
+ * (`agent-harness-targets.ts`) the way every other `McpHarnessId` member
+ * does — its config path is workspace-anchored, not home-anchored, so it
+ * structurally doesn't fit that Record's shape; see `McpHarnessId`'s own
+ * doc comment.
+ */
+export type HarnessId = 'claude-code' | 'cursor' | 'codex' | 'copilot' | 'opencode' | 'antigravity'
 
 /**
  * Harnesses that get a generated SessionStart/SessionEnd hook (PRD §3.1,
@@ -66,6 +77,19 @@ export type HarnessId = 'claude-code' | 'cursor' | 'codex' | 'copilot' | 'openco
  * absent) and Windsurf has no hook system — both excluded. Copilot/OpenCode
  * hooks (preview / JS-plugin format) are out of Wave-1 hook scope by decision;
  * they still get shims.
+ *
+ * `antigravity` (SMI-6275 Wave 5) is deliberately excluded too — a stated
+ * decision, not an oversight: this wave's live web-search research (see
+ * `agent-pack-installer.antigravity-mcp.ts`'s header) turned up AntiGravity's
+ * documented MCP config format but no documented SessionStart/SessionEnd
+ * hook system equivalent to Claude Code/Cursor/Codex's — unlike those three,
+ * which each have a confirmed doc page. AntiGravity gets `.agents/mcp_config.json`
+ * registration ONLY this wave (support tier 3, matching Windsurf's MCP-only
+ * profile — see `HARNESS_SUPPORT_TIER` in `agent-pack-installer.types.ts`).
+ * It also gets no named-agent shim file (`AGENT_SHIM_TARGETS.antigravity` is
+ * `null` in `agent-harness-targets.ts`, for the same "no verified evidence
+ * yet" reason). Revisit both if/when AntiGravity ships a documented
+ * hook/shim equivalent.
  */
 export const HOOK_HARNESSES: readonly HarnessId[] = ['claude-code', 'cursor', 'codex']
 


### PR DESCRIPTION
## Business Summary

**What shipped:** `sklx agent install` now sets up AntiGravity (Google's AI coding IDE) alongside every other supported client — it writes AntiGravity's MCP server registration into `.agents/mcp_config.json` at the project's workspace root, and `agent uninstall` can remove it again cleanly. This closes the last unshipped request from external tester hytonylee's original feature ask (GH#2166).

**Quality bar:** Implementation + full local verification (204/204 relevant tests, lint/typecheck/audit:standards clean). The exact on-disk JSON schema was verified against AntiGravity's own live documentation (two official pages, corroborated by two independent third-party write-ups) rather than assumed from another client's format. Still pending: GPT-5.6-Sol cross-model PR review and live CI, both before merge.

**Net result:** Feature complete for this wave. AntiGravity gets MCP config support only (no hooks, no companion-agent shim) — explicitly scoped that way pending verified evidence AntiGravity has an equivalent to Claude Code/Cursor's hook system.

---

## Technical detail

Implements Wave 5 of `docs/internal/implementation/cursor-antigravity-tier-parity-plan.md`, depending on Wave 4 (SMI-6274, merged `6b1d857`)'s workspace-scope resolver.

- `HarnessId` (`packages/core/src/services/agent-pack/types.ts`) gains `'antigravity'`.
- New `packages/core/src/install/agent-pack-installer.antigravity-mcp.ts`: AntiGravity's MCP config is workspace-anchored (not home-anchored like the other 7 `McpHarnessId` targets), so it gets its own writer mirroring the Cursor split (`agent-pack-installer.cursor-mcp.ts`) rather than an `AGENT_MCP_TARGETS` entry. `McpHarnessId` now explicitly excludes `antigravity`.
- `agent-pack-installer.ts`: `installAgentPack` now resolves AntiGravity's workspace scope on every run — auto-detecting an existing `.agents/` marker, not just under `--scope workspace` — and always emits a report row (previously omitted entirely when undetected), matching every other harness's reporting shape.
- `agent-manifest-path-guard.ts` gains a second, workspace-relative allowlist so `uninstallAgentPack` can actually remove AntiGravity's workspace-scoped artifacts — this also fixes a latent gap from Wave 4 (the skill-pack path was never uninstallable either).
- New test file `agent-pack-installer.antigravity-mcp.test.ts` covers entry shape, idempotency, conflict/`--force`, and uninstall (including preserving a hand-added sibling key).
- `packages/core/CHANGELOG.md` updated.

Pre-push note: this worktree's container needed one `docker compose restart dev` to self-heal a native `better-sqlite3` binding before push succeeded (SMI-5351 documented remedy) — unrelated to the code change itself.