### PR TITLE
feat(core): SMI-6277 Wave 7 -- AntiGravity MCP snippet parity

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to `@skillsmith/cli` are documented here.
   testers had each independently read the silent absence of `registry publish`/`list` as an
   accidental gap; no new CLI subcommands (full CLI parity is tracked separately) (SMI-6266
   Wave 8, SMI-6278)
+- **Fix**: The MCP config snippet for Google Antigravity now sets `SKILLSMITH_CLIENT: "antigravity"`,
+  so copying it verbatim installs skills to AntiGravity's own directory instead of silently
+  falling back to Claude Code's default — the same fix Cursor got earlier. `command`/`args`
+  stay plain `npx` (AntiGravity has no known `npx`-resolution problem, unlike Cursor) (SMI-6266
+  Wave 7, SMI-6277)
 - **Feature**: `skillsmith whoami` now shows your live effective license tier (and, when the
   live check returns one, your per-minute API rate limit) alongside the existing masked-key/
   session display, resolved via the same credential-aware `resolveEffectiveTier()` live check

--- a/packages/cli/src/templates/mcp-server.template.snippets.ts
+++ b/packages/cli/src/templates/mcp-server.template.snippets.ts
@@ -232,6 +232,15 @@ SKILLSMITH_API_KEY = "sk_live_..."`,
   // by an independent third-party source): global config at
   // ~/.gemini/config/mcp_config.json, standard `mcpServers` object shape
   // (same command/args/env fields every non-Codex/non-OpenCode client uses).
+  //
+  // SMI-6277 Wave 7: SKILLSMITH_CLIENT tells the server to install to
+  // AntiGravity's own skills directory instead of the default
+  // ~/.claude/skills — without it, an AntiGravity user who copies this
+  // snippet verbatim silently gets Claude Code's install path (same fix
+  // Cursor got in SMI-5894 Wave 1 Step 7). `command`/`args` stay plain
+  // `npx` — unlike Cursor, AntiGravity has no known `npx`-resolution
+  // problem, so there is no reason to switch it to a resolved-path
+  // placeholder.
   antigravity: {
     label: 'Google Antigravity',
     configPath: '~/.gemini/config/mcp_config.json',
@@ -242,7 +251,8 @@ SKILLSMITH_API_KEY = "sk_live_..."`,
       "command": "npx",
       "args": ["-y", "{{name}}"],
       "env": {
-        "SKILLSMITH_API_KEY": "sk_live_..."
+        "SKILLSMITH_API_KEY": "sk_live_...",
+        "SKILLSMITH_CLIENT": "antigravity"
       }
     }
   }

--- a/packages/website/src/lib/mcp-client-snippets.parity.test.ts
+++ b/packages/website/src/lib/mcp-client-snippets.parity.test.ts
@@ -162,14 +162,17 @@ describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', (
           })
         } else {
           const mcpServers = parsed.mcpServers as Record<string, { env?: Record<string, string> }>
-          // SMI-5894 Wave 1 Step 7: cursor's body already carries
-          // SKILLSMITH_CLIENT before withApiKey() runs — the merged env
-          // block keeps that key alongside the injected API key, unlike
-          // every other JSON client whose env block starts empty.
+          // SMI-5894 Wave 1 Step 7 / SMI-6277 Wave 7: cursor's and
+          // antigravity's bodies already carry SKILLSMITH_CLIENT before
+          // withApiKey() runs — the merged env block keeps that key
+          // alongside the injected API key, unlike every other JSON client
+          // whose env block starts empty.
           const expectedEnv =
             snippet.id === 'cursor'
               ? { SKILLSMITH_CLIENT: 'cursor', SKILLSMITH_API_KEY: expectedValue }
-              : { SKILLSMITH_API_KEY: expectedValue }
+              : snippet.id === 'antigravity'
+                ? { SKILLSMITH_CLIENT: 'antigravity', SKILLSMITH_API_KEY: expectedValue }
+                : { SKILLSMITH_API_KEY: expectedValue }
           expect(mcpServers['@skillsmith/mcp-server'].env).toEqual(expectedEnv)
         }
       } else if (snippet.format === 'toml') {
@@ -191,6 +194,20 @@ describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', (
     }
     expect(parsed.mcpServers['@skillsmith/mcp-server'].env).toEqual({
       SKILLSMITH_CLIENT: 'cursor',
+    })
+  })
+
+  // SMI-6277 Wave 7: without SKILLSMITH_CLIENT, an AntiGravity user who
+  // copies the MCP snippet gets Claude Code's default install path
+  // (~/.claude/skills) instead of ~/.gemini/config/skills.
+  it('antigravity snippet includes SKILLSMITH_CLIENT="antigravity" even before an API key is added', () => {
+    const antigravity = MCP_CLIENT_SNIPPETS.find((s) => s.id === 'antigravity')
+    expect(antigravity).toBeDefined()
+    const parsed = JSON.parse(antigravity!.body) as {
+      mcpServers: Record<string, { env?: Record<string, string> }>
+    }
+    expect(parsed.mcpServers['@skillsmith/mcp-server'].env).toEqual({
+      SKILLSMITH_CLIENT: 'antigravity',
     })
   })
 })

