### PR TITLE
fix(scripts): docs/internal ancestry-check engine + pre-push tier fix (SMI-6260 Wave 1)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -135,6 +135,64 @@ if [ $SECURITY_STATUS -ne 0 ]; then
   exit 1
 fi
 
+# =============================================================================
+# SMI-6260 Wave 1: warn-only docs/internal (and other .gitmodules mount)
+# pointer-ancestry check, between Phase 2 and Phase 3. Advisory only — NEVER
+# blocks the push (the hard gate is Wave 2's CI job, not built yet).
+#
+# Cannot reuse DOCS_ONLY/CHANGED_FILES from Phase 2's pre-push-check.sh —
+# it just ran via `bash "$(dirname "$0")/../scripts/pre-push-check.sh"`
+# above, a CHILD PROCESS, so nothing it computed is visible back in this
+# shell. Independently recomputes the changed-file list here, matching
+# scripts/lib/hook-docker-detect.sh's own existing duplication pattern
+# (each caller sources the shared lib and computes its own answer).
+# =============================================================================
+GITMODULES_FILE="$(dirname "$0")/../.gitmodules"
+if [ -f "$GITMODULES_FILE" ]; then
+  if PP_SUB_UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); then
+    PP_SUB_CHANGED=$(git diff --name-only "$PP_SUB_UPSTREAM..HEAD" 2>/dev/null || true)
+  else
+    git fetch origin main --quiet 2>/dev/null || true
+    PP_SUB_CHANGED=$(git diff --name-only origin/main..HEAD 2>/dev/null || true)
+  fi
+
+  # Generic over .gitmodules entries — exact-match discipline mirroring
+  # scripts/ci/classify-changes.ts's getSubmoduleMounts()/isSubmoduleMount()
+  # (never glob-match a mount path; it's data read from .gitmodules, not an
+  # authored pattern).
+  PP_SUB_MOUNTS=$(grep -E '^[[:space:]]*path[[:space:]]*=' "$GITMODULES_FILE" \
+    | sed -E 's/^[[:space:]]*path[[:space:]]*=[[:space:]]*//' \
+    | sed -E 's/^"(.*)"$/\1/')
+
+  PP_SUB_TOUCHED=0
+  if [ -n "$PP_SUB_CHANGED" ] && [ -n "$PP_SUB_MOUNTS" ]; then
+    while IFS= read -r pp_mount; do
+      [ -z "$pp_mount" ] && continue
+      if printf '%s\n' "$PP_SUB_CHANGED" | grep -qxF "$pp_mount"; then
+        PP_SUB_TOUCHED=1
+        break
+      fi
+    done <<PP_SUB_MOUNTS_EOF
+$PP_SUB_MOUNTS
+PP_SUB_MOUNTS_EOF
+  fi
+
+  if [ "$PP_SUB_TOUCHED" = "1" ]; then
+    echo "🔗 Checking submodule pointer ancestry (warn-only)..."
+    POINTER_CHECK_SCRIPT="$(dirname "$0")/../scripts/ci/check-submodule-pointer.sh"
+    if [ -r "$POINTER_CHECK_SCRIPT" ]; then
+      git fetch origin main --quiet 2>/dev/null || true
+      # check-submodule-pointer.sh itself gracefully SKIPs any mount whose
+      # local checkout isn't initialized (never requires a developer to
+      # have docs/internal checked out just to push), and --mode=warn
+      # always exits 0 regardless of what it finds — this call can never
+      # fail the push.
+      bash "$POINTER_CHECK_SCRIPT" --mode=warn --target=origin/main || true
+    fi
+    echo ""
+  fi
+fi
+
 # Phase 3: Format check (SMI-1835 follow-up; SMI-4681 host fallback)
 # Catches Prettier issues before they hit CI - shift left approach
 # SMI-4681: source shared detection so macOS+worktree falls back to host

