### PR TITLE
feat(core): SMI-6276 Wave 6 Step 1 -- client-parameterize SubagentGenerator

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Feature**: companion subagent files (`generateSubagent`/`generateMinimalSubagent`,
+  `@skillsmith/core/services/SubagentGenerator`, SMI-6276 Wave 6 Step 1) now generate
+  client-specific frontmatter instead of Claude-shaped tool names/model tiers for every
+  client. New `SubagentGenerator.client-profiles.ts` defines an exhaustive per-client
+  generation profile (frontmatter fields, tool-vocabulary policy, model policy). AntiGravity
+  gets its own mapped tool vocabulary as a YAML array (its own docs warn an unmapped tool
+  name can hang the subagent process) and no Claude model field (a different vendor/model
+  family); Cursor mirrors Claude Code's shape exactly (documented compatibility surface);
+  Copilot/OpenCode/Windsurf/others omit `tools:`/`model:` per each client's own confirmed
+  reasoning. `TransformationService`'s cache key now includes the target client (a
+  same-skill-different-client request could otherwise be served a stale other-client's
+  cached result); `generateSubagentContent()`'s `description:` frontmatter field is now
+  JSON.stringify()-quoted as a valid YAML double-quoted scalar (previously broke on a
+  description containing `: ` or ` #`). `installFromContent()` now correctly forwards its
+  resolved client into `applyOptimization()` instead of silently defaulting to claude-code.
+
 - **Feature**: `sklx agent install` now supports AntiGravity as a harness (`@skillsmith/core/install`,
   SMI-6275 Wave 5, closing the last unshipped ask of GH#2166). `HarnessId` gains `'antigravity'`,
   but — unlike every other MCP-capable harness — it is deliberately excluded from `McpHarnessId`

--- a/packages/core/src/exports/services.ts
+++ b/packages/core/src/exports/services.ts
@@ -63,6 +63,15 @@ export {
   type ClaudeModel,
 } from '../services/SubagentGenerator.js'
 
+// SMI-6276 (Wave 6 Step 1): per-client companion-subagent generation profile.
+export {
+  getSubagentGenerationProfile,
+  SUBAGENT_CLIENT_PROFILES,
+  type SubagentGenerationProfile,
+  type SubagentToolsPolicy,
+  type SubagentModelPolicy,
+} from '../services/SubagentGenerator.client-profiles.js'
+
 // SMI-5456 Wave 1 Step 4: multi-target portable agent-pack generator.
 export {
   generateAgentPack,

--- a/packages/core/src/services/SubagentGenerator.client-profiles.ts
+++ b/packages/core/src/services/SubagentGenerator.client-profiles.ts
@@ -1,0 +1,359 @@
+/**
+ * SMI-6276 (Wave 6 Step 1): per-client generation profile for companion
+ * subagent files (`SubagentGenerator.ts`).
+ *
+ * `SubagentGenerator.generateSubagentContent()` predates multi-client support
+ * entirely — it always emitted Claude-native tool names (`Read, Write, Bash,
+ * WebFetch, Grep, Glob, WebSearch`) plus a `model: <haiku|sonnet|opus>`
+ * frontmatter field, for every client `COMPANION_AGENT_TARGETS`
+ * (`../install/paths.ts`) writes a companion-agent file for — including
+ * clients whose own agent-definition format doesn't have a `tools:` or
+ * `model:` concept, has one with entirely different value semantics, or (a
+ * real, spec-documented failure mode for AntiGravity specifically — see
+ * below) can HANG the subagent process on an unmapped tool name.
+ *
+ * This module is the exhaustive per-client answer, keyed on `ClientId`
+ * (matching `COMPANION_AGENT_TARGETS`'s own key set, not the narrower
+ * `HarnessId` — every `ClientId` gets a companion-agent file written
+ * somewhere per `COMPANION_AGENT_TARGETS`, so every one needs a content
+ * decision here too). For each client:
+ *
+ * 1. Which frontmatter fields it accepts (`includeSkillsField`,
+ *    `toolsPolicy`, `modelPolicy`, `extraFrontmatterLines`).
+ * 2. Its tool-identifier vocabulary and value SHAPE — `'claude-native'`
+ *    (Skillsmith's internal tool names ARE that client's own names, emitted
+ *    as a comma-separated scalar, no translation needed), `'mapped-array'`
+ *    (the client has its OWN, confirmed-different tool vocabulary AND
+ *    expects a YAML array rather than a scalar — translate through
+ *    `toolNameMap`, silently drop any internal name with no confirmed
+ *    mapping, and omit the field entirely if nothing maps), or `'omit'`
+ *    (vocabulary not independently verified at all — never emit the field
+ *    rather than guess a wrong value).
+ * 3. Its model-selection policy — `'claude-enum'` (accepts Claude's
+ *    `haiku|sonnet|opus` values directly) or `'omit'` (either no `model:`
+ *    concept at all, or one with value semantics that don't line up with
+ *    Skillsmith's internal enum — including a DIFFERENT PROVIDER's own
+ *    model-tier vocabulary, which is a family swap, not just a renaming).
+ *
+ * Confidence levels (style follows `../install/agent-harness-targets.ts`'s
+ * own header — HIGH/MEDIUM/LOW per client, dated citation, never asserted
+ * past what the citation actually supports):
+ *
+ * - **claude-code** — HIGH. Claude Code's own native subagent format
+ *   (`.claude/agents/*.md`): `name`, `description`, `tools` (comma-separated
+ *   Claude tool names), `model`. This is this repo's pre-existing behavior
+ *   (unchanged by this wave) and matches `renderClaudeShim()`
+ *   (`agent-pack/shims.ts`), which uses the identical `name`/`description`/
+ *   `tools` frontmatter shape for the fixed named-agent shim.
+ * - **cursor** — HIGH, verified live against cursor.com/docs/subagents
+ *   (fetched 2026-08-30): "Cursor recognizes subagent files across multiple
+ *   directory formats: `.cursor/agents/` (Cursor format), `.claude/agents/`
+ *   (Claude compatibility), `.codex/agents/` (Codex compatibility)."
+ *   `COMPANION_AGENT_TARGETS.cursor` resolves to the SAME path as
+ *   `claude-code` (`~/.claude/agents/<name>-specialist.md` — see that
+ *   table's own comment: "Cursor 2.4+ reads `.claude/agents/` natively — no
+ *   separate shim file"), so the file this generator actually writes for
+ *   `--client cursor` is read by Cursor through that Claude-compatibility
+ *   path and must carry genuine Claude-format frontmatter — this profile
+ *   mirrors `claude-code`'s exactly (same object, not a coincidental
+ *   duplicate). Cursor's OWN native `.cursor/agents/*.md` format is verified
+ *   DIFFERENT (fields: `name`, `description`, `model` — values `inherit`,
+ *   `fast`, or a hardcoded model ID, NOT Claude's `haiku|sonnet|opus` enum —
+ *   `readonly`, `is_background`; explicitly NO `tools` field: "Subagents
+ *   inherit all tools from the parent, including MCP tools from configured
+ *   servers") but Skillsmith never writes to that native directory (no
+ *   `.cursor/agents/` entry exists in `COMPANION_AGENT_TARGETS`), so that
+ *   narrower native schema does not govern the file this generator produces.
+ * - **antigravity** — HIGH for the schema itself, verified live against
+ *   `antigravity.google/docs/subagents/` (fetched 2026-08-30, cross-checked
+ *   by an independent WebSearch and by Wayback snapshots bracketing
+ *   2026-08-06 through 2026-08-16 — see
+ *   `docs/internal/implementation/smi-6276-subagent-true-antigravity-repro.md`
+ *   for the full investigation, filed for the separate `subagent: true`
+ *   question but covering this same schema). **Correction of SMI-5982's
+ *   original sourcing**: that wave cited
+ *   `antigravity.google/docs/cli/commands/agents` (the CLI `/agents` TUI
+ *   command reference, whose example happens to show only `name`+
+ *   `description`) as if it were the full schema. The real, richer schema
+ *   lives at `/docs/subagents`: `name`, `description` (both required),
+ *   `tools` (`string[]`, default `[]` — a YAML ARRAY, not a scalar, of
+ *   AntiGravity's OWN tool names, e.g. `view_file`, `replace_file_content`,
+ *   `grep_search`, `run_command` — confirmed DIFFERENT from Skillsmith's
+ *   Claude-style names), `mainAgent`/`subagent` (booleans, both default
+ *   `true` — the `subagent: true` question is Step 2's separate scope, not
+ *   touched here), `model` (`inherit|flash|pro`, default `inherit` — NOT
+ *   Claude's `haiku|sonnet|opus`), `commandExecutionPolicy`, `mcpServers`,
+ *   `skills`/`plugins` (skill PATHS like `skills/my-helper-skill` — a
+ *   DIFFERENT concept from Skillsmith's own `skills: <bare-name>` extension
+ *   field below, not reused here for that reason).
+ *
+ *   MEDIUM for the specific tool-name MAPPING used here: the docs page only
+ *   gives 4 example tool names (not a complete enumeration), so
+ *   `toolNameMap` below covers only those 4, mapped by clear name
+ *   correspondence (`view_file`→Read, `replace_file_content`→Write/Edit,
+ *   `grep_search`→Grep, `run_command`→Bash); Skillsmith's `Glob`, `WebFetch`,
+ *   and `WebSearch` have no confirmed AntiGravity equivalent and are
+ *   silently dropped, never guessed. This is deliberately a `'mapped-array'`
+ *   policy rather than `'omit'`, unlike every other unverified-vocabulary
+ *   client in this table: AntiGravity's own schema documents `tools`
+ *   defaulting to `[]` (empty) when omitted — the OPPOSITE of Cursor's
+ *   "inherits from parent" or Copilot's "all tools available" defaults — so
+ *   omitting the field here would ship a companion subagent with literally
+ *   ZERO tool access, not a harmlessly-permissive default. A confidently-cited
+ *   partial mapping is more correct than that, and strictly safer than
+ *   guessing at unconfirmed names: the same docs page's own "Known Issue
+ *   (Tool Validation)" warns that "specifying an unmapped or misspelled tool
+ *   name in the `tools` list may cause the subagent process to hang during
+ *   execution" — every name emitted here is a name AntiGravity's own docs
+ *   use as a worked example, never an invented one.
+ *
+ *   `model:` is OMITTED for AntiGravity, not mapped — deliberately, not for
+ *   lack of trying. AntiGravity's `flash`/`pro` are Gemini model tiers;
+ *   Skillsmith's `haiku`/`sonnet`/`opus` are Claude model tiers. These are
+ *   two DIFFERENT model families from two different vendors, not two
+ *   spellings of the same capability scale — `haiku→flash` and `opus→pro`
+ *   are plausible analogies, but `sonnet` (Skillsmith's own default "for
+ *   balanced workloads", `determineModel()`) has no principled third rung to
+ *   land on in a 2-tier scale, and no official source equates any Claude
+ *   tier to any Gemini tier. Omitting the field uses AntiGravity's own
+ *   documented default (`inherit` — defer to whatever tier the invoking
+ *   session already uses), which is a real, working, spec-sanctioned value,
+ *   not an absence of a decision.
+ * - **copilot** — MEDIUM, verified live against GitHub's own docs
+ *   (docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/create-custom-agents,
+ *   fetched 2026-08-30): `.agent.md` frontmatter DOES support a `tools` list
+ *   (documented examples: `"read"`, `"edit"`, `"search"`) and a `model`
+ *   field. NOT verified: a full mapping from Skillsmith's own 8-tool
+ *   vocabulary (`Read`/`Write`/`Edit`/`Bash`/`Grep`/`Glob`/`WebFetch`/
+ *   `WebSearch`) onto Copilot's identifier set — only 2-3 of the 8 have a
+ *   plausible lowercase counterpart in the documented examples, with no
+ *   confirmed equivalents for `Bash`/`Grep`/`Glob`/`WebFetch` specifically.
+ *   Unlike AntiGravity, Copilot's own docs confirm omission is SAFE here —
+ *   "Omitting tools grants access to all available tools — the default is
+ *   permissive" — so, per this wave's fallback rule, omit `tools:` rather
+ *   than emit a guessed-wrong partial mapping; the omission doesn't cripple
+ *   the subagent the way it would for AntiGravity. `model:` is likewise
+ *   omitted — its value format (Copilot's own model catalog IDs) has no
+ *   confirmed correspondence to Skillsmith's internal `haiku|sonnet|opus`
+ *   abstraction.
+ * - **opencode** — MEDIUM, verified live against opencode.ai/v2/docs/agents/
+ *   (fetched 2026-08-30): confirmed frontmatter fields `description`, `mode`
+ *   (`primary|subagent|all`), `model` (`provider/model#variant` format — NOT
+ *   Claude's `haiku|sonnet|opus` enum), `color`, `steps`, `permissions`. This
+ *   repo's own `renderOpenCodeShim()` (`agent-pack/shims.ts`) already
+ *   documents the load-bearing fact this profile reuses: "OpenCode's
+ *   frontmatter `tools` field is a permission map, not a plain list; setting
+ *   it wrong would restrict tools rather than reference them" — same
+ *   precedent applied here, omitting `tools:` rather than writing a
+ *   Claude-shaped value into a boolean-permission-map field (a different,
+ *   harder mapping problem than AntiGravity's plain array — not attempted in
+ *   this wave). `mode: subagent` IS included (HIGH confidence for this one
+ *   line specifically — mirrors the already-shipped `renderOpenCodeShim()`
+ *   verbatim). `model:` omitted — no confirmed mapping from Skillsmith's
+ *   internal enum to OpenCode's `provider/model` format.
+ * - **windsurf** — LOW. No independently confirmed per-subagent-file
+ *   frontmatter schema for tool/model restriction was found; Windsurf's
+ *   Cascade agent runtime is additionally documented as being retired (EOL
+ *   2026-07-01, superseded by Devin Local). Omit `tools:` and `model:`,
+ *   matching this table's existing conservative default for windsurf
+ *   (`COMPANION_AGENT_TARGETS.windsurf`'s own comment: "No
+ *   `AGENT_SHIM_TARGETS` entry exists for windsurf ... defaults to today's
+ *   actual behavior" — that comment covers the file PATH only; this module
+ *   makes the equivalent conservative call for the file's CONTENT).
+ * - **agents** — LOW. This `ClientId` is the generic cross-agent /
+ *   `AGENTS.md` convention (also Codex's install target — "Codex: reads
+ *   ONLY `~/.agents/skills`", `../install/paths.ts`'s own header comment).
+ *   The `AGENTS.md` standard itself has no required fields and no YAML
+ *   frontmatter for its single project-instructions file (openai/codex's own
+ *   `AGENTS.md`; agents.md spec) — there is no confirmed per-agent-definition
+ *   file schema with tool/model fields for this identifier at all. Omit
+ *   `tools:` and `model:`.
+ * - **hermes** — LOW. Hermes's own documented frontmatter
+ *   (hermes-agent.nousresearch.com/docs/) is for SKILL files (`name`,
+ *   `description`, `version`, `author`, `platforms`), not a separate
+ *   subagent-definition schema with tool/model restriction fields. Omit
+ *   `tools:` and `model:`.
+ * - **grok** — LOW. Grok Build (docs.x.ai/build/overview,
+ *   github.com/xai-org/grok-build) confirms agent frontmatter EXISTS
+ *   ("Subagents can declare their own `mcpServers` in agent frontmatter") but
+ *   no built-in tool-identifier vocabulary or Claude-comparable model enum is
+ *   documented. Omit `tools:` and `model:`.
+ *
+ * @see docs/internal/implementation/cursor-antigravity-tier-parity-plan.md (Wave 6 Step 1)
+ * @see docs/internal/implementation/smi-6276-subagent-true-antigravity-repro.md (AntiGravity schema source-of-truth)
+ */
+
+import { CANONICAL_CLIENT, type ClientId } from '../install/paths.js'
+
+/**
+ * `'claude-native'` — Skillsmith's internal tool names (`Read`, `Write`,
+ * `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `WebSearch`) ARE this client's
+ * own tool-identifier vocabulary; emit `tools:` as a plain comma-separated
+ * scalar list, no translation needed.
+ *
+ * `'mapped-array'` — this client has its OWN, confirmed-different tool
+ * vocabulary AND expects `tools:` as a YAML array (not a scalar). Translate
+ * through the profile's `toolNameMap`; any internal name with no confirmed
+ * entry is silently dropped (never guessed), and the field is omitted
+ * entirely if the mapped result is empty.
+ *
+ * `'omit'` — this client's tool vocabulary (or its `tools:` field's VALUE
+ * shape) has not been independently verified to accept Skillsmith's internal
+ * names as-is, and omitting the field is either safe (permissive default,
+ * e.g. Copilot) or the only defensible choice given no evidence at all.
+ * Never emit a guessed-wrong value.
+ */
+export type SubagentToolsPolicy = 'claude-native' | 'mapped-array' | 'omit'
+
+/**
+ * `'claude-enum'` — this client accepts a `model:` field whose values are
+ * (or are compatible with) Skillsmith's internal `haiku|sonnet|opus` enum.
+ *
+ * `'omit'` — either no `model:` concept exists for this client, or its
+ * value semantics (a hardcoded model ID, a `provider/model` string, a
+ * different vendor's own model-tier vocabulary, an `inherit`/`fast`
+ * keyword, etc.) don't correspond to Skillsmith's internal enum. Omit the
+ * field rather than emit a value the client would reject, silently ignore,
+ * or (worse) apply as a real but wrong model selection.
+ */
+export type SubagentModelPolicy = 'claude-enum' | 'omit'
+
+/** Per-client shape of the generated companion-subagent file's frontmatter. */
+export interface SubagentGenerationProfile {
+  /** How well-evidenced this profile's fields are (see module header). */
+  confidence: 'HIGH' | 'MEDIUM' | 'LOW'
+  /** One-line pointer to the citation backing this profile (see module header for the full text). */
+  citation: string
+  /**
+   * Whether to emit Skillsmith's own `skills: <skill-name>` extension field
+   * (a Skillsmith convention — a bare skill name — not any external
+   * harness's own field of the same name, e.g. AntiGravity's `skills:`
+   * expects PATHS and is a different concept) — kept true only for clients
+   * this generator has always emitted it for.
+   */
+  includeSkillsField: boolean
+  toolsPolicy: SubagentToolsPolicy
+  /**
+   * Skillsmith-internal tool name -> this client's own tool identifier.
+   * Only present (and only meaningful) when `toolsPolicy === 'mapped-array'`.
+   * An internal name with no entry here is silently dropped, never guessed.
+   */
+  toolNameMap?: Readonly<Record<string, string>>
+  modelPolicy: SubagentModelPolicy
+  /**
+   * Static frontmatter lines specific to this client, appended after
+   * `tools:` (when present) and before `model:` (when present). Empty for
+   * every client except OpenCode's `mode: subagent`.
+   */
+  extraFrontmatterLines: readonly string[]
+}
+
+/** claude-code's own native format — this generator's pre-existing (unchanged) behavior. */
+const CLAUDE_FORMAT_PROFILE: SubagentGenerationProfile = {
+  confidence: 'HIGH',
+  citation:
+    "Claude Code's native `.claude/agents/*.md` subagent format (name/description/tools/model) — this repo's pre-existing behavior; matches renderClaudeShim() (agent-pack/shims.ts).",
+  includeSkillsField: true,
+  toolsPolicy: 'claude-native',
+  modelPolicy: 'claude-enum',
+  extraFrontmatterLines: [],
+}
+
+/** Minimal name+description-only shape shared by every unverified-vocabulary client. */
+function minimalProfile(
+  confidence: SubagentGenerationProfile['confidence'],
+  citation: string,
+  extraFrontmatterLines: readonly string[] = []
+): SubagentGenerationProfile {
+  return {
+    confidence,
+    citation,
+    includeSkillsField: false,
+    toolsPolicy: 'omit',
+    modelPolicy: 'omit',
+    extraFrontmatterLines,
+  }
+}
+
+/**
+ * AntiGravity's own tool vocabulary (antigravity.google/docs/subagents/,
+ * fetched 2026-08-30) — only the 4 names the docs page itself uses as
+ * worked examples. See module header for why this is `'mapped-array'`
+ * rather than `'omit'` (AntiGravity's own `tools` default is `[]`, not
+ * permissive) and why `Glob`/`WebFetch`/`WebSearch` have no entry.
+ */
+const ANTIGRAVITY_TOOL_NAME_MAP: Readonly<Record<string, string>> = {
+  Read: 'view_file',
+  Write: 'replace_file_content',
+  Edit: 'replace_file_content',
+  Bash: 'run_command',
+  Grep: 'grep_search',
+}
+
+export const SUBAGENT_CLIENT_PROFILES: Readonly<Record<ClientId, SubagentGenerationProfile>> = {
+  'claude-code': CLAUDE_FORMAT_PROFILE,
+  // Mirrors claude-code exactly: COMPANION_AGENT_TARGETS.cursor writes into
+  // the SAME `~/.claude/agents/<name>-specialist.md` path, and Cursor reads
+  // that directory as a documented Claude-compatibility surface (see module
+  // header). This is a deliberate object reuse, not accidental sharing.
+  cursor: CLAUDE_FORMAT_PROFILE,
+  antigravity: {
+    confidence: 'HIGH',
+    citation:
+      'antigravity.google/docs/subagents/ (fetched 2026-08-30, cross-checked via independent WebSearch + Wayback bracketing 2026-08-06..2026-08-16; see smi-6276-subagent-true-antigravity-repro.md): tools is a YAML array of AntiGravity-own names defaulting to [] when omitted; model is inherit|flash|pro (a different vendor/model family from Claude — omitted rather than force-mapped).',
+    includeSkillsField: false,
+    toolsPolicy: 'mapped-array',
+    toolNameMap: ANTIGRAVITY_TOOL_NAME_MAP,
+    modelPolicy: 'omit',
+    extraFrontmatterLines: [],
+  },
+  copilot: minimalProfile(
+    'MEDIUM',
+    "docs.github.com custom-agents docs (fetched 2026-08-30): tools/model fields exist and omitting tools is documented as permissive ('all tools available') — safe to omit rather than guess the full Skillsmith-tool-name mapping."
+  ),
+  opencode: minimalProfile(
+    'MEDIUM',
+    "opencode.ai/v2/docs/agents/ (fetched 2026-08-30) + this repo's own renderOpenCodeShim(): tools is a boolean permission map, not a list — omit rather than mis-shape it. mode: subagent is HIGH-confidence and included.",
+    ['mode: subagent']
+  ),
+  windsurf: minimalProfile(
+    'LOW',
+    'No confirmed per-subagent-file tools/model schema found; Cascade is documented as being retired (EOL 2026-07-01).'
+  ),
+  agents: minimalProfile(
+    'LOW',
+    'The generic AGENTS.md convention has no required fields and no confirmed per-agent-definition-file schema at all.'
+  ),
+  hermes: minimalProfile(
+    'LOW',
+    'hermes-agent.nousresearch.com/docs/: documented frontmatter is for SKILL files (name/description/version/author/platforms), not a subagent tools/model schema.'
+  ),
+  grok: minimalProfile(
+    'LOW',
+    'docs.x.ai/build/overview + xai-org/grok-build: agent frontmatter exists but no built-in tool-identifier vocabulary or Claude-comparable model enum is documented.'
+  ),
+}
+
+/** Resolve the per-client generation profile for `client` (default: canonical / claude-code). */
+export function getSubagentGenerationProfile(
+  client: ClientId = CANONICAL_CLIENT
+): SubagentGenerationProfile {
+  return SUBAGENT_CLIENT_PROFILES[client]
+}
+
+/**
+ * Translate Skillsmith-internal tool names through `profile.toolNameMap`,
+ * dropping any name with no confirmed entry and de-duplicating the result
+ * (two internal names can map to the same client tool, e.g. AntiGravity's
+ * `Write`/`Edit` -> `replace_file_content`). Returns `[]` when nothing maps
+ * — callers must omit the `tools:` field entirely in that case, not emit an
+ * empty array, per this module's own fallback philosophy.
+ */
+export function mapToolNames(
+  tools: readonly string[],
+  profile: SubagentGenerationProfile
+): string[] {
+  const map = profile.toolNameMap ?? {}
+  const mapped = tools.map((tool) => map[tool]).filter((tool): tool is string => tool !== undefined)
+  return Array.from(new Set(mapped))
+}

--- a/packages/core/src/services/SubagentGenerator.helpers.ts
+++ b/packages/core/src/services/SubagentGenerator.helpers.ts
@@ -1,0 +1,247 @@
+/**
+ * SMI-1788: Pure helper functions for SubagentGenerator — tool detection,
+ * trigger-phrase extraction, model selection, and Claude-tool-named
+ * guidance text. Split out under the 500-line standard (SMI-6276) following
+ * this directory's existing `.helpers.ts` convention (see
+ * SkillAnalyzer.helpers.ts / SkillDecomposer.helpers.ts).
+ */
+
+import type { ToolUsageAnalysis } from './SkillAnalyzer.js'
+import { CLAUDE_MODELS, type ClaudeModel } from './SubagentGenerator.types.js'
+
+/**
+ * Tool detection patterns for analyzing skill content
+ */
+export const TOOL_PATTERNS: Record<string, { patterns: string[]; priority: number }> = {
+  Read: {
+    patterns: ['read file', 'read the', 'examine', 'view file', 'Read tool', 'check file'],
+    priority: 1,
+  },
+  Write: {
+    patterns: ['write file', 'create file', 'save to', 'output to', 'Write tool', 'generate file'],
+    priority: 2,
+  },
+  Edit: {
+    patterns: [
+      'edit file',
+      'modify',
+      'update file',
+      'patch',
+      'Edit tool',
+      'change file',
+      'refactor',
+    ],
+    priority: 2,
+  },
+  Bash: {
+    patterns: [
+      'bash',
+      'npm',
+      'npx',
+      'git',
+      'docker',
+      'yarn',
+      'pnpm',
+      'terminal',
+      'shell',
+      'command',
+    ],
+    priority: 3,
+  },
+  Grep: {
+    patterns: ['grep', 'search for', 'find text', 'pattern match', 'Grep tool', 'search in'],
+    priority: 1,
+  },
+  Glob: {
+    patterns: ['glob', 'find file', 'file pattern', 'list files', 'Glob tool', 'locate'],
+    priority: 1,
+  },
+  WebFetch: {
+    patterns: ['fetch', 'http', 'api call', 'url', 'WebFetch', 'download', 'request'],
+    priority: 2,
+  },
+  WebSearch: {
+    patterns: ['web search', 'search online', 'lookup online', 'WebSearch', 'search the web'],
+    priority: 2,
+  },
+}
+
+/**
+ * Minimum tools that most subagents need
+ */
+export const BASE_TOOLS = ['Read']
+
+/**
+ * SMI-1819: Maximum length for subagent names to prevent overly long identifiers
+ */
+export const MAX_SUBAGENT_NAME_LENGTH = 100
+
+/**
+ * Generate tool usage guidelines for a subagent (Claude-named tools).
+ * Only used for clients whose `toolsPolicy` is `'claude-native'` — see
+ * `SubagentGenerator.client-profiles.ts` and `OMITTED_TOOLS_GUIDANCE`.
+ */
+export function generateToolGuidelines(tools: string[]): string {
+  const guidelines: string[] = []
+
+  if (tools.includes('Read')) {
+    guidelines.push('- **Read**: Use to examine files before modifications')
+  }
+  if (tools.includes('Write')) {
+    guidelines.push('- **Write**: Use for creating new files only')
+  }
+  if (tools.includes('Edit')) {
+    guidelines.push('- **Edit**: Use for modifying existing files')
+  }
+  if (tools.includes('Bash')) {
+    guidelines.push('- **Bash**: Use for command execution, prefer non-destructive commands')
+  }
+  if (tools.includes('Grep')) {
+    guidelines.push('- **Grep**: Use for searching file contents')
+  }
+  if (tools.includes('Glob')) {
+    guidelines.push('- **Glob**: Use for finding files by pattern')
+  }
+  if (tools.includes('WebFetch')) {
+    guidelines.push('- **WebFetch**: Use for fetching web content')
+  }
+  if (tools.includes('WebSearch')) {
+    guidelines.push('- **WebSearch**: Use for searching the web')
+  }
+
+  return guidelines.length > 0 ? guidelines.join('\n') : '- Use tools minimally and efficiently'
+}
+
+/**
+ * SMI-6276: fallback tool-usage guidance for any client whose companion
+ * subagent file does not carry Claude-named tools in its `tools:`
+ * frontmatter — either because the field is omitted entirely, or because it
+ * was translated into that client's OWN vocabulary (`mapped-array`, e.g.
+ * AntiGravity's `view_file`/`run_command`). Naming Claude-specific tool
+ * identifiers in this prose body would be misleading either way, so this
+ * stays generic. See `SubagentGenerator.client-profiles.ts`.
+ */
+export const OMITTED_TOOLS_GUIDANCE =
+  '- Use the tools available on this platform minimally and efficiently'
+
+/**
+ * Generate CLAUDE.md integration snippet
+ *
+ * NOTE (SMI-6276): deliberately NOT client-parameterized — CLAUDE.md is
+ * inherently a Claude Code artifact regardless of which client the
+ * companion-agent FILE itself targets, so this always describes the
+ * Claude-side delegation recommendation. Out of this wave's scope; see
+ * `SubagentGenerator.client-profiles.ts`'s header for what IS in scope.
+ */
+export function generateClaudeMdSnippet(
+  skillName: string,
+  description: string,
+  triggerPhrases: string[],
+  tools: string[],
+  model: ClaudeModel
+): string {
+  const triggerPatterns =
+    triggerPhrases.length > 0
+      ? triggerPhrases.map((p) => `- "${p}"`).join('\n')
+      : '- [add trigger patterns]'
+
+  const exampleTask = triggerPhrases.length > 0 ? triggerPhrases[0] : `execute ${skillName} task`
+
+  return `
+### Subagent Delegation: ${skillName}
+
+When tasks match ${skillName} triggers, delegate to the ${skillName}-specialist
+subagent instead of executing directly. This provides context isolation and
+~37-97% token savings.
+
+**Trigger Patterns:**
+${triggerPatterns}
+
+**Delegation Example:**
+\`\`\`
+Task("${skillName}-specialist", "${exampleTask}", "${skillName}-specialist")
+\`\`\`
+
+**Model:** ${model}
+**Tools:** ${tools.join(', ')}
+`
+}
+
+/**
+ * Extract trigger phrases from skill description and content
+ */
+export function extractTriggerPhrases(description: string, content: string): string[] {
+  const phrases: string[] = []
+
+  // Common trigger phrase patterns
+  const patterns = [
+    /when\s+(?:you\s+)?(?:need\s+to\s+)?(.+?)(?:[.,]|$)/gi,
+    /use\s+(?:this\s+)?(?:when|for)\s+(.+?)(?:[.,]|$)/gi,
+    /(?:helps?\s+(?:you\s+)?(?:to\s+)?)?(.+?)(?:\s+tasks?|\s+operations?)/gi,
+  ]
+
+  const textToSearch = description + ' ' + content.slice(0, 2000) // Search first 2000 chars
+
+  for (const pattern of patterns) {
+    for (const match of textToSearch.matchAll(pattern)) {
+      const phrase = match[1].trim().toLowerCase()
+      if (phrase.length >= 5 && phrase.length <= 50 && !phrases.includes(phrase)) {
+        phrases.push(phrase)
+      }
+    }
+  }
+
+  // Extract from "trigger" or "invoke" mentions
+  const triggerMatch = content.match(/trigger[s]?\s*[:=]\s*["`']([^"`']+)["`']/gi)
+  if (triggerMatch) {
+    for (const match of triggerMatch) {
+      const phrase = match.replace(/trigger[s]?\s*[:=]\s*["`']/i, '').replace(/["`']$/, '')
+      if (!phrases.includes(phrase.toLowerCase())) {
+        phrases.push(phrase.toLowerCase())
+      }
+    }
+  }
+
+  return phrases.slice(0, 5) // Limit to 5 phrases
+}
+
+/**
+ * Determine optimal model for subagent
+ * SMI-1795: Uses CLAUDE_MODELS constants for type safety
+ */
+export function determineModel(toolUsage: ToolUsageAnalysis, lineCount: number): ClaudeModel {
+  // Haiku for simple, fast operations
+  if (toolUsage.detectedTools.length <= 2 && lineCount < 200) {
+    return CLAUDE_MODELS.HAIKU
+  }
+
+  // Opus for complex, reasoning-heavy tasks
+  if (
+    toolUsage.bashCommandCount > 5 ||
+    (toolUsage.fileReadCount > 3 && toolUsage.fileWriteCount > 3)
+  ) {
+    return CLAUDE_MODELS.OPUS
+  }
+
+  // Sonnet for balanced workloads (default)
+  return CLAUDE_MODELS.SONNET
+}
+
+/**
+ * Detect tools needed from skill content
+ */
+export function detectTools(content: string): string[] {
+  const lowerContent = content.toLowerCase()
+  const detectedTools = new Set<string>(BASE_TOOLS)
+
+  for (const [tool, config] of Object.entries(TOOL_PATTERNS)) {
+    for (const pattern of config.patterns) {
+      if (lowerContent.includes(pattern.toLowerCase())) {
+        detectedTools.add(tool)
+        break
+      }
+    }
+  }
+
+  return Array.from(detectedTools)
+}

--- a/packages/core/src/services/SubagentGenerator.helpers.ts
+++ b/packages/core/src/services/SubagentGenerator.helpers.ts
@@ -173,11 +173,34 @@ Task("${skillName}-specialist", "${exampleTask}", "${skillName}-specialist")
 export function extractTriggerPhrases(description: string, content: string): string[] {
   const phrases: string[] = []
 
-  // Common trigger phrase patterns
+  // Common trigger phrase patterns. CodeQL finding (SMI-6276, polynomial
+  // regex / ReDoS): the original patterns paired an optional word group
+  // (e.g. `(?:you\s+)?`) directly against a lazy wildcard capture
+  // (`(.+?)`) — since `.` also matches the letters/spaces the optional
+  // group matches, the engine has exponentially many ways to split
+  // ambiguous input (long runs of repeated words/spaces) between "the
+  // optional group matched" and "the wildcard consumed it instead".
+  // `textToSearch` includes up to 2000 chars of externally-authored
+  // SKILL.md content (a real untrusted-input path in a skill registry).
+  // Fix: bound each capture group to a small fixed max length instead of
+  // an unbounded lazy wildcard — extracted phrases are truncated to <=50
+  // chars a few lines below regardless, so this changes no real-world
+  // behavior, but caps worst-case backtracking work to a small constant
+  // instead of growing with input length.
+  const MAX_CANDIDATE_PHRASE_LENGTH = 60
   const patterns = [
-    /when\s+(?:you\s+)?(?:need\s+to\s+)?(.+?)(?:[.,]|$)/gi,
-    /use\s+(?:this\s+)?(?:when|for)\s+(.+?)(?:[.,]|$)/gi,
-    /(?:helps?\s+(?:you\s+)?(?:to\s+)?)?(.+?)(?:\s+tasks?|\s+operations?)/gi,
+    new RegExp(
+      `when\\s+(?:you\\s+)?(?:need\\s+to\\s+)?([^.,]{1,${MAX_CANDIDATE_PHRASE_LENGTH}})(?:[.,]|$)`,
+      'gi'
+    ),
+    new RegExp(
+      `use\\s+(?:this\\s+)?(?:when|for)\\s+([^.,]{1,${MAX_CANDIDATE_PHRASE_LENGTH}})(?:[.,]|$)`,
+      'gi'
+    ),
+    new RegExp(
+      `(?:helps?\\s+(?:you\\s+)?(?:to\\s+)?)?([^\\n]{1,${MAX_CANDIDATE_PHRASE_LENGTH}}?)(?:\\s+tasks?|\\s+operations?)`,
+      'gi'
+    ),
   ]
 
   const textToSearch = description + ' ' + content.slice(0, 2000) // Search first 2000 chars

--- a/packages/core/src/services/SubagentGenerator.ts
+++ b/packages/core/src/services/SubagentGenerator.ts
@@ -9,186 +9,95 @@
  *
  * Part of the Skillsmith Optimization Layer for transforming
  * community skills into more performant versions.
+ *
+ * SMI-6276 (Wave 6 Step 1): companion-agent frontmatter is now generated
+ * per TARGET CLIENT via `SubagentGenerator.client-profiles.ts` — this file
+ * no longer emits Claude-native tool names / a Claude `model:` value
+ * unconditionally for every client `COMPANION_AGENT_TARGETS` writes a
+ * companion file for. Types split to `.types.ts`, pure helpers split to
+ * `.helpers.ts` (500-line standard).
  */
 
-import type { SkillAnalysis, ToolUsageAnalysis } from './SkillAnalyzer.js'
+// Re-export types for public API (SMI-6276 split — see SubagentGenerator.types.ts)
+export type {
+  ClaudeModel,
+  SubagentDefinition,
+  SubagentGenerationResult,
+} from './SubagentGenerator.types.js'
+export { CLAUDE_MODELS } from './SubagentGenerator.types.js'
 
-/**
- * SMI-1795: Claude model constants for type safety and consistency
- */
-export const CLAUDE_MODELS = {
-  HAIKU: 'haiku',
-  SONNET: 'sonnet',
-  OPUS: 'opus',
-} as const
-
-export type ClaudeModel = (typeof CLAUDE_MODELS)[keyof typeof CLAUDE_MODELS]
-
-/**
- * Generated subagent definition
- */
-export interface SubagentDefinition {
-  /** Subagent name (e.g., "jest-helper-specialist") */
-  name: string
-
-  /** Description for the Task tool */
-  description: string
-
-  /** Trigger phrases that should invoke this subagent */
-  triggerPhrases: string[]
-
-  /** Tools the subagent needs access to */
-  tools: string[]
-
-  /** Recommended model */
-  model: ClaudeModel
-
-  /** The full markdown content for ~/.claude/agents/ */
-  content: string
-}
-
-/**
- * Result of subagent generation
- */
-export interface SubagentGenerationResult {
-  /** Whether a subagent was generated */
-  generated: boolean
-
-  /** The subagent definition (if generated) */
-  subagent?: SubagentDefinition
-
-  /** Reason if not generated */
-  reason?: string
-
-  /** CLAUDE.md integration snippet */
-  claudeMdSnippet?: string
-}
-
-/**
- * Tool detection patterns for analyzing skill content
- */
-const TOOL_PATTERNS: Record<string, { patterns: string[]; priority: number }> = {
-  Read: {
-    patterns: ['read file', 'read the', 'examine', 'view file', 'Read tool', 'check file'],
-    priority: 1,
-  },
-  Write: {
-    patterns: ['write file', 'create file', 'save to', 'output to', 'Write tool', 'generate file'],
-    priority: 2,
-  },
-  Edit: {
-    patterns: [
-      'edit file',
-      'modify',
-      'update file',
-      'patch',
-      'Edit tool',
-      'change file',
-      'refactor',
-    ],
-    priority: 2,
-  },
-  Bash: {
-    patterns: [
-      'bash',
-      'npm',
-      'npx',
-      'git',
-      'docker',
-      'yarn',
-      'pnpm',
-      'terminal',
-      'shell',
-      'command',
-    ],
-    priority: 3,
-  },
-  Grep: {
-    patterns: ['grep', 'search for', 'find text', 'pattern match', 'Grep tool', 'search in'],
-    priority: 1,
-  },
-  Glob: {
-    patterns: ['glob', 'find file', 'file pattern', 'list files', 'Glob tool', 'locate'],
-    priority: 1,
-  },
-  WebFetch: {
-    patterns: ['fetch', 'http', 'api call', 'url', 'WebFetch', 'download', 'request'],
-    priority: 2,
-  },
-  WebSearch: {
-    patterns: ['web search', 'search online', 'lookup online', 'WebSearch', 'search the web'],
-    priority: 2,
-  },
-}
-
-/**
- * Minimum tools that most subagents need
- */
-const BASE_TOOLS = ['Read']
-
-/**
- * SMI-1819: Maximum length for subagent names to prevent overly long identifiers
- */
-const MAX_SUBAGENT_NAME_LENGTH = 100
-
-/**
- * Generate tool usage guidelines for a subagent
- */
-function generateToolGuidelines(tools: string[]): string {
-  const guidelines: string[] = []
-
-  if (tools.includes('Read')) {
-    guidelines.push('- **Read**: Use to examine files before modifications')
-  }
-  if (tools.includes('Write')) {
-    guidelines.push('- **Write**: Use for creating new files only')
-  }
-  if (tools.includes('Edit')) {
-    guidelines.push('- **Edit**: Use for modifying existing files')
-  }
-  if (tools.includes('Bash')) {
-    guidelines.push('- **Bash**: Use for command execution, prefer non-destructive commands')
-  }
-  if (tools.includes('Grep')) {
-    guidelines.push('- **Grep**: Use for searching file contents')
-  }
-  if (tools.includes('Glob')) {
-    guidelines.push('- **Glob**: Use for finding files by pattern')
-  }
-  if (tools.includes('WebFetch')) {
-    guidelines.push('- **WebFetch**: Use for fetching web content')
-  }
-  if (tools.includes('WebSearch')) {
-    guidelines.push('- **WebSearch**: Use for searching the web')
-  }
-
-  return guidelines.length > 0 ? guidelines.join('\n') : '- Use tools minimally and efficiently'
-}
+import type { SkillAnalysis } from './SkillAnalyzer.js'
+import { CANONICAL_CLIENT, type ClientId } from '../install/paths.js'
+import { getSubagentGenerationProfile, mapToolNames } from './SubagentGenerator.client-profiles.js'
+import {
+  CLAUDE_MODELS,
+  type ClaudeModel,
+  type SubagentGenerationResult,
+} from './SubagentGenerator.types.js'
+import {
+  MAX_SUBAGENT_NAME_LENGTH,
+  generateToolGuidelines,
+  OMITTED_TOOLS_GUIDANCE,
+  generateClaudeMdSnippet,
+  extractTriggerPhrases,
+  determineModel,
+  detectTools,
+} from './SubagentGenerator.helpers.js'
 
 /**
  * Generate subagent markdown content
+ *
+ * SMI-6276 (Wave 6 Step 1): frontmatter shape is now driven by the target
+ * client's generation profile (`SubagentGenerator.client-profiles.ts`) —
+ * `Read, Write, Bash, WebFetch, Grep, Glob, WebSearch` plus a Claude
+ * `model:` value are no longer emitted unconditionally for every client.
  */
 function generateSubagentContent(
   name: string,
   description: string,
   triggerPhrases: string[],
   tools: string[],
-  model: ClaudeModel
+  model: ClaudeModel,
+  client: ClientId
 ): string {
   const triggerString =
     triggerPhrases.length > 0
       ? triggerPhrases.map((p) => `"${p}"`).join(', ')
       : '[describe trigger conditions]'
 
-  const toolGuidelines = generateToolGuidelines(tools)
+  const profile = getSubagentGenerationProfile(client)
 
-  return `---
-name: ${name}
-description: ${description} Use when ${triggerString}.
-skills: ${name.replace('-specialist', '')}
-tools: ${tools.join(', ')}
-model: ${model}
----
+  const frontmatterLines = [
+    '---',
+    `name: ${name}`,
+    `description: ${description} Use when ${triggerString}.`,
+  ]
+  if (profile.includeSkillsField) {
+    frontmatterLines.push(`skills: ${name.replace('-specialist', '')}`)
+  }
+  if (profile.toolsPolicy === 'claude-native') {
+    frontmatterLines.push(`tools: ${tools.join(', ')}`)
+  } else if (profile.toolsPolicy === 'mapped-array') {
+    // SMI-6276: this client expects a YAML array of ITS OWN tool names, not
+    // a Claude-shaped comma list — never emit the unmapped/mis-shaped value
+    // (the AntiGravity docs' own "Known Issue" warns an unmapped name can
+    // hang the subagent process on invocation). Omit the key entirely when
+    // nothing maps, rather than an empty `tools: []` that says nothing.
+    const mappedTools = mapToolNames(tools, profile)
+    if (mappedTools.length > 0) {
+      frontmatterLines.push('tools:', ...mappedTools.map((tool) => `  - ${tool}`))
+    }
+  }
+  frontmatterLines.push(...profile.extraFrontmatterLines)
+  if (profile.modelPolicy === 'claude-enum') {
+    frontmatterLines.push(`model: ${model}`)
+  }
+  frontmatterLines.push('---')
+
+  const toolGuidelines =
+    profile.toolsPolicy === 'claude-native' ? generateToolGuidelines(tools) : OMITTED_TOOLS_GUIDANCE
+
+  return `${frontmatterLines.join('\n')}
 
 ## Operating Protocol
 
@@ -223,135 +132,23 @@ If the task cannot be completed:
 }
 
 /**
- * Generate CLAUDE.md integration snippet
- */
-function generateClaudeMdSnippet(
-  skillName: string,
-  description: string,
-  triggerPhrases: string[],
-  tools: string[],
-  model: ClaudeModel
-): string {
-  const triggerPatterns =
-    triggerPhrases.length > 0
-      ? triggerPhrases.map((p) => `- "${p}"`).join('\n')
-      : '- [add trigger patterns]'
-
-  const exampleTask = triggerPhrases.length > 0 ? triggerPhrases[0] : `execute ${skillName} task`
-
-  return `
-### Subagent Delegation: ${skillName}
-
-When tasks match ${skillName} triggers, delegate to the ${skillName}-specialist
-subagent instead of executing directly. This provides context isolation and
-~37-97% token savings.
-
-**Trigger Patterns:**
-${triggerPatterns}
-
-**Delegation Example:**
-\`\`\`
-Task("${skillName}-specialist", "${exampleTask}", "${skillName}-specialist")
-\`\`\`
-
-**Model:** ${model}
-**Tools:** ${tools.join(', ')}
-`
-}
-
-/**
- * Extract trigger phrases from skill description and content
- */
-function extractTriggerPhrases(description: string, content: string): string[] {
-  const phrases: string[] = []
-
-  // Common trigger phrase patterns
-  const patterns = [
-    /when\s+(?:you\s+)?(?:need\s+to\s+)?(.+?)(?:[.,]|$)/gi,
-    /use\s+(?:this\s+)?(?:when|for)\s+(.+?)(?:[.,]|$)/gi,
-    /(?:helps?\s+(?:you\s+)?(?:to\s+)?)?(.+?)(?:\s+tasks?|\s+operations?)/gi,
-  ]
-
-  const textToSearch = description + ' ' + content.slice(0, 2000) // Search first 2000 chars
-
-  for (const pattern of patterns) {
-    for (const match of textToSearch.matchAll(pattern)) {
-      const phrase = match[1].trim().toLowerCase()
-      if (phrase.length >= 5 && phrase.length <= 50 && !phrases.includes(phrase)) {
-        phrases.push(phrase)
-      }
-    }
-  }
-
-  // Extract from "trigger" or "invoke" mentions
-  const triggerMatch = content.match(/trigger[s]?\s*[:=]\s*["`']([^"`']+)["`']/gi)
-  if (triggerMatch) {
-    for (const match of triggerMatch) {
-      const phrase = match.replace(/trigger[s]?\s*[:=]\s*["`']/i, '').replace(/["`']$/, '')
-      if (!phrases.includes(phrase.toLowerCase())) {
-        phrases.push(phrase.toLowerCase())
-      }
-    }
-  }
-
-  return phrases.slice(0, 5) // Limit to 5 phrases
-}
-
-/**
- * Determine optimal model for subagent
- * SMI-1795: Uses CLAUDE_MODELS constants for type safety
- */
-function determineModel(toolUsage: ToolUsageAnalysis, lineCount: number): ClaudeModel {
-  // Haiku for simple, fast operations
-  if (toolUsage.detectedTools.length <= 2 && lineCount < 200) {
-    return CLAUDE_MODELS.HAIKU
-  }
-
-  // Opus for complex, reasoning-heavy tasks
-  if (
-    toolUsage.bashCommandCount > 5 ||
-    (toolUsage.fileReadCount > 3 && toolUsage.fileWriteCount > 3)
-  ) {
-    return CLAUDE_MODELS.OPUS
-  }
-
-  // Sonnet for balanced workloads (default)
-  return CLAUDE_MODELS.SONNET
-}
-
-/**
- * Detect tools needed from skill content
- */
-function detectTools(content: string): string[] {
-  const lowerContent = content.toLowerCase()
-  const detectedTools = new Set<string>(BASE_TOOLS)
-
-  for (const [tool, config] of Object.entries(TOOL_PATTERNS)) {
-    for (const pattern of config.patterns) {
-      if (lowerContent.includes(pattern.toLowerCase())) {
-        detectedTools.add(tool)
-        break
-      }
-    }
-  }
-
-  return Array.from(detectedTools)
-}
-
-/**
  * Generate a companion subagent for a skill
  *
  * @param skillName - The name of the skill
  * @param description - The skill's description
  * @param content - The full SKILL.md content
  * @param analysis - Analysis from SkillAnalyzer
+ * @param client - SMI-6276: target client for the generated companion-agent
+ *   frontmatter shape (default: canonical / `claude-code`, preserving prior
+ *   behavior for every existing caller). See `SubagentGenerator.client-profiles.ts`.
  * @returns Subagent generation result
  */
 export function generateSubagent(
   skillName: string,
   description: string,
   content: string,
-  analysis: SkillAnalysis
+  analysis: SkillAnalysis,
+  client: ClientId = CANONICAL_CLIENT
 ): SubagentGenerationResult {
   // SMI-1815: Validate skill name is non-empty
   if (!skillName || skillName.trim() === '') {
@@ -395,7 +192,8 @@ export function generateSubagent(
     subagentDescription,
     triggerPhrases,
     allTools,
-    model
+    model,
+    client
   )
 
   // Generate CLAUDE.md snippet
@@ -427,12 +225,16 @@ export function generateSubagent(
  * @param skillName - The name of the skill
  * @param description - The skill's description
  * @param content - The full SKILL.md content
+ * @param client - SMI-6276: target client for the generated companion-agent
+ *   frontmatter shape (default: canonical / `claude-code`, preserving prior
+ *   behavior for every existing caller). See `SubagentGenerator.client-profiles.ts`.
  * @returns Subagent generation result
  */
 export function generateMinimalSubagent(
   skillName: string,
   description: string,
-  content: string
+  content: string,
+  client: ClientId = CANONICAL_CLIENT
 ): SubagentGenerationResult {
   // SMI-1815: Validate skill name is non-empty
   if (!skillName || skillName.trim() === '') {
@@ -460,7 +262,8 @@ export function generateMinimalSubagent(
     subagentDescription,
     triggerPhrases,
     detectedTools,
-    model
+    model,
+    client
   )
 
   const claudeMdSnippet = generateClaudeMdSnippet(

--- a/packages/core/src/services/SubagentGenerator.ts
+++ b/packages/core/src/services/SubagentGenerator.ts
@@ -67,10 +67,18 @@ function generateSubagentContent(
 
   const profile = getSubagentGenerationProfile(client)
 
+  // SMI-6276 pr-reviewer finding: `description` is free text sourced from
+  // the SKILL.md being transformed — an unquoted plain YAML scalar breaks
+  // if it contains `: ` (reinterpreted as a nested key) or ` #` (truncated
+  // as a comment). JSON.stringify() produces a valid YAML double-quoted
+  // scalar (YAML's double-quote escaping is a superset of JSON's), so this
+  // composes the full description+trigger text as a plain JS string FIRST,
+  // then quotes the whole thing once — not per-field — so the result is
+  // safe regardless of what the source content contains.
   const frontmatterLines = [
     '---',
     `name: ${name}`,
-    `description: ${description} Use when ${triggerString}.`,
+    `description: ${JSON.stringify(`${description} Use when ${triggerString}.`)}`,
   ]
   if (profile.includeSkillsField) {
     frontmatterLines.push(`skills: ${name.replace('-specialist', '')}`)

--- a/packages/core/src/services/SubagentGenerator.types.ts
+++ b/packages/core/src/services/SubagentGenerator.types.ts
@@ -1,0 +1,56 @@
+/**
+ * SMI-1788: Types for SubagentGenerator — split out under the 500-line
+ * standard (SMI-6276) following this directory's existing `.types.ts`
+ * convention (see SkillAnalyzer.types.ts / SkillDecomposer.types.ts).
+ */
+
+/**
+ * SMI-1795: Claude model constants for type safety and consistency
+ */
+export const CLAUDE_MODELS = {
+  HAIKU: 'haiku',
+  SONNET: 'sonnet',
+  OPUS: 'opus',
+} as const
+
+export type ClaudeModel = (typeof CLAUDE_MODELS)[keyof typeof CLAUDE_MODELS]
+
+/**
+ * Generated subagent definition
+ */
+export interface SubagentDefinition {
+  /** Subagent name (e.g., "jest-helper-specialist") */
+  name: string
+
+  /** Description for the Task tool */
+  description: string
+
+  /** Trigger phrases that should invoke this subagent */
+  triggerPhrases: string[]
+
+  /** Tools the subagent needs access to */
+  tools: string[]
+
+  /** Recommended model */
+  model: ClaudeModel
+
+  /** The full markdown content for the target client's companion-agent directory */
+  content: string
+}
+
+/**
+ * Result of subagent generation
+ */
+export interface SubagentGenerationResult {
+  /** Whether a subagent was generated */
+  generated: boolean
+
+  /** The subagent definition (if generated) */
+  subagent?: SubagentDefinition
+
+  /** Reason if not generated */
+  reason?: string
+
+  /** CLAUDE.md integration snippet */
+  claudeMdSnippet?: string
+}

--- a/packages/core/src/services/TransformationService.ts
+++ b/packages/core/src/services/TransformationService.ts
@@ -25,96 +25,19 @@ import {
   parallelizeTaskCalls,
   type DecompositionResult,
 } from './SkillDecomposer.js'
-import {
-  generateSubagent,
-  type SubagentGenerationResult,
-  type SubagentDefinition,
-} from './SubagentGenerator.js'
+import { generateSubagent, type SubagentGenerationResult } from './SubagentGenerator.js'
+import { CANONICAL_CLIENT, type ClientId } from '../install/paths.js'
+import type {
+  CachedTransformation,
+  TransformationResult,
+  TransformationServiceOptions,
+} from './TransformationService.types.js'
 
-/**
- * Full transformation result for a skill
- */
-export interface TransformationResult {
-  /** Whether transformation was applied */
-  transformed: boolean
-
-  /** The optimized main SKILL.md content */
-  mainSkillContent: string
-
-  /** Sub-skills (if decomposed) */
-  subSkills: Array<{
-    filename: string
-    content: string
-  }>
-
-  /** Companion subagent (if generated) */
-  subagent?: SubagentDefinition
-
-  /** CLAUDE.md integration snippet */
-  claudeMdSnippet?: string
-
-  /** Transformation statistics */
-  stats: TransformationStats
-
-  /** Analysis that informed the transformation */
-  analysis: SkillAnalysis
-
-  /** Attribution footer added to content */
-  attribution: string
-}
-
-/**
- * Statistics about the transformation
- */
-export interface TransformationStats {
-  /** Original content line count */
-  originalLines: number
-
-  /** Optimized main skill line count */
-  optimizedLines: number
-
-  /** Number of sub-skills extracted */
-  subSkillCount: number
-
-  /** Whether Task() calls were parallelized */
-  tasksParallelized: boolean
-
-  /** Whether subagent was generated */
-  subagentGenerated: boolean
-
-  /** Estimated token reduction percentage */
-  tokenReductionPercent: number
-
-  /** Transformation duration in ms */
-  transformDurationMs: number
-}
-
-/**
- * Cached transformation entry
- */
-interface CachedTransformation {
-  result: TransformationResult
-  skillHash: string
-  cachedAt: string
-  version: string
-}
-
-/**
- * Configuration for TransformationService
- */
-export interface TransformationServiceOptions {
-  /** Cache TTL in seconds (default: 3600 = 1 hour) */
-  cacheTtl?: number
-
-  /** Enable caching (default: true) */
-  enableCache?: boolean
-
-  /** Force re-transformation even if cached (default: false) */
-  forceTransform?: boolean
-
-  /** Transformation version for cache invalidation */
-  version?: string
-}
+export type {
+  TransformationResult,
+  TransformationStats,
+  TransformationServiceOptions,
+} from './TransformationService.types.js'
 
 const DEFAULT_OPTIONS: Required<TransformationServiceOptions> = {
   cacheTtl: 3600, // 1 hour
@@ -161,13 +84,18 @@ export class TransformationService {
    * @param skillName - Human-readable skill name
    * @param description - Skill description
    * @param content - The full SKILL.md content
+   * @param client - SMI-6276: target client for the generated companion-agent
+   *   frontmatter shape (default: canonical / `claude-code`, preserving prior
+   *   behavior for every existing caller). See
+   *   `SubagentGenerator.client-profiles.ts`.
    * @returns Transformation result
    */
   async transform(
     skillId: string,
     skillName: string,
     description: string,
-    content: string
+    content: string,
+    client: ClientId = CANONICAL_CLIENT
   ): Promise<TransformationResult> {
     const startTime = Date.now()
 
@@ -216,7 +144,7 @@ export class TransformationService {
     const decomposition = decomposeSkill(transformedContent, analysis)
 
     // 3. Generate subagent if beneficial
-    const subagentResult = generateSubagent(skillName, description, content, analysis)
+    const subagentResult = generateSubagent(skillName, description, content, analysis, client)
 
     // Build result
     const result = this.buildResult(
@@ -244,12 +172,15 @@ export class TransformationService {
    * @param skillName - Human-readable skill name
    * @param description - Skill description
    * @param content - The full SKILL.md content
+   * @param client - SMI-6276: target client for the generated companion-agent
+   *   frontmatter shape (default: canonical / `claude-code`).
    * @returns Transformation result
    */
   transformWithoutCache(
     skillName: string,
     description: string,
-    content: string
+    content: string,
+    client: ClientId = CANONICAL_CLIENT
   ): TransformationResult {
     const startTime = Date.now()
 
@@ -282,7 +213,7 @@ export class TransformationService {
     const decomposition = decomposeSkill(transformedContent, analysis)
 
     // 3. Generate subagent if beneficial
-    const subagentResult = generateSubagent(skillName, description, content, analysis)
+    const subagentResult = generateSubagent(skillName, description, content, analysis, client)
 
     return this.buildResult(decomposition, subagentResult, analysis, tasksParallelized, startTime)
   }
@@ -477,15 +408,18 @@ export class TransformationService {
  * @param skillName - Human-readable skill name
  * @param description - Skill description
  * @param content - The full SKILL.md content
+ * @param client - SMI-6276: target client for the generated companion-agent
+ *   frontmatter shape (default: canonical / `claude-code`).
  * @returns Transformation result
  */
 export function transformSkill(
   skillName: string,
   description: string,
-  content: string
+  content: string,
+  client: ClientId = CANONICAL_CLIENT
 ): TransformationResult {
   const service = new TransformationService()
-  return service.transformWithoutCache(skillName, description, content)
+  return service.transformWithoutCache(skillName, description, content, client)
 }
 
 export default TransformationService

--- a/packages/core/src/services/TransformationService.ts
+++ b/packages/core/src/services/TransformationService.ts
@@ -108,7 +108,7 @@ export class TransformationService {
 
     // Check cache first (unless force transform)
     if (!this.options.forceTransform && this.cache) {
-      const cached = this.getCachedTransformation(skillId, content)
+      const cached = this.getCachedTransformation(skillId, content, client)
       if (cached) {
         return cached
       }
@@ -121,7 +121,7 @@ export class TransformationService {
 
       // Cache the result
       if (this.cache) {
-        this.cacheTransformation(skillId, content, result)
+        this.cacheTransformation(skillId, content, result, client)
       }
 
       return result
@@ -157,7 +157,7 @@ export class TransformationService {
 
     // Cache the result
     if (this.cache) {
-      this.cacheTransformation(skillId, content, result)
+      this.cacheTransformation(skillId, content, result, client)
     }
 
     return result
@@ -231,11 +231,15 @@ export class TransformationService {
   /**
    * Get cached transformation if available and valid
    */
-  private getCachedTransformation(skillId: string, content: string): TransformationResult | null {
+  private getCachedTransformation(
+    skillId: string,
+    content: string,
+    client: ClientId
+  ): TransformationResult | null {
     if (!this.cache) return null
 
     try {
-      const cacheKey = this.buildCacheKey(skillId)
+      const cacheKey = this.buildCacheKey(skillId, client)
       const cached = this.cache.get<CachedTransformation>(cacheKey)
 
       if (!cached) return null
@@ -266,12 +270,13 @@ export class TransformationService {
   private cacheTransformation(
     skillId: string,
     content: string,
-    result: TransformationResult
+    result: TransformationResult,
+    client: ClientId
   ): void {
     if (!this.cache) return
 
     try {
-      const cacheKey = this.buildCacheKey(skillId)
+      const cacheKey = this.buildCacheKey(skillId, client)
       const contentHash = this.hashContent(content)
 
       const cacheEntry: CachedTransformation = {
@@ -289,10 +294,13 @@ export class TransformationService {
   }
 
   /**
-   * Build cache key for a skill
+   * Build cache key for a skill. Includes `client` (SMI-6276 pr-reviewer
+   * finding) -- without it, a cached transformation generated for one
+   * client's frontmatter shape gets silently served back for a different
+   * client, defeating the whole point of client-parameterized generation.
    */
-  private buildCacheKey(skillId: string): string {
-    return `${CACHE_KEY_PREFIX}${skillId}`
+  private buildCacheKey(skillId: string, client: ClientId): string {
+    return `${CACHE_KEY_PREFIX}${skillId}:${client}`
   }
 
   /**

--- a/packages/core/src/services/TransformationService.types.ts
+++ b/packages/core/src/services/TransformationService.types.ts
@@ -1,0 +1,94 @@
+/**
+ * Type definitions for `TransformationService.ts` — split out (SMI-6276)
+ * when the `client` parameter threaded through by Wave 6 Step 1 pushed the
+ * combined file past the 500-line standard. Re-exported verbatim from
+ * `TransformationService.ts` so its own public import path is unaffected.
+ */
+
+import type { SkillAnalysis } from './SkillAnalyzer.js'
+import type { SubagentDefinition } from './SubagentGenerator.js'
+
+/**
+ * Full transformation result for a skill
+ */
+export interface TransformationResult {
+  /** Whether transformation was applied */
+  transformed: boolean
+
+  /** The optimized main SKILL.md content */
+  mainSkillContent: string
+
+  /** Sub-skills (if decomposed) */
+  subSkills: Array<{
+    filename: string
+    content: string
+  }>
+
+  /** Companion subagent (if generated) */
+  subagent?: SubagentDefinition
+
+  /** CLAUDE.md integration snippet */
+  claudeMdSnippet?: string
+
+  /** Transformation statistics */
+  stats: TransformationStats
+
+  /** Analysis that informed the transformation */
+  analysis: SkillAnalysis
+
+  /** Attribution footer added to content */
+  attribution: string
+}
+
+/**
+ * Statistics about the transformation
+ */
+export interface TransformationStats {
+  /** Original content line count */
+  originalLines: number
+
+  /** Optimized main skill line count */
+  optimizedLines: number
+
+  /** Number of sub-skills extracted */
+  subSkillCount: number
+
+  /** Whether Task() calls were parallelized */
+  tasksParallelized: boolean
+
+  /** Whether subagent was generated */
+  subagentGenerated: boolean
+
+  /** Estimated token reduction percentage */
+  tokenReductionPercent: number
+
+  /** Transformation duration in ms */
+  transformDurationMs: number
+}
+
+/**
+ * Cached transformation entry
+ */
+export interface CachedTransformation {
+  result: TransformationResult
+  skillHash: string
+  cachedAt: string
+  version: string
+}
+
+/**
+ * Configuration for TransformationService
+ */
+export interface TransformationServiceOptions {
+  /** Cache TTL in seconds (default: 3600 = 1 hour) */
+  cacheTtl?: number
+
+  /** Enable caching (default: true) */
+  enableCache?: boolean
+
+  /** Force re-transformation even if cached (default: false) */
+  forceTransform?: boolean
+
+  /** Transformation version for cache invalidation */
+  version?: string
+}

--- a/packages/core/src/services/__tests__/SubagentGenerator.client-profiles.test.ts
+++ b/packages/core/src/services/__tests__/SubagentGenerator.client-profiles.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Tests for SubagentGenerator.client-profiles (SMI-6276)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { CLIENT_IDS } from '../../install/paths.js'
+import {
+  SUBAGENT_CLIENT_PROFILES,
+  getSubagentGenerationProfile,
+  mapToolNames,
+} from '../SubagentGenerator.client-profiles.js'
+
+describe('SubagentGenerator.client-profiles', () => {
+  describe('SUBAGENT_CLIENT_PROFILES', () => {
+    it('has an entry for every ClientId', () => {
+      for (const client of CLIENT_IDS) {
+        expect(SUBAGENT_CLIENT_PROFILES[client]).toBeDefined()
+      }
+    })
+
+    it('gives cursor the exact same profile object as claude-code (deliberate reuse)', () => {
+      expect(SUBAGENT_CLIENT_PROFILES.cursor).toBe(SUBAGENT_CLIENT_PROFILES['claude-code'])
+    })
+
+    it('claude-code accepts Claude-native tools and a Claude model enum', () => {
+      const profile = SUBAGENT_CLIENT_PROFILES['claude-code']
+      expect(profile.toolsPolicy).toBe('claude-native')
+      expect(profile.modelPolicy).toBe('claude-enum')
+      expect(profile.includeSkillsField).toBe(true)
+    })
+
+    it('antigravity uses a mapped tool array and omits the model field', () => {
+      const profile = SUBAGENT_CLIENT_PROFILES.antigravity
+      expect(profile.toolsPolicy).toBe('mapped-array')
+      expect(profile.modelPolicy).toBe('omit')
+      expect(profile.includeSkillsField).toBe(false)
+      expect(profile.toolNameMap).toBeDefined()
+    })
+
+    it('opencode includes the mode: subagent line but omits tools/model', () => {
+      const profile = SUBAGENT_CLIENT_PROFILES.opencode
+      expect(profile.toolsPolicy).toBe('omit')
+      expect(profile.modelPolicy).toBe('omit')
+      expect(profile.extraFrontmatterLines).toContain('mode: subagent')
+    })
+
+    it('every unverified-vocabulary client (copilot/windsurf/agents/hermes/grok) omits tools and model', () => {
+      for (const client of ['copilot', 'windsurf', 'agents', 'hermes', 'grok'] as const) {
+        const profile = SUBAGENT_CLIENT_PROFILES[client]
+        expect(profile.toolsPolicy).toBe('omit')
+        expect(profile.modelPolicy).toBe('omit')
+      }
+    })
+  })
+
+  describe('getSubagentGenerationProfile', () => {
+    it('defaults to the claude-code (canonical) profile when no client is given', () => {
+      expect(getSubagentGenerationProfile()).toBe(SUBAGENT_CLIENT_PROFILES['claude-code'])
+    })
+
+    it('resolves the antigravity profile by name', () => {
+      expect(getSubagentGenerationProfile('antigravity')).toBe(SUBAGENT_CLIENT_PROFILES.antigravity)
+    })
+  })
+
+  describe('mapToolNames', () => {
+    const antigravityProfile = SUBAGENT_CLIENT_PROFILES.antigravity
+
+    it('maps confirmed Skillsmith tool names to AntiGravity-own identifiers', () => {
+      const mapped = mapToolNames(['Read', 'Bash', 'Grep'], antigravityProfile)
+      expect(mapped).toEqual(['view_file', 'run_command', 'grep_search'])
+    })
+
+    it('deduplicates Write and Edit onto the same AntiGravity tool', () => {
+      const mapped = mapToolNames(['Write', 'Edit'], antigravityProfile)
+      expect(mapped).toEqual(['replace_file_content'])
+    })
+
+    it('silently drops internal tool names with no confirmed AntiGravity mapping', () => {
+      const mapped = mapToolNames(['Glob', 'WebFetch', 'WebSearch'], antigravityProfile)
+      expect(mapped).toEqual([])
+    })
+
+    it('returns an empty array for a profile with no toolNameMap', () => {
+      const mapped = mapToolNames(['Read', 'Bash'], SUBAGENT_CLIENT_PROFILES['claude-code'])
+      expect(mapped).toEqual([])
+    })
+  })
+})

--- a/packages/core/src/services/__tests__/SubagentGenerator.helpers.test.ts
+++ b/packages/core/src/services/__tests__/SubagentGenerator.helpers.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Tests for `SubagentGenerator.helpers.ts` — split from
+ * `SubagentGenerator.ts` (SMI-6276 Wave 6 Step 1, 500-line standard).
+ */
+import { describe, it, expect } from 'vitest'
+import { extractTriggerPhrases } from '../SubagentGenerator.helpers.js'
+
+describe('extractTriggerPhrases', () => {
+  it('extracts phrases from normal descriptions and content', () => {
+    const phrases = extractTriggerPhrases(
+      'Use this when you need to test REST APIs.',
+      'This skill helps you validate API responses.'
+    )
+    expect(phrases.length).toBeGreaterThan(0)
+    expect(phrases.length).toBeLessThanOrEqual(5)
+  })
+
+  it('returns an empty array for content with no trigger-like phrasing', () => {
+    const phrases = extractTriggerPhrases('A skill', 'Nothing special here')
+    expect(Array.isArray(phrases)).toBe(true)
+  })
+
+  // CodeQL finding (SMI-6276, "polynomial regular expression used on
+  // uncontrolled data"): the pre-fix patterns paired an optional word group
+  // directly against an unbounded lazy wildcard capture, giving
+  // polynomially-many ways to split ambiguous repeated content between "the
+  // optional group matched" and "the wildcard consumed it instead" --
+  // `description` here is NOT length-capped before reaching these patterns
+  // (only `content` is sliced to 2000 chars), and is untrusted,
+  // externally-authored text in a skill registry — a genuine attack
+  // surface. Empirically confirmed (not just theoretical) before this fix:
+  // the exact 3-pattern loop below, run against a ~32KB adversarial
+  // description built the same way as this test's input, took ~1.25s
+  // pre-fix and ~7ms post-fix on this same test machine -- a real,
+  // measurable quadratic-ish blowup a large-enough description would turn
+  // into a genuine multi-second-or-more DoS.
+  it('does not exhibit polynomial-time blowup on adversarial "helps ... tasks" input (ReDoS)', () => {
+    const adversarialDescription = 'helps you to ' + 'a '.repeat(16000) + 'nomatch'
+    const start = Date.now()
+    const phrases = extractTriggerPhrases(adversarialDescription, '')
+    const elapsedMs = Date.now() - start
+
+    expect(Array.isArray(phrases)).toBe(true)
+    // The fixed patterns finish in single-digit milliseconds regardless of
+    // input size (bounded capture groups cap worst-case per-position work
+    // to a small constant); the pre-fix patterns measured ~1250ms on this
+    // exact input on this machine. 1000ms leaves generous CI-jitter
+    // headroom while still failing hard on any reintroduction of the
+    // unbounded-wildcard shape.
+    expect(elapsedMs).toBeLessThan(1000)
+  })
+
+  it('does not exhibit polynomial-time blowup on adversarial "when ... need to" input (ReDoS)', () => {
+    const adversarialDescription = 'when ' + 'you need to '.repeat(16000) + 'nomatch'
+    const start = Date.now()
+    const phrases = extractTriggerPhrases(adversarialDescription, '')
+    const elapsedMs = Date.now() - start
+
+    expect(Array.isArray(phrases)).toBe(true)
+    expect(elapsedMs).toBeLessThan(1000)
+  })
+
+  it('still caps extracted phrases at the existing 50-character limit', () => {
+    const longDescription = 'when you need to ' + 'x'.repeat(200) + '.'
+    const phrases = extractTriggerPhrases(longDescription, '')
+    for (const phrase of phrases) {
+      expect(phrase.length).toBeLessThanOrEqual(50)
+    }
+  })
+})

--- a/packages/core/src/services/__tests__/SubagentGenerator.test.ts
+++ b/packages/core/src/services/__tests__/SubagentGenerator.test.ts
@@ -4,8 +4,16 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { parse as parseYaml } from 'yaml'
 import { generateSubagent, generateMinimalSubagent } from '../SubagentGenerator.js'
 import { analyzeSkill } from '../SkillAnalyzer.js'
+
+/** Extract just the frontmatter block (between the two `---` markers) as raw text. */
+function extractFrontmatter(content: string): string {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) throw new Error('No frontmatter block found in generated content')
+  return match[1]
+}
 
 describe('SubagentGenerator', () => {
   describe('generateSubagent', () => {
@@ -358,6 +366,65 @@ Search for patterns using grep.
       expect(content).toMatch(/^mode: subagent$/m)
       expect(content).not.toMatch(/^tools:/m)
       expect(content).not.toMatch(/^model:/m)
+    })
+  })
+
+  // GPT-5.6-Sol round-2 pr-reviewer confirmation (SMI-6276): round 1's fix
+  // (JSON.stringify()-quoting the description) was CONFIRMED-FIXED, but the
+  // round-1 regression tests only asserted a description LINE existed, never
+  // actually exercised a hazardous `: ` or ` #` sequence. This closes that
+  // coverage gap by parsing the generated frontmatter with a real YAML
+  // parser, proving both that it's syntactically valid AND that the
+  // hazardous substrings survive intact rather than corrupting the block.
+  describe('YAML-safe description quoting (SMI-6276 round 2)', () => {
+    // Heavy tool-usage body (same pattern already proven above in this file)
+    // to reliably clear generateSubagent()'s own "worth generating" gate —
+    // the hazardous text under test lives only in the `description` argument
+    // passed to generateSubagent(), not the source SKILL.md's own frontmatter.
+    const heavyToolBody = `---
+name: hazard-skill
+description: A skill with heavy tool usage for YAML-hazard testing
+---
+
+# Hazard Skill
+
+- npm install
+- git status
+- docker build
+- npx something
+- yarn add
+- pnpm install
+
+Use bash to execute commands.
+Terminal operations are common.
+`
+
+    it('a description containing ": " does not get reinterpreted as a nested YAML key', () => {
+      const description = 'Handles config: values and other: colon-separated pairs'
+      const analysis = analyzeSkill(heavyToolBody)
+      const result = generateSubagent('colon-skill', description, heavyToolBody, analysis)
+
+      const frontmatter = extractFrontmatter(result.subagent!.content)
+      const parsed = parseYaml(frontmatter) as Record<string, unknown>
+      // The full description text must survive as ONE string value under the
+      // `description` key — not silently truncated, and not exploded into
+      // extra top-level keys by an unescaped `: `.
+      expect(typeof parsed.description).toBe('string')
+      expect(parsed.description as string).toContain(description)
+      expect(Object.keys(parsed)).not.toContain('values and other')
+    })
+
+    it('a description containing " #" does not get truncated as a YAML comment', () => {
+      const description = 'Fixes issue #123 and #456 before release'
+      const analysis = analyzeSkill(heavyToolBody)
+      const result = generateSubagent('hash-skill', description, heavyToolBody, analysis)
+
+      const frontmatter = extractFrontmatter(result.subagent!.content)
+      const parsed = parseYaml(frontmatter) as Record<string, unknown>
+      expect(typeof parsed.description).toBe('string')
+      // Everything after the first ` #` must still be present -- an
+      // unquoted scalar would have silently dropped "123 and #456...".
+      expect(parsed.description as string).toContain('#123 and #456 before release')
     })
   })
 })

--- a/packages/core/src/services/__tests__/SubagentGenerator.test.ts
+++ b/packages/core/src/services/__tests__/SubagentGenerator.test.ts
@@ -215,5 +215,149 @@ Write output files.
 
       expect(result.subagent?.tools).toContain('Read')
     })
+
+    it('threads the client parameter through to a client-specific frontmatter shape', () => {
+      const content = `# Skill\n\nRun bash commands. Search for patterns using grep.`
+      const result = generateMinimalSubagent('client-skill', 'Client skill', content, 'antigravity')
+
+      expect(result.generated).toBe(true)
+      expect(result.subagent?.content).not.toMatch(/^tools: /m)
+      expect(result.subagent?.content).not.toMatch(/^model: (haiku|sonnet|opus)$/m)
+    })
+  })
+
+  describe('per-client generation profiles (SMI-6276)', () => {
+    // Mirrors the existing heavy-tool-usage fixture above so `suggestsSubagent`
+    // reliably trips — plus lines that hit Read/Bash/Grep detection so the
+    // AntiGravity mapped-array assertions below have something to map.
+    const heavyToolContent = `---
+name: multi-client-skill
+description: Exercises heavy tool usage across bash, grep, and file reads
+---
+
+# Multi Client Skill
+
+This skill runs many commands:
+- npm install
+- git status
+- docker build
+- npx something
+- yarn add
+- pnpm install
+
+Use bash to execute commands.
+Terminal operations are common.
+Read files to examine content before changes.
+Search for patterns using grep.
+`
+    const description = 'Exercises heavy tool usage across bash, grep, and file reads'
+    const analysis = analyzeSkill(heavyToolContent)
+
+    it('generates distinct frontmatter for Claude Code, Cursor, AntiGravity, and an omit-fallback client in the same run', () => {
+      const claudeResult = generateSubagent(
+        'multi-client-skill',
+        description,
+        heavyToolContent,
+        analysis,
+        'claude-code'
+      )
+      const cursorResult = generateSubagent(
+        'multi-client-skill',
+        description,
+        heavyToolContent,
+        analysis,
+        'cursor'
+      )
+      const antigravityResult = generateSubagent(
+        'multi-client-skill',
+        description,
+        heavyToolContent,
+        analysis,
+        'antigravity'
+      )
+      const copilotResult = generateSubagent(
+        'multi-client-skill',
+        description,
+        heavyToolContent,
+        analysis,
+        'copilot'
+      )
+
+      expect(claudeResult.generated).toBe(true)
+      expect(cursorResult.generated).toBe(true)
+      expect(antigravityResult.generated).toBe(true)
+      expect(copilotResult.generated).toBe(true)
+
+      const claudeContent = claudeResult.subagent!.content
+      const cursorContent = cursorResult.subagent!.content
+      const antigravityContent = antigravityResult.subagent!.content
+      const copilotContent = copilotResult.subagent!.content
+
+      // Claude Code: Claude-native comma-list tools + a Claude model enum value.
+      expect(claudeContent).toMatch(/^tools: .*Read/m)
+      expect(claudeContent).toMatch(/^model: (haiku|sonnet|opus)$/m)
+
+      // Cursor deliberately mirrors Claude Code — COMPANION_AGENT_TARGETS.cursor
+      // resolves to the SAME `.claude/agents/` file, which Cursor reads as a
+      // documented compatibility surface (see client-profiles.ts header) — so
+      // identical output here is the intended, evidence-backed behavior, not
+      // an accidental fallback to a shared default.
+      expect(cursorContent).toEqual(claudeContent)
+
+      // AntiGravity: genuinely different shape — proves this isn't just
+      // Cursor's case reused everywhere. No Claude-shaped scalar `tools:`
+      // line, no Claude model enum value, and its OWN mapped vocabulary
+      // rendered as a real YAML array (not a comma-joined string).
+      expect(antigravityContent).not.toMatch(/^tools: /m)
+      expect(antigravityContent).not.toContain('Read,')
+      expect(antigravityContent).not.toMatch(/^model: (haiku|sonnet|opus)$/m)
+      expect(antigravityContent).toMatch(/^tools:$/m)
+      expect(antigravityContent).toContain('  - run_command')
+      expect(antigravityContent).toContain('  - grep_search')
+      expect(antigravityContent).toContain('  - view_file')
+      // Step 2 is a separate, independent question (not this wave's scope) —
+      // regression-pin that this wave's fix does not touch it either way.
+      expect(antigravityContent).not.toMatch(/^subagent:/m)
+
+      // Copilot: the unverified-vocabulary fallback path — omits both fields
+      // entirely rather than guessing a partial/wrong mapping.
+      expect(copilotContent).not.toMatch(/^tools:/m)
+      expect(copilotContent).not.toMatch(/^model:/m)
+
+      // Every client still gets the universal minimum (name + description).
+      for (const content of [claudeContent, cursorContent, antigravityContent, copilotContent]) {
+        expect(content).toMatch(/^name: multi-client-skill-specialist$/m)
+        expect(content).toMatch(/^description: /m)
+      }
+    })
+
+    it('emits an AntiGravity tools array using only confirmed identifiers, not Claude names', () => {
+      const result = generateSubagent(
+        'multi-client-skill',
+        description,
+        heavyToolContent,
+        analysis,
+        'antigravity'
+      )
+
+      const content = result.subagent!.content
+      // Never leak Skillsmith's internal Claude-style names into the value.
+      expect(content).not.toMatch(/- (Read|Write|Edit|Bash|Grep|Glob|WebFetch|WebSearch)$/m)
+    })
+
+    it('gives OpenCode a mode: subagent line but no tools/model fields', () => {
+      const result = generateSubagent(
+        'multi-client-skill',
+        description,
+        heavyToolContent,
+        analysis,
+        'opencode'
+      )
+
+      const content = result.subagent!.content
+      expect(content).toMatch(/^mode: subagent$/m)
+      expect(content).not.toMatch(/^tools:/m)
+      expect(content).not.toMatch(/^model:/m)
+    })
   })
 })

--- a/packages/core/src/services/__tests__/TransformationService.test.ts
+++ b/packages/core/src/services/__tests__/TransformationService.test.ts
@@ -5,6 +5,27 @@
 
 import { describe, it, expect } from 'vitest'
 import { TransformationService, transformSkill } from '../TransformationService.js'
+import { createTestDatabase } from '../../../tests/helpers/database.js'
+
+const HEAVY_TOOL_USAGE_CONTENT = `---
+name: tool-skill
+description: A skill with heavy tool usage
+---
+
+# Tool Skill
+
+This skill runs many commands:
+- npm install packages
+- git status and commit
+- docker build images
+- npx execute scripts
+- yarn add dependencies
+- pnpm install modules
+
+Use bash to execute commands.
+Terminal operations are common.
+Shell scripting is required.
+`
 
 describe('TransformationService', () => {
   describe('constructor', () => {
@@ -286,6 +307,55 @@ ${'Example\n'.repeat(500)}
       )
 
       expect(result.stats.tokenReductionPercent).toBeLessThanOrEqual(80)
+    })
+  })
+
+  // SMI-6276 pr-reviewer finding: buildCacheKey() didn't include `client`,
+  // so transform()'s cache lookup for the SAME skillId+content but a
+  // DIFFERENT client would silently return a previously-cached OTHER
+  // client's result — defeating client-parameterized generation entirely
+  // the moment caching is enabled.
+  describe('cache key includes client (SMI-6276)', () => {
+    it('does not serve a claude-code-cached transformation back for a different client', async () => {
+      const db = await createTestDatabase()
+      try {
+        const service = new TransformationService(db)
+
+        const claudeResult = await service.transform(
+          'shared-skill-id',
+          'tool-skill',
+          'A skill with heavy tool usage',
+          HEAVY_TOOL_USAGE_CONTENT,
+          'claude-code'
+        )
+        expect(claudeResult.subagent).toBeDefined()
+        expect(claudeResult.subagent?.content).toMatch(/^model: (haiku|sonnet|opus)$/m)
+
+        // SAME skillId + SAME content, DIFFERENT client — must not hit the
+        // claude-code entry just cached above.
+        const antigravityResult = await service.transform(
+          'shared-skill-id',
+          'tool-skill',
+          'A skill with heavy tool usage',
+          HEAVY_TOOL_USAGE_CONTENT,
+          'antigravity'
+        )
+        expect(antigravityResult.subagent).toBeDefined()
+        expect(antigravityResult.subagent?.content).not.toMatch(/^model: (haiku|sonnet|opus)$/m)
+
+        // And a SECOND claude-code call for the same input must still hit
+        // its own cache entry (proving this isn't just "caching broke").
+        const claudeResultAgain = await service.transform(
+          'shared-skill-id',
+          'tool-skill',
+          'A skill with heavy tool usage',
+          HEAVY_TOOL_USAGE_CONTENT,
+          'claude-code'
+        )
+        expect(claudeResultAgain.subagent?.content).toBe(claudeResult.subagent?.content)
+      } finally {
+        db.close()
+      }
     })
   })
 })

--- a/packages/core/src/services/skill-installation.content.ts
+++ b/packages/core/src/services/skill-installation.content.ts
@@ -337,8 +337,13 @@ export async function installFromContent(params: InstallFromContentParams): Prom
     }
 
     onProgress('optimize', 'Applying optimization')
+    // SMI-6276 pr-reviewer finding: `client` is already resolved above (used
+    // by manifestKeyFor/generateTips below) — passing it here is required,
+    // not optional, or this install path silently falls back to
+    // applyOptimization()'s claude-code default regardless of the real
+    // target client.
     const { finalSkillContent, subSkillFiles, subagentContent, optimizationInfo } =
-      await applyOptimization(db, skillId, skillName, skillMdContent)
+      await applyOptimization(db, skillId, skillName, skillMdContent, client)
 
     // Team-authored content wins any filename collision with a generated sub-skill.
     const teamAuthoredSubFiles = Object.entries(content)

--- a/packages/core/src/services/skill-installation.helpers.ts
+++ b/packages/core/src/services/skill-installation.helpers.ts
@@ -211,12 +211,18 @@ export { performUninstall } from './skill-installation.uninstall.js'
 /**
  * Apply skill optimization via TransformationService.
  * Returns original content if transformation fails or produces no changes.
+ *
+ * @param client - SMI-6276: target client for the generated companion-agent
+ *   frontmatter shape (default: canonical / `claude-code`, preserving prior
+ *   behavior for every existing caller). See
+ *   `SubagentGenerator.client-profiles.ts`.
  */
 export async function applyOptimization(
   db: Database,
   skillId: string,
   skillName: string,
-  skillMdContent: string
+  skillMdContent: string,
+  client: ClientId = CANONICAL_CLIENT
 ): Promise<OptimizationResult> {
   try {
     const transformService = new TransformationService(db, {
@@ -233,7 +239,8 @@ export async function applyOptimization(
       skillId,
       extractedName,
       extractedDesc,
-      skillMdContent
+      skillMdContent,
+      client
     )
 
     if (transformResult.transformed) {

--- a/packages/core/src/services/skill-installation.service.ts
+++ b/packages/core/src/services/skill-installation.service.ts
@@ -302,7 +302,7 @@ export class SkillInstallationService {
             claudeMdSnippet: undefined as string | undefined,
             optimizationInfo: { optimized: false as const },
           }
-        : await applyOptimization(this.db, skillId, skillName, skillMdContent)
+        : await applyOptimization(this.db, skillId, skillName, skillMdContent, this.client)
 
       const { finalSkillContent, subSkillFiles, subagentContent, optimizationInfo } = optimizeResult
       const contentHash = hashContent(finalSkillContent)

--- a/packages/core/tests/unit/services/skill-installation.content.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.content.test.ts
@@ -51,7 +51,11 @@ async function cleanupTmpDirs(): Promise<void> {
   await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
 }
 
-function createService(db: Database): SkillInstallationService {
+function createService(
+  db: Database,
+  client?: import('../../../src/install/paths.js').ClientId,
+  companionBaseDir?: string
+): SkillInstallationService {
   const skillRepo = new SkillRepository(db)
   const skillDependencyRepo = new SkillDependencyRepository(db)
 
@@ -61,8 +65,27 @@ function createService(db: Database): SkillInstallationService {
     skillDependencyRepo,
     skillsDir,
     manifestPath,
+    ...(client !== undefined && { client }),
+    ...(companionBaseDir !== undefined && { companionBaseDir }),
   })
 }
+
+// SMI-6276 pr-reviewer finding: content substantial enough to trigger BOTH
+// quickTransformCheck (>=3 heavy-tool-pattern mentions) and
+// generateSubagent()'s own gate (lineCount >= 300) deterministically, so a
+// companion subagent is always generated regardless of analysis heuristics.
+const HEAVY_TOOL_USAGE_SKILL_MD = `---
+name: heavy-tool-skill
+description: A skill that runs npm, git, and docker commands extensively for testing client-aware subagent generation
+---
+
+# Heavy Tool Skill
+
+This skill runs \`npm install\`, \`git commit\`, and \`docker build\` as part of
+its normal operation, plus assorted Bash( invocations elsewhere in this file.
+
+${Array.from({ length: 300 }, (_, i) => `Padding line ${i} to exceed the subagent-generation line-count threshold.`).join('\n')}
+`
 
 describe('SMI-5905 Wave 1: installFromContent()', () => {
   let db: Database
@@ -345,5 +368,54 @@ describe('SMI-5905 Wave 1: installFromContent()', () => {
     expect(result.success).toBe(false)
     expect(result.errorCode).toBe('SCAN_REJECTED')
     await expect(fs.access(path.join(skillsDir, 'acme-tool'))).rejects.toThrow()
+  })
+
+  // SMI-6276 pr-reviewer finding (round 1): installFromContent() had `client`
+  // in scope (used elsewhere for the manifest key + tips) but never forwarded
+  // it into applyOptimization(), silently generating Claude-shaped subagent
+  // content regardless of the real target client. This proves the fix by
+  // installing the SAME heavy-tool-usage content under two different clients
+  // and asserting the written companion-subagent files actually differ in
+  // client-specific ways -- before the fix, both would be byte-identical
+  // (both Claude-shaped) despite requesting different clients.
+  it('threads the target client through to subagent generation — AntiGravity gets its own tool vocabulary, not Claude-shaped output', async () => {
+    const claudeService = createService(db, 'claude-code')
+    const claudeResult = await claudeService.installFromContent({
+      skillId: 'acme/heavy-tool-skill',
+      version: '1.0.0',
+      content: { 'SKILL.md': HEAVY_TOOL_USAGE_SKILL_MD },
+    })
+    expect(claudeResult.success).toBe(true)
+    expect(claudeResult.optimization?.subagentGenerated).toBe(true)
+    const claudeSubagentPath = claudeResult.optimization?.subagentPath
+    expect(claudeSubagentPath).toBeTruthy()
+    const claudeSubagentContent = await fs.readFile(claudeSubagentPath as string, 'utf-8')
+    // Claude-code gets the pre-existing Claude-shaped frontmatter.
+    expect(claudeSubagentContent).toMatch(/^model: (haiku|sonnet|opus)$/m)
+    expect(claudeSubagentContent).toMatch(/^tools: [A-Za-z]/m)
+
+    await cleanupTmpDirs()
+    await createTmpDirs()
+    db.close()
+    db = await createTestDatabase()
+
+    // AntiGravity's companion-agent path is workspace-relative (directory-
+    // package mode) and requires an explicit companionBaseDir — tmpDir
+    // stands in for "the calling client's real project" here.
+    const antigravityService = createService(db, 'antigravity', tmpDir)
+    const antigravityResult = await antigravityService.installFromContent({
+      skillId: 'acme/heavy-tool-skill',
+      version: '1.0.0',
+      content: { 'SKILL.md': HEAVY_TOOL_USAGE_SKILL_MD },
+    })
+    expect(antigravityResult.success).toBe(true)
+    expect(antigravityResult.optimization?.subagentGenerated).toBe(true)
+    const antigravitySubagentPath = antigravityResult.optimization?.subagentPath
+    expect(antigravitySubagentPath).toBeTruthy()
+    const antigravitySubagentContent = await fs.readFile(antigravitySubagentPath as string, 'utf-8')
+    // AntiGravity gets its own mapped tool vocabulary as a YAML array, and no
+    // Claude model field — the exact divergence this fix makes possible.
+    expect(antigravitySubagentContent).not.toMatch(/^model: (haiku|sonnet|opus)$/m)
+    expect(antigravitySubagentContent).not.toMatch(/^tools: [A-Za-z]/m)
   })
 })

--- a/packages/core/tests/unit/services/skill-installation.content.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.content.test.ts
@@ -17,6 +17,7 @@ import { SkillDependencyRepository } from '../../../src/repositories/SkillDepend
 import { createTestDatabase } from '../../helpers/database.js'
 import type { Database } from '../../../src/db/database-interface.js'
 import type { SkillContent } from '../../../src/services/skill-installation.types.js'
+import type { ClientId } from '../../../src/install/paths.js'
 
 const VALID_SKILL_MD = `---
 name: acme-tool
@@ -53,7 +54,7 @@ async function cleanupTmpDirs(): Promise<void> {
 
 function createService(
   db: Database,
-  client?: import('../../../src/install/paths.js').ClientId,
+  client?: ClientId,
   companionBaseDir?: string
 ): SkillInstallationService {
   const skillRepo = new SkillRepository(db)


### PR DESCRIPTION
## Business Summary

**What shipped:** Skillsmith's companion-subagent generator now writes correct, client-specific frontmatter instead of shipping Claude tool names and model tiers to every client. Most notably, AntiGravity's generated subagent files previously carried tool names and formatting AntiGravity's own docs warn can hang the subagent process — that's fixed for the four AntiGravity tools with a confirmed mapping, with everything else safely omitted rather than guessed.

**Quality bar:** Implementation + a parallel investigation that independently verified AntiGravity's real schema against Google's live docs and Wayback-archived snapshots (repro doc merged separately to docs-internal). Every per-client claim in the new profile table is cited with a source and a confidence level (HIGH/MEDIUM/LOW), following this repo's existing house style for that kind of thing. 180/180 relevant tests passing, lint/typecheck/audit:standards clean. Still pending: GPT-5.6-Sol cross-model PR review and live CI, both before merge.

**Net result:** Feature complete for this step. Step 2 of this wave (whether AntiGravity needs `subagent: true`) was resolved separately — the investigation determined it's correctly left out (AntiGravity defaults that field to `true`), citing this same schema research.

---

## Technical detail

Implements Wave 6 Step 1 of `docs/internal/implementation/cursor-antigravity-tier-parity-plan.md`.

- New `packages/core/src/services/SubagentGenerator.client-profiles.ts`: exhaustive per-client generation profile (frontmatter fields, tool-vocabulary policy, model policy) keyed on `ClientId`, covering every client `COMPANION_AGENT_TARGETS` writes a file for.
- `SubagentGenerator.ts`'s `generateSubagent()`/`generateMinimalSubagent()` now take a `client` parameter (default: canonical/claude-code — every existing caller unaffected) and route through the shared profile.
- `TransformationService`/`skill-installation` thread the client through to the generator; `skill-installation.service.ts` now passes the install's actual target client instead of silently defaulting.
- File splits to stay under the 500-line standard: `SubagentGenerator.{types,helpers}.ts` (pure extraction, same public API via re-export) and `TransformationService.types.ts` (the new `client` param pushed the combined file to 504 lines).
- New test coverage: `SubagentGenerator.client-profiles.test.ts` + updated `SubagentGenerator.test.ts` (generates for Claude Code, Cursor, AntiGravity, Copilot in one run, asserting distinct per-client frontmatter).
- Bumps the `docs/internal` submodule pointer to the just-merged repro doc (smith-horn/skillsmith-docs#936).