--- a/packages/website/src/lib/mcp-client-snippets.ts
+++ b/packages/website/src/lib/mcp-client-snippets.ts
@@ -12,7 +12,7 @@
  * Consumed by:
  *   - packages/website/src/pages/docs/quickstart.astro (Step 2, Option C — uses `.body`)
  *   - packages/website/src/pages/docs/getting-started.astro (Option 3 — uses
- *     `withApiKey(snippet.body, snippet.format)`)
+ *     `withApiKey(snippet.body, snippet.format, snippet.id)`)
  *
  * Order matches SNIPPET_DISPLAY_ORDER in the CLI package's canonical file.
  *
@@ -52,10 +52,13 @@ export interface McpClientSnippet {
   openByDefault?: boolean
 }
 
-// The 5 "standard" JSON clients (claude-code, cursor, copilot, windsurf,
-// agents) share an identical body: they all key on the published package
-// name, not a client-specific name, so this is reused rather than
-// hand-duplicated 5 times (see Review Summary #2 in the SMI-5554 plan).
+// The 4 "standard" JSON clients (claude-code, copilot, windsurf, agents)
+// share an identical body: they all key on the published package name, not
+// a client-specific name, so this is reused rather than hand-duplicated 4
+// times (see Review Summary #2 in the SMI-5554 plan). Cursor and AntiGravity
+// each get their own dedicated body below (CURSOR_JSON_BODY /
+// ANTIGRAVITY_JSON_BODY) because they carry a client-specific
+// SKILLSMITH_CLIENT env var that the other 4 must NOT get.
 const STANDARD_JSON_BODY = `{
   "mcpServers": {
     "@skillsmith/mcp-server": {
@@ -65,8 +68,9 @@ const STANDARD_JSON_BODY = `{
   }
 }`
 
-// SMI-5894 Wave 1 Step 7: Cursor is the one "standard" JSON client that
-// does NOT reuse STANDARD_JSON_BODY — it needs SKILLSMITH_CLIENT in its own
+// SMI-5894 Wave 1 Step 7: Cursor is a "standard" JSON client that does
+// NOT reuse STANDARD_JSON_BODY (AntiGravity is the other one, below) — it
+// needs SKILLSMITH_CLIENT in its own
 // env block so installs route to ~/.cursor/skills instead of the default
 // ~/.claude/skills. withApiKeyJson() below special-cases this body (like
 // the OpenCode branch) to merge SKILLSMITH_API_KEY into the EXISTING env
@@ -85,6 +89,28 @@ const CURSOR_JSON_BODY = `{
       "command": "<paste output of: which skillsmith-mcp (macOS/Linux) or where skillsmith-mcp (Windows)>",
       "env": {
         "SKILLSMITH_CLIENT": "cursor"
+      }
+    }
+  }
+}`
+
+// SMI-6277 Wave 7: AntiGravity is a second "standard" JSON client that does
+// NOT reuse STANDARD_JSON_BODY — it needs SKILLSMITH_CLIENT in its own env
+// block so installs route to ~/.gemini/config/skills instead of the default
+// ~/.claude/skills (mirrors packages/cli/src/templates/mcp-server.template.snippets.ts's
+// antigravity entry; same fix Cursor got in SMI-5894 Wave 1 Step 7). Unlike
+// Cursor, AntiGravity keeps a plain `npx` command — it has no known
+// `npx`-resolution problem. withApiKeyJson() below special-cases this body
+// (like the Cursor branch) to merge SKILLSMITH_API_KEY into the EXISTING env
+// block rather than creating a new one via the generic STANDARD_ARGS_LINE
+// path, which assumes no env block is present yet.
+const ANTIGRAVITY_JSON_BODY = `{
+  "mcpServers": {
+    "@skillsmith/mcp-server": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"],
+      "env": {
+        "SKILLSMITH_CLIENT": "antigravity"
       }
     }
   }