--- a/scripts/ci/check-submodule-pointer.helpers.sh
+++ b/scripts/ci/check-submodule-pointer.helpers.sh
@@ -198,6 +198,23 @@ evaluate_layer2() {
 
     _CSP_FAIL_RULES=()
     _CSP_FAIL_MSGS=()
+    # SMI-6260 review fix: tracks whether the T-axis already emitted R4's own
+    # "PASS-WARN" verdict line, so the unconditional-PASS fallback below (for
+    # the no-FAIL-rules case) doesn't ALSO print a second, redundant generic
+    # "PASS: ... OK relative to ..." line for the same mount immediately
+    # after it. Confirmed live before this fix: a pure R4 case (S ahead of T
+    # on a live branch, no B-axis R7 match) printed BOTH lines back-to-back —
+    # every rule in the R0-R11 table is defined as exactly one verdict per
+    # mount (see this file's own "print_result — unified output line" and
+    # "Returns 0 (PASS/SKIP) or 1 (FAIL)" contract above), and R4's own
+    # verdict is "PASS + warning annotation", not "PASS + warning annotation,
+    # then also a second unrelated PASS". Must NOT just `return 0`
+    # immediately after printing R4's line — the combined-state (T<S<B) case
+    # requires the B-axis (R7) check below to still run and can still FAIL
+    # even though R4 passed on the T-axis alone (see check-submodule-pointer.test.ts's
+    # "combined state T < S < B" case) — this flag only suppresses the later
+    # redundant PASS print, it does not skip any evaluation.
+    _CSP_R4_WARNED=0
 
     # T-axis: S vs T (R2/R3/R4/R5/R6 — mutually exclusive with each other).
     if [ "$_CSP_S" = "$_CSP_T" ]; then
@@ -210,6 +227,7 @@ evaluate_layer2() {
     elif git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_T" "$_CSP_S" 2>/dev/null; then
         if git -C "$_CSP_DIR" branch -r --contains "$_CSP_S" 2>/dev/null | grep -q .; then
             print_result "PASS-WARN (R4)" "$_CSP_MOUNT" "\`$_CSP_S\` is ahead of \`$_CSP_T\` and lives on a live remote branch (legitimate 'docs PR merged just after' case, SMI-5666)" "$_CSP_BLOCK"
+            _CSP_R4_WARNED=1
         else
             _CSP_FAIL_RULES+=("R5")
             _CSP_FAIL_MSGS+=("R5: orphaned tip: \`$_CSP_S\`'s branch was force-pushed or deleted after this pointer was set; re-bump to a commit on a live branch, or to \`$_CSP_T\`")
@@ -228,7 +246,9 @@ evaluate_layer2() {
     fi
 
     if [ "${#_CSP_FAIL_RULES[@]}" -eq 0 ]; then
-        print_result "PASS" "$_CSP_MOUNT" "\`$_CSP_S\` OK relative to \`$_CSP_T\`" "$_CSP_BLOCK"
+        if [ "$_CSP_R4_WARNED" -ne 1 ]; then
+            print_result "PASS" "$_CSP_MOUNT" "\`$_CSP_S\` OK relative to \`$_CSP_T\`" "$_CSP_BLOCK"
+        fi
         return 0
     fi
 

--- a/scripts/ci/check-submodule-pointer.helpers.sh
+++ b/scripts/ci/check-submodule-pointer.helpers.sh
@@ -1,0 +1,252 @@
+# scripts/ci/check-submodule-pointer.helpers.sh
+# SMI-6260 Wave 1 — rule-evaluation engine for check-submodule-pointer.sh.
+# Split out of that file per CLAUDE.md's 500-line convention. Sourced only,
+# never run standalone. Bash (not POSIX sh) — arrays are used throughout.
+#
+# Implements the R0-R11 + R-FETCH accept/reject rule table from
+# docs/internal/implementation/smi-6260-docs-internal-pointer-regression-gate.md's
+# "Design decisions" section (binding, reviewed twice). Definitions:
+#   M = a gitlink mount path from .gitmodules
+#   S = the gitlink SHA in the ref under test (--ref)
+#   T = tip of M's configured upstream branch (branch= in .gitmodules), in
+#       its own remote, after a full fetch of all refs
+#   B = the gitlink SHA at the diff-base ref (--before if given, else
+#       --target) — "the pointer already registered" on the target/base ref
+#
+# Two-layer evaluation model (binding, see plan doc):
+#   Layer 1 (preconditions) — R-FETCH, R1 (S exists), R10/R11 (B absent vs.
+#     unresolvable). A Layer-1 failure short-circuits Layer 2 entirely: no
+#     R2-R7 comparison is attempted (merge-base --is-ancestor against a
+#     nonexistent/unresolvable SHA is not a well-formed call).
+#   Layer 2 (comparisons) — R2-R7, independently evaluated and AND-combined
+#     (not first-match): the overall per-mount verdict is FAIL if ANY
+#     applicable FAIL-yielding rule matches, even when a PASS-yielding rule
+#     (R2/R4) also matches on its own axis (the T<S<B combined-state case).
+#     Primary-message priority when multiple FAILs match:
+#     R1 > R8 > R11 > R7 > R5 > R6 > R3.
+
+# Parse every `path = ...` value out of a .gitmodules file, regardless of
+# which [submodule "..."] section it sits in — mirrors
+# scripts/ci/classify-changes.ts's getSubmoduleMounts() (a plain per-line
+# regex over the whole file, not a per-section parse).
+parse_gitmodules_mounts() {
+    awk '
+        /^[ \t]*path[ \t]*=/ {
+            v = $0
+            sub(/^[ \t]*path[ \t]*=[ \t]*/, "", v)
+            gsub(/^"|"$/, "", v)
+            if (length(v) > 0) print v
+        }
+    ' "$1"
+}
+
+# Read one INI-style key for the [submodule "..."] section whose `path`
+# value exactly equals $2 (e.g. get_mount_field .gitmodules docs/internal
+# branch). Exact string match on path, never a glob — mirrors
+# scripts/ci/classify-changes.ts's isSubmoduleMount() doc comment: a mount
+# path is data read from .gitmodules, not an authored pattern.
+get_mount_field() {
+    awk -v target="$2" -v want="$3" '
+        function flush() { if (vals["path"] == target && (want in vals)) print vals[want] }
+        /^\[submodule/ { flush(); delete vals; next }
+        /^[ \t]*[A-Za-z_][A-Za-z0-9_]*[ \t]*=/ {
+            key = $0
+            sub(/[ \t]*=.*/, "", key)
+            gsub(/^[ \t]+|[ \t]+$/, "", key)
+            v = $0
+            sub(/^[^=]*=[ \t]*/, "", v)
+            gsub(/^"|"$/, "", v)
+            vals[key] = v
+            next
+        }
+        END { flush() }
+    ' "$1"
+}
+
+# Friendly "org/repo:branch" slug for a mount's R3 message, derived from its
+# configured url + branch. Falls back to the mount path itself if the url
+# can't be parsed into a slug (e.g. a non-GitHub URL).
+repo_slug() {
+    _CSP_URL="$(get_mount_field "$1" "$2" url)"
+    _CSP_BRANCH="$(get_mount_field "$1" "$2" branch)"
+    [ -z "$_CSP_BRANCH" ] && _CSP_BRANCH="main"
+    _CSP_SLUG="$(printf '%s' "$_CSP_URL" | sed -E 's#^[a-zA-Z]+://[^/]+/##; s#^[^:]+:##; s#\.git$##')"
+    [ -z "$_CSP_SLUG" ] && _CSP_SLUG="$2"
+    printf '%s:%s' "$_CSP_SLUG" "$_CSP_BRANCH"
+}
+
+# print_result — unified output line. severity: PASS|PASS-WARN|SKIP|FAIL.
+# is_blocking (0/1) downgrades a FAIL's displayed severity to WARN (mount
+# not in BLOCKING_MOUNTS) without changing the caller's exit-code decision,
+# which is made separately in check-submodule-pointer.sh's main loop.
+print_result() {
+    _CSP_SEV="$1" _CSP_MOUNT="$2" _CSP_LINE="$3" _CSP_BLOCKING="$4"
+    if [ "$_CSP_SEV" = "FAIL" ] && [ "$_CSP_BLOCKING" != "1" ]; then
+        _CSP_SEV="WARN (non-blocking mount)"
+    fi
+    printf '%s [%s]: %s\n' "$_CSP_SEV" "$_CSP_MOUNT" "$_CSP_LINE"
+}
+
+# evaluate_mount repo_root mount ref diff_base changed_files mode
+#                pat_available is_blocking
+# Returns 0 (PASS/SKIP) or 1 (FAIL) — the caller decides whether a FAIL on
+# this mount affects the process exit code (BLOCKING_MOUNTS x --mode=block).
+evaluate_mount() {
+    _CSP_ROOT="$1" _CSP_MOUNT="$2" _CSP_REF="$3" _CSP_BASE="$4"
+    _CSP_CHANGED="$5" _CSP_MODE="$6" _CSP_PAT="$7" _CSP_BLOCK="$8"
+
+    _CSP_TOUCHED=0
+    if printf '%s\n' "$_CSP_CHANGED" | grep -qxF "$_CSP_MOUNT"; then
+        _CSP_TOUCHED=1
+    fi
+
+    if [ "$_CSP_TOUCHED" -eq 0 ]; then
+        if [ "$_CSP_PAT" = "false" ]; then
+            print_result "SKIP-PASS (R9)" "$_CSP_MOUNT" "PAT unavailable, but diff does not touch this mount — nothing to check" "$_CSP_BLOCK"
+        else
+            print_result "SKIP-PASS (R0)" "$_CSP_MOUNT" "diff does not touch this mount" "$_CSP_BLOCK"
+        fi
+        return 0
+    fi
+
+    if [ "$_CSP_PAT" = "false" ]; then
+        print_result "FAIL" "$_CSP_MOUNT" "R8: external contributors cannot bump \`$_CSP_MOUNT\`; ask a maintainer to push this pointer bump on your behalf" "$_CSP_BLOCK"
+        return 1
+    fi
+
+    _CSP_S="$(git -C "$_CSP_ROOT" ls-tree "$_CSP_REF" -- "$_CSP_MOUNT" 2>/dev/null | awk '{print $3}')"
+    _CSP_B="$(git -C "$_CSP_ROOT" ls-tree "$_CSP_BASE" -- "$_CSP_MOUNT" 2>/dev/null | awk '{print $3}')"
+
+    if [ -z "$_CSP_S" ]; then
+        print_result "SKIP-PASS" "$_CSP_MOUNT" "no gitlink entry at --ref (path removed, or never a submodule at this ref) — nothing to check" "$_CSP_BLOCK"
+        return 0
+    fi
+
+    # Not-initialized check: test for a LITERAL .git entry directly under the
+    # mount directory (file or dir — a submodule's own .git is a file
+    # pointing at ../../.git/modules/<path> since git 1.7.8+). Deliberately
+    # NOT `git -C "$_CSP_DIR" rev-parse --git-dir`: for an uninitialized
+    # mount (an empty directory with no .git of its own), git's repo
+    # discovery walks UP the directory tree and silently finds the PARENT
+    # repo's own .git instead of failing — that would make this check
+    # always report "initialized" even when the submodule plainly isn't.
+    _CSP_DIR="$_CSP_ROOT/$_CSP_MOUNT"
+    if [ ! -e "$_CSP_DIR/.git" ]; then
+        print_result "SKIP" "$_CSP_MOUNT" "local submodule checkout not initialized — cannot verify ancestry locally (CI initializes this before running; a developer pushing without the submodule checked out is never blocked)" "$_CSP_BLOCK"
+        return 0
+    fi
+
+    _CSP_BRANCH="$(get_mount_field "$_CSP_ROOT/.gitmodules" "$_CSP_MOUNT" branch)"
+    [ -z "$_CSP_BRANCH" ] && _CSP_BRANCH="main"
+
+    _CSP_ATTEMPTS=1
+    [ "$_CSP_MODE" = "block" ] && _CSP_ATTEMPTS=2
+    _CSP_FETCH_OK=0
+    _CSP_I=0
+    while [ "$_CSP_I" -lt "$_CSP_ATTEMPTS" ]; do
+        if git -C "$_CSP_DIR" fetch origin --prune --quiet 2>/dev/null; then
+            _CSP_FETCH_OK=1
+            break
+        fi
+        _CSP_I=$((_CSP_I + 1))
+    done
+
+    if [ "$_CSP_FETCH_OK" -ne 1 ]; then
+        print_result "FAIL" "$_CSP_MOUNT" "R-FETCH: infra: fetch failed, not a content problem — re-run the check" "$_CSP_BLOCK"
+        return 1
+    fi
+
+    _CSP_T="$(git -C "$_CSP_DIR" rev-parse -q --verify "refs/remotes/origin/$_CSP_BRANCH" 2>/dev/null)"
+    if [ -z "$_CSP_T" ]; then
+        print_result "FAIL" "$_CSP_MOUNT" "R-FETCH: infra: fetch failed, not a content problem — re-run the check" "$_CSP_BLOCK"
+        return 1
+    fi
+
+    # --- Layer 1 preconditions: R1 (S exists), R10/R11 (B) ---
+    if ! git -C "$_CSP_DIR" cat-file -e "${_CSP_S}^{commit}" 2>/dev/null; then
+        print_result "FAIL" "$_CSP_MOUNT" "R1: \`$_CSP_S\` was never pushed, or its branch was deleted; push a valid commit at that SHA (or a valid replacement) and re-bump" "$_CSP_BLOCK"
+        return 1
+    fi
+
+    _CSP_B_AVAILABLE=0
+    _CSP_B_RESOLVABLE=0
+    if [ -n "$_CSP_B" ]; then
+        _CSP_B_AVAILABLE=1
+        if git -C "$_CSP_DIR" cat-file -e "${_CSP_B}^{commit}" 2>/dev/null; then
+            _CSP_B_RESOLVABLE=1
+        fi
+    fi
+
+    if [ "$_CSP_B_AVAILABLE" -eq 1 ] && [ "$_CSP_B_RESOLVABLE" -eq 0 ]; then
+        print_result "FAIL" "$_CSP_MOUNT" "R11: \`$_CSP_REF\`'s already-registered pointer \`$_CSP_B\` for \`$_CSP_MOUNT\` cannot be resolved — this predates this PR/push and was not caused by it (see the \`git update-index --cacheinfo\` hazard in 'What exists today'); a maintainer must repair \`$_CSP_REF\`'s pointer directly (see the \`docs-internal-pointer-repair\` runbook note in ADR-143) before R7 can validate new bumps against it" "$_CSP_BLOCK"
+        return 1
+    fi
+
+    evaluate_layer2 "$_CSP_ROOT" "$_CSP_MOUNT" "$_CSP_REF" "$_CSP_DIR" "$_CSP_BRANCH" \
+        "$_CSP_S" "$_CSP_T" "$_CSP_B" "$_CSP_B_AVAILABLE" "$_CSP_BLOCK"
+}
+
+# evaluate_layer2 — R2-R7, independently AND-combined. Split out of
+# evaluate_mount() for the 500-line cap; still logically "the rest of
+# evaluate_mount" (same _CSP_* naming convention, called with a fully
+# resolved S/T/B triple that has already cleared every Layer-1
+# precondition).
+evaluate_layer2() {
+    _CSP_ROOT="$1" _CSP_MOUNT="$2" _CSP_REF="$3" _CSP_DIR="$4" _CSP_BRANCH="$5"
+    _CSP_S="$6" _CSP_T="$7" _CSP_B="$8" _CSP_B_AVAILABLE="$9"
+    _CSP_BLOCK="${10}"
+
+    _CSP_FAIL_RULES=()
+    _CSP_FAIL_MSGS=()
+
+    # T-axis: S vs T (R2/R3/R4/R5/R6 — mutually exclusive with each other).
+    if [ "$_CSP_S" = "$_CSP_T" ]; then
+        : # R2 PASS
+    elif git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_S" "$_CSP_T" 2>/dev/null; then
+        _CSP_BEHIND="$(git -C "$_CSP_DIR" rev-list --count "${_CSP_S}..${_CSP_T}" 2>/dev/null || echo '?')"
+        _CSP_SLUG="$(repo_slug "$_CSP_ROOT/.gitmodules" "$_CSP_MOUNT")"
+        _CSP_FAIL_RULES+=("R3")
+        _CSP_FAIL_MSGS+=("R3: stale: behind \`$_CSP_SLUG\` by $_CSP_BEHIND commits; re-bump with \`scripts/bump-docs-pointer.sh\`")
+    elif git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_T" "$_CSP_S" 2>/dev/null; then
+        if git -C "$_CSP_DIR" branch -r --contains "$_CSP_S" 2>/dev/null | grep -q .; then
+            print_result "PASS-WARN (R4)" "$_CSP_MOUNT" "\`$_CSP_S\` is ahead of \`$_CSP_T\` and lives on a live remote branch (legitimate 'docs PR merged just after' case, SMI-5666)" "$_CSP_BLOCK"
+        else
+            _CSP_FAIL_RULES+=("R5")
+            _CSP_FAIL_MSGS+=("R5: orphaned tip: \`$_CSP_S\`'s branch was force-pushed or deleted after this pointer was set; re-bump to a commit on a live branch, or to \`$_CSP_T\`")
+        fi
+    else
+        _CSP_FAIL_RULES+=("R6")
+        _CSP_FAIL_MSGS+=("R6: diverged: rebase \`$_CSP_MOUNT\` onto \`origin/$_CSP_BRANCH\` and re-bump with \`scripts/bump-docs-pointer.sh\`")
+    fi
+
+    # B-axis: S vs B (R7) — only when B is available (R10: absent => skip
+    # this axis, not the whole mount; T-axis above still stands).
+    if [ "$_CSP_B_AVAILABLE" -eq 1 ] && [ "$_CSP_S" != "$_CSP_B" ] \
+        && git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_S" "$_CSP_B" 2>/dev/null; then
+        _CSP_FAIL_RULES+=("R7")
+        _CSP_FAIL_MSGS+=("R7: backward regression: this pointer already registers \`$_CSP_B\` on \`$_CSP_REF\`, which is ahead of the proposed \`$_CSP_S\`; re-bump to \`$_CSP_B\` or a descendant of it, never to an ancestor")
+    fi
+
+    if [ "${#_CSP_FAIL_RULES[@]}" -eq 0 ]; then
+        print_result "PASS" "$_CSP_MOUNT" "\`$_CSP_S\` OK relative to \`$_CSP_T\`" "$_CSP_BLOCK"
+        return 0
+    fi
+
+    _CSP_PRIMARY=""
+    for _CSP_WANT in R7 R5 R6 R3; do
+        for _CSP_J in "${!_CSP_FAIL_RULES[@]}"; do
+            if [ "${_CSP_FAIL_RULES[$_CSP_J]}" = "$_CSP_WANT" ]; then
+                _CSP_PRIMARY="${_CSP_FAIL_MSGS[$_CSP_J]}"
+                break 2
+            fi
+        done
+    done
+
+    print_result "FAIL" "$_CSP_MOUNT" "$_CSP_PRIMARY" "$_CSP_BLOCK"
+    for _CSP_J in "${!_CSP_FAIL_MSGS[@]}"; do
+        if [ "${_CSP_FAIL_MSGS[$_CSP_J]}" != "$_CSP_PRIMARY" ]; then
+            printf '  (also matched: %s)\n' "${_CSP_FAIL_MSGS[$_CSP_J]}"
+        fi
+    done
+    return 1
+}

--- a/scripts/ci/check-submodule-pointer.sh
+++ b/scripts/ci/check-submodule-pointer.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# scripts/ci/check-submodule-pointer.sh
+# SMI-6260 Wave 1 — docs/internal (and other .gitmodules mount) gitlink
+# ancestry gate. Full design:
+# docs/internal/implementation/smi-6260-docs-internal-pointer-regression-gate.md
+# ("Design decisions" section — binding, reviewed twice).
+#
+# Closes the PR #2609 failure mode: a submodule pointer bump that LOOKS like
+# a clean forward move (git diff/git status show a normal single-line SHA
+# change) but is actually a regression relative to the submodule's own
+# upstream history, or relative to what the target ref already registers.
+#
+# Usage:
+#   check-submodule-pointer.sh --mode=<block|warn> [--ref=<ref>]
+#     [--target=<ref>] [--before=<sha>] [--pat-available=<true|false>]
+#
+#   --mode=block   CI (pointer-check / pointer-autorepair). Exits non-zero
+#                  if any BLOCKING_MOUNTS entry FAILs. Retries a failed
+#                  fetch once before reporting R-FETCH.
+#   --mode=warn    Pre-push (.husky/pre-push). Always exits 0 — advisory
+#                  only; the hard gate is Wave 2's CI job. No fetch retry
+#                  (a local failure is cheap to re-run manually).
+#   --ref          The ref under test — source of S. Default: HEAD.
+#   --target       The diff-base / "already registered" ref — source of B,
+#                  and (with --before absent) the R0 diff base too.
+#                  Default: origin/main.
+#   --before       Overrides --target as B's source ref (post-merge
+#                  B_prev reconstruction from `github.event.before`; Wave 2
+#                  uses this — Wave 1 accepts and honors the flag without a
+#                  caller that passes it yet).
+#   --pat-available  Whether a credential is available to fetch a private
+#                  mount's remote (R8/R9). Default: true (a local
+#                  --mode=warn run uses the developer's own git
+#                  credentials, not a CI-issued PAT).
+#
+# Generic over every .gitmodules entry (parse_gitmodules_mounts /
+# get_mount_field in check-submodule-pointer.helpers.sh mirror
+# scripts/ci/classify-changes.ts's getSubmoduleMounts()/isSubmoduleMount()
+# exact-match discipline — never glob-match a mount path). Blocking
+# behavior is gated per-mount by BLOCKING_MOUNTS below: only docs/internal
+# is blocking in v1 (per the plan's "Scope boundary" design decision); the
+# three skillsmith-strategy mounts are warn-only even under --mode=block.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=check-submodule-pointer.helpers.sh
+source "$SCRIPT_DIR/check-submodule-pointer.helpers.sh"
+
+# v1 blocking allowlist (plan's "Scope boundary" design decision). The three
+# skillsmith-strategy mounts (.claude/skills, .claude/plans,
+# .claude/hive-mind) run warn-only even under --mode=block.
+BLOCKING_MOUNTS=("docs/internal")
+
+MODE=""
+REF="HEAD"
+TARGET="origin/main"
+BEFORE=""
+PAT_AVAILABLE="true"
+
+for arg in "$@"; do
+    case "$arg" in
+        --mode=*) MODE="${arg#*=}" ;;
+        --ref=*) REF="${arg#*=}" ;;
+        --target=*) TARGET="${arg#*=}" ;;
+        --before=*) BEFORE="${arg#*=}" ;;
+        --pat-available=*) PAT_AVAILABLE="${arg#*=}" ;;
+        *)
+            echo "check-submodule-pointer.sh: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ "$MODE" != "block" ] && [ "$MODE" != "warn" ]; then
+    echo "Usage: $0 --mode=<block|warn> [--ref=<ref>] [--target=<ref>] [--before=<sha>] [--pat-available=<true|false>]" >&2
+    exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+    echo "check-submodule-pointer.sh: not inside a git repository" >&2
+    exit 2
+fi
+
+GITMODULES="$REPO_ROOT/.gitmodules"
+if [ ! -f "$GITMODULES" ]; then
+    echo "check-submodule-pointer.sh: no .gitmodules found — nothing to check."
+    exit 0
+fi
+
+DIFF_BASE="${BEFORE:-$TARGET}"
+
+if ! git -C "$REPO_ROOT" rev-parse --verify -q "${REF}^{commit}" >/dev/null 2>&1; then
+    echo "check-submodule-pointer.sh: --ref='$REF' does not resolve to a commit in this repo" >&2
+    exit 2
+fi
+if ! git -C "$REPO_ROOT" rev-parse --verify -q "${DIFF_BASE}^{commit}" >/dev/null 2>&1; then
+    echo "check-submodule-pointer.sh: diff-base '$DIFF_BASE' (--before or --target) does not resolve to a commit in this repo" >&2
+    exit 2
+fi
+
+CHANGED_FILES="$(git -C "$REPO_ROOT" diff --name-only "$DIFF_BASE" "$REF" 2>/dev/null || true)"
+MOUNTS="$(parse_gitmodules_mounts "$GITMODULES")"
+
+if [ -z "$MOUNTS" ]; then
+    echo "check-submodule-pointer.sh: no submodule mounts declared in .gitmodules"
+    exit 0
+fi
+
+is_blocking_mount() {
+    for _CSP_BM in "${BLOCKING_MOUNTS[@]}"; do
+        [ "$_CSP_BM" = "$1" ] && return 0
+    done
+    return 1
+}
+
+ANY_BLOCKING_FAIL=0
+
+while IFS= read -r MOUNT; do
+    [ -z "$MOUNT" ] && continue
+    BLOCKING=0
+    is_blocking_mount "$MOUNT" && BLOCKING=1
+
+    evaluate_mount "$REPO_ROOT" "$MOUNT" "$REF" "$DIFF_BASE" "$CHANGED_FILES" "$MODE" "$PAT_AVAILABLE" "$BLOCKING"
+    MOUNT_STATUS=$?
+
+    if [ "$MOUNT_STATUS" -ne 0 ] && [ "$BLOCKING" -eq 1 ] && [ "$MODE" = "block" ]; then
+        ANY_BLOCKING_FAIL=1
+    fi
+done <<EOF
+$MOUNTS
+EOF
+
+if [ "$MODE" = "warn" ]; then
+    exit 0
+fi
+
+if [ "$ANY_BLOCKING_FAIL" -eq 1 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/lib/docs-only-patterns.sh
+++ b/scripts/lib/docs-only-patterns.sh
@@ -1,0 +1,82 @@
+# scripts/lib/docs-only-patterns.sh
+# SMI-6260 Wave 1 — canonical docs-only file classification.
+#
+# Extracted from scripts/pre-push-check.sh's inline SAFE_REGEX (and the
+# duplicated _HOOK_SAFE_REGEX copy in scripts/lib/hook-docker-detect.sh) so
+# both existing bash callers, plus a new third caller
+# (scripts/pre-push-coverage-check.sh) and .husky/pre-push's own
+# submodule-pointer wiring, share one tightened definition instead of
+# drifting independently.
+#
+# Sourced by:
+#   scripts/pre-push-check.sh
+#   scripts/lib/hook-docker-detect.sh (indirectly, via the caller-provided
+#     DETECT_LIB/HOOK_DETECT_LIB path — see that file's own sourcing block)
+#   scripts/pre-push-coverage-check.sh
+#   .husky/pre-push (submodule-pointer step)
+#
+# POSIX sh — no `local`, no `[[ ]]`, no bash arrays. This file is sourced
+# from both bash scripts (pre-push-check.sh, pre-push-coverage-check.sh) and
+# POSIX-sh contexts (hook-docker-detect.sh, .husky/pre-push itself, which
+# husky's own launcher runs via `sh -e`, not bash — see
+# .husky/_/h). Every caller-visible name is prefixed to avoid clobbering the
+# sourcing script's own variables.
+#
+# CONTRACT:
+#   DOCS_ONLY_SAFE_REGEX / DOCS_ONLY_UNSAFE_OVERRIDE — the two grep -E
+#     patterns, exposed for callers that want to inspect them directly.
+#   is_docs_only() — reads a newline-separated file list on stdin, returns
+#     0 (true, docs-only) or 1 (false, not docs-only or nothing to check).
+#     Empty stdin returns 1 (matches the pre-SMI-6260 callers' own default:
+#     "no changed files" never set DOCS_ONLY=1 — a diff that resolves to
+#     nothing to compare is treated conservatively as "run the full checks",
+#     never as an implicit skip).
+#
+# SAFE_REGEX matches files that cannot introduce production deps or
+# activate a gated test:
+#   - docs/**, **/*.md (including a submodule pointer bump under docs/, and
+#     a bare .gitmodules bump for docs/internal or a strategy mount)
+#   - .claude/development/**, .claude/templates/**
+#   - LICENSE, .github/ISSUE_TEMPLATE/**, .github/CODEOWNERS, PR template
+#   - .gitmodules (submodule pointer bumps only)
+#
+# UNSAFE_OVERRIDE vetoes an otherwise-safe match. POSIX ERE (grep -E — the
+# only flavor every caller here uses) has no negative lookahead, so
+# "*.md, but not under packages/**" cannot be expressed in one pattern.
+# Two passes instead: a positive SAFE_REGEX match, then a negative
+# UNSAFE_OVERRIDE veto — both remain portable POSIX ERE. Never reach for
+# `grep -P` as a shortcut: macOS's stock /usr/bin/grep (this repo's
+# documented host platform) doesn't support -P at all, and that would
+# silently break every host run.
+#   - packages/**/*.md — SMI-4961 hazard: a new .md at an
+#     existsSync/skipIf-gated fixture path would otherwise be misclassified
+#     as docs-only and skip the very tests it activates.
+#   - **/tests/**, **/fixtures/** — same hazard class, non-.md fixture
+#     files (e.g. a new JSON/YAML fixture under a gated tests/ directory).
+#
+# Drift note (inherited from the pre-SMI-6260 SAFE_REGEX comment): CI
+# mirrors similar logic in scripts/ci/classify-changes.ts. Kept in bash here
+# (no tsx dependency for git hooks). Worst case of drift is a false-positive
+# full run on a docs-only push (safe; never a false-negative skip).
+
+DOCS_ONLY_SAFE_REGEX='^(docs/|\.claude/development/|\.claude/templates/|\.github/(ISSUE_TEMPLATE/|CODEOWNERS|PULL_REQUEST_TEMPLATE\.md)|LICENSE$|.*\.md$|\.gitmodules$)'
+DOCS_ONLY_UNSAFE_OVERRIDE='packages/.*\.md$|.*/tests/.*|.*/fixtures/.*'
+
+is_docs_only() {
+    _DOP_FILES="$(cat)"
+    if [ -z "$_DOP_FILES" ]; then
+        return 1
+    fi
+
+    _DOP_UNSAFE=$(printf '%s\n' "$_DOP_FILES" | grep -vE "$DOCS_ONLY_SAFE_REGEX" || true)
+    if [ -n "$_DOP_UNSAFE" ]; then
+        return 1
+    fi
+
+    _DOP_OVERRIDDEN=$(printf '%s\n' "$_DOP_FILES" | grep -E "$DOCS_ONLY_UNSAFE_OVERRIDE" || true)
+    if [ -n "$_DOP_OVERRIDDEN" ]; then
+        return 1
+    fi
+
+    return 0
+}

--- a/scripts/lib/hook-docker-detect.sh
+++ b/scripts/lib/hook-docker-detect.sh
@@ -241,21 +241,39 @@ if [ "$IS_WORKTREE" = "1" ] && command -v docker >/dev/null 2>&1 && [ "$DOCKER_A
         NEEDS_FALLBACK=1
         printf "${HOOK_DETECT_YELLOW}📂 SKILLSMITH_PRE_PUSH_HOST=1 — falling back to host execution${HOOK_DETECT_NC}\n"
     else
-        # SMI-4249-style docs-only classification (mirrored from
-        # scripts/pre-push-check.sh; duplication accepted per that file's
-        # own drift note — worst case is a false-positive hard-fail on an
-        # edge-case path, never a false-negative skip of the guard).
+        # SMI-6260: docs-only classification now sourced from the shared lib
+        # (scripts/lib/docs-only-patterns.sh) instead of this file's own
+        # inline duplicate regex, which had drifted from
+        # scripts/pre-push-check.sh's now-tightened version (missing the
+        # packages/**/*.md + **/tests/** + **/fixtures/** exclusions,
+        # SMI-4961 hazard). This file doesn't reliably self-locate its own
+        # path when sourced (BASH_SOURCE is bash-only and this file is also
+        # sourced under POSIX sh — see .husky/_/h's `sh -e` launcher — and
+        # callers use two different variable names for the path they
+        # resolved to THIS file: HOOK_DETECT_LIB or DETECT_LIB, per this
+        # file's own header comment's caller list) — so reuse whichever of
+        # those the caller already set to derive the sibling lib's path
+        # instead. Missing lib (or neither var set) fails safe: never
+        # docs-only, same as the pre-SMI-6260 "no changed files" default —
+        # worst case is a false-positive hard-fail on an edge-case path,
+        # never a false-negative skip of the guard.
         _HOOK_DOCS_ONLY=0
-        _HOOK_SAFE_REGEX='^(docs/|\.claude/development/|\.claude/templates/|\.github/(ISSUE_TEMPLATE/|CODEOWNERS|PULL_REQUEST_TEMPLATE\.md)|LICENSE$|.*\.md$|\.gitmodules$)'
+        _HOOK_DOP_BASE="${DETECT_LIB:-${HOOK_DETECT_LIB:-}}"
+        if [ -n "$_HOOK_DOP_BASE" ]; then
+            _HOOK_DOP_LIB="$(dirname "$_HOOK_DOP_BASE")/docs-only-patterns.sh"
+            if [ -r "$_HOOK_DOP_LIB" ]; then
+                # shellcheck source=./docs-only-patterns.sh
+                . "$_HOOK_DOP_LIB"
+            fi
+        fi
         if _HOOK_UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); then
             _HOOK_CHANGED_FILES=$(git diff --name-only "$_HOOK_UPSTREAM..HEAD" 2>/dev/null || true)
         else
             git fetch origin main --quiet 2>/dev/null || true
             _HOOK_CHANGED_FILES=$(git diff --name-only origin/main..HEAD 2>/dev/null || true)
         fi
-        if [ -n "$_HOOK_CHANGED_FILES" ]; then
-            _HOOK_UNSAFE=$(printf '%s\n' "$_HOOK_CHANGED_FILES" | grep -vE "$_HOOK_SAFE_REGEX" || true)
-            if [ -z "$_HOOK_UNSAFE" ]; then
+        if command -v is_docs_only >/dev/null 2>&1; then
+            if printf '%s\n' "$_HOOK_CHANGED_FILES" | is_docs_only; then
                 _HOOK_DOCS_ONLY=1
             fi
         fi

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -87,21 +87,20 @@ echo ""
 # =============================================================================
 # SMI-4249: Detect docs-only / submodule-pointer pushes
 # Skip npm audit (CHECK 2) when no file in the push could introduce a
-# production dependency. CHECKS 1 (security tests) and 3 (hardcoded secrets)
-# remain unconditional.
+# production dependency. SMI-6260: CHECK 1 (security tests) is now also
+# skipped for a docs-only push (see below); CHECK 3 (hardcoded secrets)
+# remains unconditional.
 #
-# SAFE_REGEX matches files that cannot introduce production deps:
-#   - docs/**, **/*.md (including submodule pointer to docs/internal)
-#   - .claude/development/**, .claude/templates/**
-#   - LICENSE, .github/ISSUE_TEMPLATE/**, .github/CODEOWNERS, PR template
-#   - .gitmodules (submodule pointer bumps only)
-#
-# Drift note: CI mirrors similar logic in scripts/ci/classify-changes.ts.
-# Keeping in bash (no tsx dep). Worst case of drift is false-positive audit
-# run on a docs-only push (safe; never a false-negative skip).
+# SMI-6260: SAFE_REGEX + the classification function now live in
+# scripts/lib/docs-only-patterns.sh, shared with
+# scripts/lib/hook-docker-detect.sh and scripts/pre-push-coverage-check.sh —
+# see that file for the pattern definitions and drift note.
 # =============================================================================
-DOCS_ONLY=0
-SAFE_REGEX='^(docs/|\.claude/development/|\.claude/templates/|\.github/(ISSUE_TEMPLATE/|CODEOWNERS|PULL_REQUEST_TEMPLATE\.md)|LICENSE$|.*\.md$|\.gitmodules$)'
+DOCS_ONLY_LIB="$(dirname "$0")/lib/docs-only-patterns.sh"
+if [ -r "$DOCS_ONLY_LIB" ]; then
+  # shellcheck source=lib/docs-only-patterns.sh
+  . "$DOCS_ONLY_LIB"
+fi
 
 if UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); then
   CHANGED_FILES=$(git diff --name-only "$UPSTREAM..HEAD" 2>/dev/null || true)
