### PR TITLE
fix(cli): SMI-6278 Wave 8 -- state MCP-only registry publish/list policy

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skillsmith registry --help` now states that publishing and listing are MCP-only
+  today (`private_registry_publish`/`private_registry_manage`), pointing at those tools and
+  the private-registry docs page — matching already-shipped website copy. Two external
+  testers had each independently read the silent absence of `registry publish`/`list` as an
+  accidental gap; no new CLI subcommands (full CLI parity is tracked separately) (SMI-6266
+  Wave 8, SMI-6278)
 - **Feature**: `skillsmith whoami` now shows your live effective license tier (and, when the
   live check returns one, your per-minute API rate limit) alongside the existing masked-key/
   session display, resolved via the same credential-aware `resolveEffectiveTier()` live check

--- a/packages/cli/src/commands/registry-install.ts
+++ b/packages/cli/src/commands/registry-install.ts
@@ -42,11 +42,29 @@ export function createRegistryInstallCommand(): Command {
 
 /**
  * Build the `registry` command group.
+ *
+ * SMI-6278 (Wave 8): only `registry install` exists as a CLI subcommand today
+ * — publish/list are already-shipped, documented MCP-tool-only surfaces
+ * (`private_registry_publish` / `private_registry_manage`), not a gap. The
+ * trailing help text below surfaces that same stance (matching
+ * `packages/website/src/pages/docs/private-registry.astro`) so
+ * `registry --help` doesn't read as an accidental omission. No new CLI
+ * subcommands here — that's tracked separately as SMI-6290.
  */
 export function createRegistryCommand(): Command {
   return new Command('registry')
     .description("Commands for your team's private skill registry (Enterprise)")
     .addCommand(createRegistryInstallCommand())
+    .addHelpText(
+      'after',
+      `
+Note: Publishing and listing are MCP-only today — there's no CLI command for
+either yet, only for install. Use the private_registry_publish and
+private_registry_manage MCP tools instead.
+
+See https://skillsmith.app/docs/private-registry for details.
+`
+    )
 }
 
 export default createRegistryCommand


### PR DESCRIPTION
## Business Summary

**What shipped:** `skillsmith registry --help` now explains why `publish`/`list`/`approve` aren't there — pointing at the MCP tools that already handle them, instead of leaving a silent gap two external testers each independently read as a bug.

**Quality bar:** GPT-5.6-Sol cross-model review (NEEDLE) came back clean — no findings. Build, typecheck, and lint all pass; existing command tests unaffected.

**Net result:** Fully shipped, no follow-up. Full CLI parity for `registry publish`/`list`/`approve` is real, separate work already tracked as SMI-6290 — deliberately not folded in here.

---

## Technical detail

`packages/cli/src/commands/registry-install.ts` — `createRegistryCommand()` gets a Commander `.addHelpText('after', ...)` block matching the wording already live on `packages/website/src/pages/docs/private-registry.astro` ("Publishing and listing are MCP-only today..."), plus a JSDoc note explaining the policy. No new subcommands, no MCP-server changes. `Fixes GH#2508 (E-04), Fixes GH#2509 (E-05)`.