@@ -149,7 +175,7 @@ args = ["-y", "@skillsmith/mcp-server"]`,
     label: 'OpenCode',
     configPath: '~/.config/opencode/opencode.json',
     format: 'json',
-    // OpenCode's entry schema differs from the other 5 JSON clients:
+    // OpenCode's entry schema differs from the other 6 JSON clients:
     // `command` is an array and the env-var field is named `environment`,
     // not `env` (verified opencode.ai/docs/mcp-servers/).
     body: `{
@@ -192,9 +218,9 @@ args = ["-y", "@skillsmith/mcp-server"]`,
     label: 'Google Antigravity',
     configPath: '~/.gemini/config/mcp_config.json',
     format: 'json',
-    body: STANDARD_JSON_BODY,
+    body: ANTIGRAVITY_JSON_BODY,
     notes:
-      'One config file is shared across the Antigravity CLI, IDE, and 2.0. A workspace-scoped alternative also exists at <code>.agents/mcp_config.json</code> (project root) if you prefer not to register the server globally.',
+      'One config file is shared across the Antigravity CLI, IDE, and 2.0. A workspace-scoped alternative also exists at <code>.agents/mcp_config.json</code> (project root) if you prefer not to register the server globally. <code>SKILLSMITH_CLIENT</code> routes installs to <code>~/.gemini/config/skills</code> instead of the default <code>~/.claude/skills</code>.',
   },
 ]
 
@@ -205,11 +231,14 @@ const OPENCODE_ENABLED_LINE = /(\n {6}"enabled": true)\n( {4}\}\n)/
 // "SKILLSMITH_CLIENT" line so SKILLSMITH_API_KEY is merged INTO that block
 // instead of STANDARD_ARGS_LINE trying (and failing) to insert a second one.
 const CURSOR_ENV_LINE = /(\n {8}"SKILLSMITH_CLIENT": "cursor")\n( {6}\}\n)/
+// SMI-6277 Wave 7: same reasoning as CURSOR_ENV_LINE above, for AntiGravity's
+// pre-existing SKILLSMITH_CLIENT env block.
+const ANTIGRAVITY_ENV_LINE = /(\n {8}"SKILLSMITH_CLIENT": "antigravity")\n( {6}\}\n)/
 
 function withApiKeyJson(body: string, id?: McpClientId): string {
   // OpenCode's shape is keyed differently (`mcp` + `environment`, not
   // `mcpServers` + `env`) — special-cased here rather than folded into the
-  // standard branch below, so the 5 standard JSON clients stay simple.
+  // standard branch below, so the 4 standard JSON clients stay simple.
   if (body.includes('"mcp": {')) {
     return body.replace(
       OPENCODE_ENABLED_LINE,
@@ -222,6 +251,14 @@ function withApiKeyJson(body: string, id?: McpClientId): string {
   if (id === 'cursor') {
     return body.replace(
       CURSOR_ENV_LINE,
+      '$1,\n        "SKILLSMITH_API_KEY": "sk_live_your_key_here"\n$2'
+    )
+  }
+  // AntiGravity already has an "env" block (SKILLSMITH_CLIENT) too — same
+  // merge-not-replace reasoning as the cursor branch above.
+  if (id === 'antigravity') {
+    return body.replace(
+      ANTIGRAVITY_ENV_LINE,
       '$1,\n        "SKILLSMITH_API_KEY": "sk_live_your_key_here"\n$2'
     )
   }
@@ -250,8 +287,11 @@ function withApiKeyYaml(body: string): string {
  * instead of hand-authoring a second template string per client. Used by
  * getting-started.astro; quickstart.astro renders `.body` as-is.
  *
- * `id` is optional but should be passed whenever available — it's only used
- * to special-case Windsurf's `${env:VAR}` interpolation example.
+ * `id` is optional but should be passed whenever available — it's needed by
+ * withApiKeyJson() to pick Cursor's and AntiGravity's regex-based env-merge
+ * branches (both bodies already carry a `SKILLSMITH_CLIENT` env block that
+ * must be merged into, not replaced), and is also used to special-case
+ * Windsurf's `${env:VAR}` interpolation example.
  */
 export function withApiKey(
   body: string,


### PR DESCRIPTION
## Business Summary

**What shipped:** An AntiGravity user who copies our MCP setup snippet now gets skills installed to AntiGravity's own directory, not silently redirected to Claude Code's default — the same fix Cursor already got. Config-only change, no command-form switch.

**Quality bar:** Two rounds of GPT-5.6-Sol cross-model review (NEEDLE). Round 1 found stale comment counts and an incomplete doc comment, both fixed. Round 2 caught one more residual stale comment, fixed, then confirmed clean. Build, typecheck, lint, and the extended parity test suite all pass.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

Adds `SKILLSMITH_CLIENT: "antigravity"` to AntiGravity's env block in both the canonical CLI snippet matrix (`mcp-server.template.snippets.ts`) and the website mirror (`mcp-client-snippets.ts`), which must stay in parity per the existing SMI-5554 contract. `command`/`args` stay plain `npx` — unlike Cursor, AntiGravity has no verified `npx`-resolution failure, so it doesn't get Cursor's resolved-binary-path treatment. Extends the existing parity test in place rather than adding a new file. Direct parallel of SMI-5894 Wave 1 Step 7 (the Cursor equivalent).