@@ -111,11 +110,13 @@ else
   CHANGED_FILES=$(git diff --name-only origin/main..HEAD 2>/dev/null || true)
 fi
 
-if [ -n "$CHANGED_FILES" ]; then
-  UNSAFE=$(printf '%s\n' "$CHANGED_FILES" | grep -vE "$SAFE_REGEX" || true)
-  if [ -z "$UNSAFE" ]; then
+DOCS_ONLY=0
+if command -v is_docs_only >/dev/null 2>&1; then
+  if printf '%s\n' "$CHANGED_FILES" | is_docs_only; then
     DOCS_ONLY=1
   fi
+else
+  echo -e "${YELLOW}⚠️  scripts/lib/docs-only-patterns.sh missing — treating push as full (non-docs-only)${NC}"
 fi
 
 # =============================================================================
@@ -127,28 +128,38 @@ fi
 # node_modules. Mirroring the SMI-4772 fix in pre-push-coverage-check.sh:
 # invoke vitest binary directly. In Docker, pin to /app/node_modules (always
 # absolute). On host, ./node_modules works (host resolves symlinks fine).
+#
+# SMI-6260: skipped entirely for a docs-only push — none of the docs-only
+# paths (per DOCS_ONLY above) are inputs to packages/core/tests/security/,
+# and full CI still runs the suite on the PR regardless, so this isn't the
+# last line of defense. Override with SKILLSMITH_PRE_PUSH_FORCE_FULL=1.
 # =============================================================================
 echo "📋 Running security test suite..."
 
