### PR TITLE
docs(website): SMI-6266 Wave 11 -- fix stale CLI version string

### DIFF
--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -68,7 +68,7 @@ const howToSchema = {
   <p>Check the CLI is installed correctly:</p>
 
   <pre><code>{`skillsmith --version
-# Output: @skillsmith/cli v1.x.x
+# Output: @skillsmith/cli v0.8.x
 
 skillsmith --help
 # Shows available commands`}</code></pre>


### PR DESCRIPTION
## Business Summary

**What shipped:** A stale docs example is fixed — the Getting Started page's CLI verification step showed a fictional `v1.x.x`; it now shows the real `v0.8.x`.

**Quality bar:** GPT-5.6-Sol cross-model review (NEEDLE) came back clean — no findings. Build passes; no test references the old or new string.

**Found along the way:** the other two items in this wave needed no code. Live `pricing.astro` was already confirmed showing Team Workspaces for Team/Enterprise (deployed in an earlier commit). The currently-published `@skillsmith/cli@0.8.8`/`@skillsmith/core@0.12.1` packages were confirmed to already carry a client-aware footer and a client-neutral update notification — both shipped in earlier waves, just verified against the live/published surface instead of assumed from `main`.

**Net result:** Fully shipped. This closes the last wave of the SMI-6266 epic — all 11 waves now done.

---

## Technical detail

`packages/website/src/pages/docs/getting-started.astro` — one-line change, `# Output: @skillsmith/cli v1.x.x` → `# Output: @skillsmith/cli v0.8.x` (generic patch-version form to avoid re-staling on every release).