-# Run tests once, capture both output and exit code
-if [ "$USE_DOCKER" = "1" ]; then
-  TEST_OUTPUT=$(docker exec -w "$CONTAINER_WD" "$DOCKER_CONTAINER" /app/node_modules/.bin/vitest run packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
+if [ $DOCS_ONLY -eq 1 ] && [ "${SKILLSMITH_PRE_PUSH_FORCE_FULL:-0}" != "1" ]; then
+  echo -e "${BLUE}ℹ️  Skipping security test suite — docs-only push (override: SKILLSMITH_PRE_PUSH_FORCE_FULL=1)${NC}"
+  echo ""
 else
-  TEST_OUTPUT=$(run_cmd ./node_modules/.bin/vitest run packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
-fi
-TEST_STATUS=${TEST_STATUS:-0}
+  # Run tests once, capture both output and exit code
+  if [ "$USE_DOCKER" = "1" ]; then
+    TEST_OUTPUT=$(docker exec -w "$CONTAINER_WD" "$DOCKER_CONTAINER" /app/node_modules/.bin/vitest run packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
+  else
+    TEST_OUTPUT=$(run_cmd ./node_modules/.bin/vitest run packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
+  fi
+  TEST_STATUS=${TEST_STATUS:-0}
 
-# Display relevant output (filter for test results)
-echo "$TEST_OUTPUT" | grep -E "(PASS|FAIL|✓|✗|Error|test)" || true
+  # Display relevant output (filter for test results)
+  echo "$TEST_OUTPUT" | grep -E "(PASS|FAIL|✓|✗|Error|test)" || true
 
-# Check status based on exit code (more reliable than parsing output)
-if [ $TEST_STATUS -ne 0 ]; then
-  echo -e "${RED}✗ Security tests failed${NC}"
-  CHECKS_FAILED=1
-else
-  echo -e "${GREEN}✓ Security tests passed${NC}"
+  # Check status based on exit code (more reliable than parsing output)
+  if [ $TEST_STATUS -ne 0 ]; then
+    echo -e "${RED}✗ Security tests failed${NC}"
+    CHECKS_FAILED=1
+  else
+    echo -e "${GREEN}✓ Security tests passed${NC}"
+  fi
+  echo ""
 fi
-echo ""
 
 # =============================================================================
 # CHECK 2: npm audit (Optimized - single run)

--- a/scripts/pre-push-coverage-check.sh
+++ b/scripts/pre-push-coverage-check.sh
@@ -83,7 +83,45 @@ run_suite() {
   ' _ "$1"
 }
 
+# =============================================================================
+# SMI-6260: docs-only classification — independent computation. This script
+# runs as a separate `bash` child process of .husky/pre-push's Phase 4
+# (invoked via `bash "$COVERAGE_SCRIPT"`, possibly wrapped in `timeout`), so
+# it cannot inherit DOCS_ONLY/CHANGED_FILES computed by Phase 2's
+# pre-push-check.sh — that's a SEPARATE child process too, and nothing it
+# computes is visible here. Each caller of the shared lib sources it and
+# computes its own answer, matching hook-docker-detect.sh's existing
+# duplication pattern. Skips the entire per-package + root coverage loop
+# below when docs-only; override with SKILLSMITH_PRE_PUSH_FORCE_FULL=1.
+# =============================================================================
+DOCS_ONLY_LIB="$(dirname "$0")/lib/docs-only-patterns.sh"
+if [ -r "$DOCS_ONLY_LIB" ]; then
+  # shellcheck source=lib/docs-only-patterns.sh
+  . "$DOCS_ONLY_LIB"
+fi
+
+if UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); then
+  CHANGED_FILES=$(git diff --name-only "$UPSTREAM..HEAD" 2>/dev/null || true)
+else
+  git fetch origin main --quiet 2>/dev/null || true
+  CHANGED_FILES=$(git diff --name-only origin/main..HEAD 2>/dev/null || true)
+fi
+
+DOCS_ONLY=0
+if command -v is_docs_only >/dev/null 2>&1; then
+  if printf '%s\n' "$CHANGED_FILES" | is_docs_only; then
+    DOCS_ONLY=1
+  fi
+else
+  echo "⚠️  scripts/lib/docs-only-patterns.sh missing — treating push as full (non-docs-only)"
+fi
+
 echo "🔍 Running pre-push test check..."
+
+if [ "$DOCS_ONLY" = "1" ] && [ "${SKILLSMITH_PRE_PUSH_FORCE_FULL:-0}" != "1" ]; then
+  echo "ℹ️  Skipping per-package coverage — docs-only push (override: SKILLSMITH_PRE_PUSH_FORCE_FULL=1)"
+  exit 0
+fi
 
 # SMI-3502: Per-workspace tests (eliminates aggregate contention)
 FAILED_PACKAGES=""

--- a/scripts/tests/check-submodule-pointer.test.ts
+++ b/scripts/tests/check-submodule-pointer.test.ts
@@ -210,6 +210,13 @@ describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
     expect(r.status).toBe(0)
     expect(r.stdout).toContain('PASS-WARN (R4)')
     expect(r.stdout).toContain('live remote branch')
+    // SMI-6260 review fix: a pure R4 case (no independent B-axis R7 match)
+    // must emit exactly ONE result line for the mount -- R4's own verdict is
+    // "PASS + warning annotation", a single line, not that line followed by
+    // a second, redundant generic "PASS: ... OK relative to ..." line for
+    // the same mount. Confirmed live before the fix: both lines printed.
+    const resultLines = r.stdout.split('\n').filter((line) => line.includes('[docs/internal]'))
+    expect(resultLines).toHaveLength(1)
   })
 
   it('R5: S is a strict descendant of T but contained in no remote branch -> FAIL (orphaned)', () => {

--- a/scripts/tests/check-submodule-pointer.test.ts
+++ b/scripts/tests/check-submodule-pointer.test.ts
@@ -1,0 +1,558 @@
+/**
+ * SMI-6260 Wave 1 — scripts/ci/check-submodule-pointer.sh test suite.
+ *
+ * One case per rule (R0-R11 + R-FETCH) from the plan's binding accept/reject
+ * table, using small local bare-repo git fixtures with REAL commits forming
+ * real ancestor/descendant/diverged/orphaned graphs — never mocked git
+ * command output. This is exactly the "SQL/graph-correctness-shaped logic"
+ * CLAUDE.md's SMI-6015 lesson warns gets reviewed but never tested if
+ * coverage is skipped.
+ *
+ * Every fixture follows the same shape: a bare "sub-remote.git" (the
+ * submodule's own upstream), a "seed" working clone used to create
+ * additional commits/branches on that remote, a "parent" repo (a tiny
+ * stand-in for skillsmith itself) with a .gitmodules registering
+ * docs/internal, and docs/internal itself as a real clone of sub-remote.git
+ * inside parent — i.e. a genuinely initialized submodule checkout, not a
+ * simulated one. check-submodule-pointer.sh is invoked as a real child
+ * process (spawnSync) against the parent fixture, exactly as CI/pre-push
+ * would invoke it.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const SCRIPT = join(REPO_ROOT, 'scripts', 'ci', 'check-submodule-pointer.sh')
+
+const FAKE_SHA_1 = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+const FAKE_SHA_2 = 'cafef00d'.repeat(5) // 40 hex chars
+
+// ---------------------------------------------------------------------------
+// Fixture plumbing
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: makeFixtureEnv() }).trim()
+}
+
+function initRepo(dir: string, branch: string): void {
+  mkdirSync(dir, { recursive: true })
+  git(dir, 'init', '-q', '-b', branch)
+  git(dir, 'config', 'commit.gpgsign', 'false')
+}
+
+function commitFile(dir: string, relPath: string, content: string, message: string): string {
+  writeFileSync(join(dir, relPath), content)
+  git(dir, 'add', relPath)
+  git(dir, 'commit', '-q', '-m', message)
+  return git(dir, 'rev-parse', 'HEAD')
+}
+
+interface Fixture {
+  root: string
+  subRemoteDir: string
+  seedDir: string
+  parentDir: string
+  mountDir: string
+  branch: string
+  /** The seed commit BEFORE T — a valid, resolvable ancestor of everything below. */
+  base: string
+  /** The submodule's upstream tip at fixture-build time. */
+  T: string
+}
+
+/**
+ * Build the standard fixture: a bare sub-remote with two commits on
+ * `branch` (base -> T, both pushed), a "seed" working clone of it (for
+ * creating further branches/commits per-test), and a "parent" repo with
+ * docs/internal already a real, initialized clone of sub-remote — i.e. the
+ * mount's local checkout has already fetched `base` and `T` by construction.
+ */
+function buildFixture(branch = 'main'): Fixture {
+  const root = makeFixtureTempDir('csp-fixture')
+  const subRemoteDir = join(root, 'sub-remote.git')
+  execFileSync('git', ['init', '-q', '--bare', '-b', branch, subRemoteDir], {
+    env: makeFixtureEnv(),
+  })
+
+  const seedDir = join(root, 'seed')
+  initRepo(seedDir, branch)
+  const base = commitFile(seedDir, 'f0.txt', 'base\n', 'base commit')
+  git(seedDir, 'remote', 'add', 'origin', subRemoteDir)
+  git(seedDir, 'push', '-q', 'origin', branch)
+  const T = commitFile(seedDir, 'f1.txt', 'tip\n', 'T commit')
+  git(seedDir, 'push', '-q', 'origin', branch)
+
+  const parentDir = join(root, 'parent')
+  initRepo(parentDir, 'main')
+  writeFileSync(
+    join(parentDir, '.gitmodules'),
+    `[submodule "docs/internal"]\n\tpath = docs/internal\n\turl = ${subRemoteDir}\n\tbranch = ${branch}\n`
+  )
+  git(parentDir, 'add', '.gitmodules')
+  git(parentDir, 'commit', '-q', '-m', 'init (no gitlink yet)')
+
+  const mountDir = join(parentDir, 'docs', 'internal')
+  execFileSync('git', ['clone', '-q', subRemoteDir, mountDir], { env: makeFixtureEnv() })
+
+  return { root, subRemoteDir, seedDir, parentDir, mountDir, branch, base, T }
+}
+
+/** Register `sha` as docs/internal's gitlink in a new commit on `parentDir`. */
+function commitGitlink(parentDir: string, sha: string, message: string): string {
+  git(parentDir, 'update-index', '--add', '--cacheinfo', `160000,${sha},docs/internal`)
+  git(parentDir, 'commit', '-q', '-m', message)
+  return git(parentDir, 'rev-parse', 'HEAD')
+}
+
+/** A commit touching an unrelated file only (never touches the mount — R0/R9 fixtures). */
+function commitUnrelated(parentDir: string, message = 'unrelated change'): string {
+  return commitFile(parentDir, `unrelated-${Date.now()}-${Math.random()}.txt`, 'x\n', message)
+}
+
+interface RunResult {
+  status: number
+  stdout: string
+  stderr: string
+}
+
+function runScript(parentDir: string, args: string[]): RunResult {
+  const result = spawnSync('bash', [SCRIPT, ...args], {
+    cwd: parentDir,
+    encoding: 'utf8',
+    env: makeFixtureEnv(),
+  })
+  return { status: result.status ?? -1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
+}
+
+const createdRoots: string[] = []
+function track(f: Fixture): Fixture {
+  createdRoots.push(f.root)
+  return f
+}
+
+afterEach(() => {
+  while (createdRoots.length > 0) {
+    const dir = createdRoots.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// R0-R11 + R-FETCH
+// ---------------------------------------------------------------------------
+
+describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
+  it('R0: diff does not touch the mount -> SKIP-PASS, exit 0', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.T, 'bump to T')
+    commitUnrelated(f.parentDir)
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('SKIP-PASS (R0)')
+  })
+
+  it('R1: S object absent after full fetch -> FAIL, exit 1 (block mode)', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'base bump (target)')
+    commitGitlink(f.parentDir, FAKE_SHA_1, 'S = never-pushed SHA')
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R1:')
+    expect(r.stdout).toContain(FAKE_SHA_1)
+    expect(r.stdout).toContain('was never pushed')
+  })
+
+  it('R2: S === T -> PASS (T-axis), exit 0', () => {
+    const f = track(buildFixture())
+    // target registers `base` (an ancestor of T, still resolvable) as B, so
+    // this exercises R2 with B genuinely available (not entangled with R10).
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T')
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('PASS [docs/internal]')
+    expect(r.stdout).not.toMatch(/R[3-7]:/)
+  })
+
+  it('R3: S is a strict ancestor of T -> FAIL (stale), exit 1', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'base bump (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T (stale once remote advances)')
+    // Advance the remote AFTER the pointer was set — the script's own full
+    // fetch must observe this and classify S as behind.
+    commitFile(f.seedDir, 'f2.txt', 'advance\n', 'remote advances past T')
+    git(f.seedDir, 'push', '-q', 'origin', f.branch)
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R3:')
+    expect(r.stdout).toContain('stale')
+    expect(r.stdout).toContain('by 1 commits')
+  })
+
+  it('R4: S is a strict descendant of T and lives on a live remote branch -> PASS + warning', () => {
+    const f = track(buildFixture())
+    git(f.seedDir, 'checkout', '-q', '-b', 'later')
+    const sDesc = commitFile(f.seedDir, 'f2.txt', 'later\n', 'S: descendant of T on a live branch')
+    git(f.seedDir, 'push', '-q', 'origin', 'later')
+
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, sDesc, 'S = descendant of T')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('PASS-WARN (R4)')
+    expect(r.stdout).toContain('live remote branch')
+  })
+
+  it('R5: S is a strict descendant of T but contained in no remote branch -> FAIL (orphaned)', () => {
+    const f = track(buildFixture())
+    git(f.seedDir, 'checkout', '-q', '-b', 'throwaway')
+    const orphanSha = commitFile(f.seedDir, 'f2.txt', 'orphan\n', 'S: will be orphaned')
+    git(f.seedDir, 'push', '-q', 'origin', 'throwaway')
+    // Prime the mount's local object store with the SHA while the branch
+    // still exists remotely — mirrors the real-world SMI-5823 scenario
+    // (a pointer set when the branch was live; the branch is force-pushed
+    // or deleted AFTER, but the mount's own store still has the object).
+    git(f.mountDir, 'fetch', 'origin', '--prune', '--quiet')
+    git(f.seedDir, 'push', '-q', 'origin', '--delete', 'throwaway')
+
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, orphanSha, 'S = now-orphaned descendant')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R5:')
+    expect(r.stdout).toContain('orphaned tip')
+    expect(r.stdout).toContain('force-pushed or deleted')
+  })
+
+  it('R6: S is neither an ancestor nor a descendant of T -> FAIL (diverged)', () => {
+    const f = track(buildFixture())
+    git(f.seedDir, 'checkout', '-q', '--orphan', 'diverged-root')
+    execFileSync('git', ['rm', '-rf', '--quiet', '.'], { cwd: f.seedDir, env: makeFixtureEnv() })
+    const divergedSha = commitFile(
+      f.seedDir,
+      'fz.txt',
+      'diverged\n',
+      'S: unrelated root, diverged from T'
+    )
+    git(f.seedDir, 'push', '-q', 'origin', 'diverged-root')
+
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, divergedSha, 'S = diverged commit')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R6:')
+    expect(r.stdout).toContain('diverged')
+  })
+
+  it('R7: S is a strict ancestor of B -> FAIL (backward regression)', () => {
+    const f = track(buildFixture())
+    const bSha = commitFile(f.seedDir, 'f2.txt', 'further\n', 'B: descendant of T, still on main')
+    git(f.seedDir, 'push', '-q', 'origin', f.branch)
+
+    const c1 = commitGitlink(f.parentDir, bSha, 'B = further-than-T (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T (strict ancestor of B)')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R7:')
+    expect(r.stdout).toContain('backward regression')
+    expect(r.stdout).toContain(bSha)
+  })
+
+  it('R8: PAT unavailable and diff touches the mount -> FAIL', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T')
+    const r = runScript(f.parentDir, [
+      '--mode=block',
+      '--ref=HEAD',
+      `--target=${c1}`,
+      '--pat-available=false',
+    ])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R8:')
+    expect(r.stdout).toContain('external contributors cannot bump')
+  })
+
+  it('R9: PAT unavailable and diff does not touch the mount -> SKIP-PASS', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.T, 'bump to T')
+    commitUnrelated(f.parentDir)
+    const r = runScript(f.parentDir, [
+      '--mode=block',
+      '--ref=HEAD',
+      `--target=${c1}`,
+      '--pat-available=false',
+    ])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('SKIP-PASS (R9)')
+  })
+
+  it('R10: B absent from the tree entirely -> R7 not evaluated, T-axis still resolves', () => {
+    const f = track(buildFixture())
+    // The `init` commit inside buildFixture() has NO gitlink entry at all —
+    // use it directly as the diff base so B is genuinely absent, not merely
+    // unresolvable (that's R11).
+    const initCommit = git(f.parentDir, 'rev-parse', 'HEAD')
+    commitGitlink(f.parentDir, f.T, 'first-ever registration of docs/internal')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${initCommit}`])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('PASS [docs/internal]')
+    expect(r.stdout).not.toContain('R7:')
+    expect(r.stdout).not.toContain('R11:')
+  })
+
+  it('R11: B present in the tree but unresolvable -> FAIL, distinct "not caused by this PR" message', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, FAKE_SHA_2, 'B = dangling/never-pushed SHA')
+    commitGitlink(f.parentDir, f.T, 'S = T (real, resolvable)')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R11:')
+    expect(r.stdout).toContain(FAKE_SHA_2)
+    expect(r.stdout).toContain('predates this PR/push and was not caused by it')
+    expect(r.stdout).toContain('ADR-143')
+  })
+
+  it('R-FETCH: the fetch itself fails -> distinct infra message, not R1/R11; retries once in block mode', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T')
+    // Point the mount's own remote at a nonexistent path so every fetch
+    // attempt fails — simulates a network/auth failure, not a content
+    // problem with S or B.
+    git(f.mountDir, 'remote', 'set-url', 'origin', '/nonexistent/path/does-not-exist.git')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R-FETCH:')
+    expect(r.stdout).toContain('infra: fetch failed, not a content problem')
+    expect(r.stdout).not.toContain('R1:')
+    expect(r.stdout).not.toContain('R11:')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Evaluation-order / combination semantics, precondition gating, mode
+// behavior, --before honoring, and the PR #2609 regression replay.
+// ---------------------------------------------------------------------------
+
+describe('check-submodule-pointer.sh — evaluation order, gating, and mode semantics', () => {
+  it('combined state T < S < B: R4 (T-axis PASS) does not mask R7 (B-axis FAIL) — overall FAIL', () => {
+    const f = track(buildFixture())
+    git(f.seedDir, 'checkout', '-q', '-b', 'later')
+    const sSha = commitFile(f.seedDir, 'f2.txt', 'later\n', 'S: descendant of T, on live branch')
+    git(f.seedDir, 'push', '-q', 'origin', 'later')
+    const bSha = commitFile(
+      f.seedDir,
+      'f3.txt',
+      'even-later\n',
+      'B: further descendant, still live'
+    )
+    git(f.seedDir, 'push', '-q', 'origin', 'later')
+
+    const c1 = commitGitlink(f.parentDir, bSha, 'B = further descendant (target)')
+    commitGitlink(f.parentDir, sSha, 'S = descendant of T, ancestor of B')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    // A naive first-match implementation would stop at R4's PASS. The
+    // binding evaluation-order semantics require the overall verdict to be
+    // FAIL because R7 also independently matches.
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('PASS-WARN (R4)')
+    expect(r.stdout).toContain('R7:')
+    expect(r.stdout).toContain('backward regression')
+  })
+
+  it('dedicated evaluation-order case: R2 (T-axis PASS, S===T) does not mask R7 (B-axis FAIL) — overall FAIL', () => {
+    const f = track(buildFixture())
+    git(f.seedDir, 'checkout', '-q', '-b', 'future')
+    const bSha = commitFile(
+      f.seedDir,
+      'f2.txt',
+      'future\n',
+      'B: child of T, on a separate branch (main stays at T)'
+    )
+    git(f.seedDir, 'push', '-q', 'origin', 'future')
+
+    const c1 = commitGitlink(f.parentDir, bSha, 'B = future (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T (===fetched tip; R2 on the T-axis)')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    // R2 (S===T) is a silent pass on the T-axis — unlike R4, it has no
+    // message of its own, so the mount's single-line verdict is driven
+    // entirely by R7's FAIL. The key assertion is that R2 being satisfied
+    // does NOT suppress R7 (a naive first-match implementation would never
+    // reach the B-axis check at all once the T-axis matched R2).
+    expect(r.status).toBe(1)
+    expect(r.stdout).not.toContain('PASS-WARN')
+    expect(r.stdout).toContain('FAIL [docs/internal]')
+    expect(r.stdout).toContain('R7:')
+  })
+
+  it('precondition gating: R1 present short-circuits Layer 2 — no R2-R7 comparison attempted, no crash', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, FAKE_SHA_1, 'S = never-pushed SHA')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R1:')
+    expect(r.stdout).not.toMatch(/R[2-7]:/)
+    expect(r.stderr).not.toMatch(/unbound variable|command not found|syntax error/i)
+  })
+
+  it('precondition gating: R11 present short-circuits Layer 2 even though S alone would resolve cleanly', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, FAKE_SHA_2, 'B = dangling SHA')
+    commitGitlink(f.parentDir, f.T, 'S = T (would otherwise cleanly PASS R2)')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R11:')
+    expect(r.stdout).not.toMatch(/R[2-7]:/)
+    expect(r.stdout).not.toContain('PASS')
+    expect(r.stderr).not.toMatch(/unbound variable|command not found|syntax error/i)
+  })
+
+  it('--mode=warn prints the same FAIL verdict as --mode=block but always exits 0', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T (stale once remote advances)')
+    commitFile(f.seedDir, 'f2.txt', 'advance\n', 'remote advances past T')
+    git(f.seedDir, 'push', '-q', 'origin', f.branch)
+
+    const warnResult = runScript(f.parentDir, ['--mode=warn', '--ref=HEAD', `--target=${c1}`])
+    expect(warnResult.status).toBe(0)
+    expect(warnResult.stdout).toContain('R3:')
+
+    const blockResult = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(blockResult.status).toBe(1)
+    expect(blockResult.stdout).toContain('R3:')
+  })
+
+  it('BLOCKING_MOUNTS gating: a FAIL on a non-blocking mount is downgraded to WARN and never blocks --mode=block', () => {
+    const f = track(buildFixture())
+    // Second mount, not docs/internal — must be warn-only even under
+    // --mode=block per the plan's v1 scope-boundary decision.
+    const strategyRemote = join(f.root, 'strategy-remote.git')
+    execFileSync('git', ['init', '-q', '--bare', '-b', 'skills', strategyRemote], {
+      env: makeFixtureEnv(),
+    })
+    const strategySeed = join(f.root, 'strategy-seed')
+    initRepo(strategySeed, 'skills')
+    commitFile(strategySeed, 'g.txt', 'g\n', 'strategy seed commit')
+    git(strategySeed, 'remote', 'add', 'origin', strategyRemote)
+    git(strategySeed, 'push', '-q', 'origin', 'skills')
+
+    // Register the second mount in .gitmodules and give it an unresolvable
+    // (R1-triggering) gitlink — a real FAIL, but on a non-blocking mount.
+    const gitmodulesPath = join(f.parentDir, '.gitmodules')
+    const existing = execFileSync('cat', [gitmodulesPath], { encoding: 'utf8' })
+    writeFileSync(
+      gitmodulesPath,
+      `${existing}\n[submodule ".claude/skills"]\n\tpath = .claude/skills\n\turl = ${strategyRemote}\n\tbranch = skills\n`
+    )
+    git(f.parentDir, 'add', '.gitmodules')
+    execFileSync('git', ['clone', '-q', strategyRemote, join(f.parentDir, '.claude', 'skills')], {
+      env: makeFixtureEnv(),
+    })
+    git(f.parentDir, 'add', '.claude/skills')
+    git(f.parentDir, 'commit', '-q', '-m', 'add strategy mount')
+    const c1 = commitGitlink(f.parentDir, f.base, 'B(docs/internal) = base (target)')
+
+    // Bump docs/internal cleanly (S===T) AND the strategy mount to an
+    // unresolvable SHA (R1) in the same commit.
+    git(f.parentDir, 'update-index', '--add', '--cacheinfo', `160000,${f.T},docs/internal`)
+    git(f.parentDir, 'update-index', '--add', '--cacheinfo', `160000,${FAKE_SHA_1},.claude/skills`)
+    git(f.parentDir, 'commit', '-q', '-m', 'docs/internal clean, .claude/skills R1')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('WARN (non-blocking mount) [.claude/skills]')
+    expect(r.stdout).toContain('R1:')
+    expect(r.stdout).not.toContain('FAIL [.claude/skills]')
+  })
+
+  it('not-initialized local checkout is skipped gracefully, never blocks (advisory even under --mode=block)', () => {
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    rmSync(f.mountDir, { recursive: true, force: true })
+    mkdirSync(f.mountDir, { recursive: true })
+    git(f.parentDir, 'update-index', '--add', '--cacheinfo', `160000,${f.T},docs/internal`)
+    git(f.parentDir, 'commit', '-q', '-m', 'bump while mount uninitialized on disk')
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('SKIP [docs/internal]')
+    expect(r.stdout).toContain('not initialized')
+  })
+
+  it('--before overrides --target as the source of B (post-merge B_prev reconstruction, Wave 2 usage)', () => {
+    const f = track(buildFixture())
+    // --target points at a commit registering an UNRESOLVABLE B (would
+    // trigger R11 if used) — --before must win instead, pointing at a
+    // commit registering a valid, resolvable B.
+    const wrongTarget = commitGitlink(f.parentDir, FAKE_SHA_2, 'wrong target: unresolvable B')
+    const rightBefore = commitGitlink(f.parentDir, f.base, 'right before: resolvable B = base')
+    commitGitlink(f.parentDir, f.T, 'S = T (descendant of base, so R7 does not fire either)')
+
+    const r = runScript(f.parentDir, [
+      '--mode=block',
+      '--ref=HEAD',
+      `--target=${wrongTarget}`,
+      `--before=${rightBefore}`,
+    ])
+    expect(r.status).toBe(0)
+    expect(r.stdout).not.toContain('R11:')
+    expect(r.stdout).toContain('PASS [docs/internal]')
+  })
+
+  // Regression test for the confirmed root-cause incident (PR #2609,
+  // SMI-6205 Wave 4): the squash commit 21ec0139c moved the docs/internal
+  // gitlink e89c8fd -> 928fc96e7, a forward bump relative to the PR
+  // branch's own prior pointer — parent-side history looked clean. But
+  // 928fc96 ("SMI-6205 PR #2609 pre-merge review report") is a strict
+  // ancestor of cadbd29 ("SMI-6205 PR #2609 post-merge governance retro"),
+  // which had ALREADY landed on docs/internal's own origin/main before
+  // #2609 merged — the merge silently regressed the registered pointer
+  // backward relative to docs/internal's own mainline (an R3 case: S stale
+  // relative to T). Replaying the literal real SHAs isn't practical in an
+  // isolated fixture (they're private-submodule commits, unreachable from
+  // a throwaway bare repo) — this fixture mirrors the exact same shape
+  // (S ahead-looking-but-actually-behind-T) with synthetic commits instead.
+  it('PR #2609 regression replay (synthetic 928fc96/cadbd29-shaped fixture) -> R3-FAIL', () => {
+    const f = track(buildFixture())
+    // S: the "pre-merge review report"-equivalent commit (928fc96).
+    const preMergeReportSha = f.T
+    const c1 = commitGitlink(f.parentDir, f.base, 'B = base (target)')
+    commitGitlink(
+      f.parentDir,
+      preMergeReportSha,
+      'gitlink bump: e89c8fd-equivalent -> 928fc96-equivalent'
+    )
+    // T advances past S: the "post-merge governance retro"-equivalent
+    // commit (cadbd29) lands on docs/internal's own origin/main before the
+    // parent-repo PR merges.
+    commitFile(f.seedDir, 'retro.txt', 'retro\n', 'cadbd29-equivalent: post-merge governance retro')
+    git(f.seedDir, 'push', '-q', 'origin', f.branch)
+
+    const r = runScript(f.parentDir, ['--mode=block', '--ref=HEAD', `--target=${c1}`])
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('R3:')
+    expect(r.stdout).toContain('stale')
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** A new automated check that catches a real, recurring bug: `docs/internal` (this repo's internal-docs submodule) can silently regress backward when a PR merges with a stale snapshot, dropping already-merged content with no visible trace in the PR diff. This first PR lays the groundwork — a shared, well-tested ancestry-checking engine, plus a fix so pushing a docs-only change no longer runs the full ~3-5 minute test suite for what should be a ~30 second push. The engine is wired up as an advisory (warn-only) local check in this PR; the hard, PR-blocking CI gate follows in a second PR.

**Quality bar:** Implementation by a Sonnet subagent, independently re-verified line-by-line against the plan's binding design (not trusted from the subagent's report alone) — re-ran the full 22-test suite myself, re-ran `audit:standards`/`preflight`/`typecheck`/`lint`/`format:check`, and read the core rule engine in full. The plan itself went through two adversarial review passes before implementation began (a same-family Claude fallback review, since the normal cross-model GPT-5.6-Sol dispatch failed for tooling reasons — see SMI-6333), catching three real logic gaps in the original rule design before any code was written. A full governance code-review pass found zero findings; report at `docs/internal/code_review/2026-08-30-smi-6260-wave1-pre-push-and-ancestry-engine.md`.

**Found along the way:** an unrelated pre-existing quirk in `docs-only.yml`'s path filter (harmless today, filed as [SMI-6328](https://linear.app/smith-horn-group/issue/SMI-6328)) and a tooling gap in the cross-model review dispatch process itself ([SMI-6333](https://linear.app/smith-horn-group/issue/SMI-6333)) — neither bundled into this PR.

**Net result:** This PR alone is a pure improvement (faster docs pushes, an advisory heads-up on a stale pointer) with no enforcement teeth yet. The actual gate that blocks a bad merge lands in the follow-up PR, tracked on the same Linear issue (SMI-6260).

---

## Technical detail

**New files:**
- `scripts/lib/docs-only-patterns.sh` — canonical docs-only classification, now shared by all three bash callers instead of three independently-drifting copies. Tightened to exclude `packages/**/*.md` and `**/tests/**`/`**/fixtures/**` from the docs-only bucket (closes an SMI-4961-class hazard: a new `.md` at a gated fixture path would otherwise be misclassified as safe-to-skip).
- `scripts/ci/check-submodule-pointer.sh` + `scripts/ci/check-submodule-pointer.helpers.sh` — the ancestry-check engine. Implements an R0-R11 + R-FETCH rule table with a two-layer evaluation model (preconditions gate comparisons; comparisons are independently AND-combined, not first-match) per the plan's binding design. Generic over every `.gitmodules` mount, but only `docs/internal` is blocking in v1 — the three `skillsmith-strategy` mounts are warn-only.
- `scripts/tests/check-submodule-pointer.test.ts` — 22 tests against real local bare-repo git fixtures (not mocked git output), including a combined-state case, precondition-gating cases, a simulated fetch-failure case, and a synthetic replay of the real PR #2609 regression this whole plan exists to catch.

**Modified:**
- `scripts/pre-push-check.sh`, `scripts/lib/hook-docker-detect.sh` — source the shared lib instead of inlining/duplicating the regex; the security-test-suite check (Phase 2 CHECK 1) now skips on a docs-only push.
- `scripts/pre-push-coverage-check.sh` — gains its own independent docs-only computation (it runs as a separate child process, so it can't inherit the other script's classification) and skips the full per-package coverage loop on a docs-only push.
- `.husky/pre-push` — new warn-only step: if a push touches any `.gitmodules` mount, runs the new engine in `--mode=warn` and prints the result, but never blocks the push.

**Override:** `SKILLSMITH_PRE_PUSH_FORCE_FULL=1` forces the full pre-push suite regardless of docs-only classification.

**Plan:** `docs/internal/implementation/smi-6260-docs-internal-pointer-regression-gate.md`
**Linear:** SMI-6260 (this is PR 1 of 2 — Wave 2 adds the required CI gate, post-merge auto-repair, and the bump script)
