### PR TITLE
chore(env): provision STRATEGY_SUBMODULE_PAT, unblock SMI-6260 Wave 2 Step 4

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -92,6 +92,21 @@ LINEAR_PROJECT_TEAM=
 # @type=string(startsWith=gh) @required=false @sensitive
 # SKILLSMITH_PAT_CONTACT=
 
+# GitHub PAT - read access to the private smith-horn/skillsmith-docs repo
+# (checked out locally as the docs/internal submodule). Consumed in CI by
+# three workflows via the matching STRATEGY_SUBMODULE_PAT GitHub Actions
+# secret: docs-folder-index.yml, concurrency-audit-pr.yml, and
+# openapi-spec-sync.yml (SMI-6337 -- provisioned 2026-08-31 after the prior
+# secret was confirmed to have never existed as an accessible repo/env/org
+# secret, silently degrading all three consumers to their continue-on-error
+# fallback path indefinitely). Fine-grained, single-repo-scoped, following
+# the MIRROR_PUSH_TOKEN precedent (publishing-guide.md) rather than a repo
+# admin's own personal classic PAT. Not required for local `varlock run --`
+# use (no local script reads it today) -- documented here so it's tracked as
+# @sensitive rather than living only in .env undeclared.
+# @type=string(startsWith=github_pat_) @required=false @sensitive
+# STRATEGY_SUBMODULE_PAT=
+
 # =============================================================================
 # GITHUB APP - For high-rate skill discovery (15K req/hr)
 # Created: January 4, 2026


### PR DESCRIPTION
## Business Summary

**What shipped:** \`STRATEGY_SUBMODULE_PAT\` — the credential three CI workflows (\`docs-folder-index.yml\`, \`concurrency-audit-pr.yml\`, \`openapi-spec-sync.yml\`) have relied on since inception to clone the private \`docs/internal\` submodule — never actually existed as an accessible secret. All three silently degraded to their fallback path on every run, indefinitely, producing green checkmarks for work that was never actually happening. A real credential is now provisioned and set as the repo secret; this PR documents it in \`.env.schema\`.

**Quality bar:** Verified end-to-end against live CI, not just "secret is set." Re-ran \`docs-folder-index.yml\` on a real commit and confirmed an actual \`git clone\` now succeeds (previously always a fatal auth error) and the real folder-index check now runs — it correctly caught a genuinely stale Folder Reference table (a real, live finding, unrelated to this fix). Re-ran SMI-6260's \`pointer-check\` job on a historical branch and confirmed it now produces a real R7 backward-regression verdict instead of the previous R9 skip-pass, proving the ancestry-check engine works end-to-end with a real credential. Directly verified \`main\`'s currently-registered \`docs/internal\` pointer is fresh (no pre-existing regression to repair first).

**Found along the way:** the Folder Reference table drift surfaced by the now-working check is real and current on \`main\` — tracked separately, not fixed in this PR (it requires a commit in the private \`skillsmith-docs\` repo, out of scope here). Also: this PR's \`git push\` exposed a real security lapse on my part — an exploratory \`grep\` briefly included \`.env\` and printed the raw PAT value into the session transcript. Flagged immediately; recommend rotating this credential as a precaution even though the transcript isn't broadly shared.

**Net result:** Fully shipped for the credential-provisioning half. As a direct consequence, \`pointer-check\` (SMI-6260's ancestry gate) has been promoted to a required branch-protection status check on \`main\` — no code change, done via \`gh api\` after observing real passing and failing runs. This closes SMI-6260's one remaining open thread (Wave 2 Step 4).

---

## Technical detail

- \`.env.schema\`: documents \`STRATEGY_SUBMODULE_PAT\` as \`@sensitive\`, following the existing \`SKILLSMITH_PAT_*\`/\`MIRROR_PUSH_TOKEN\` convention (fine-grained, single-repo-scoped, read-only against \`smith-horn/skillsmith-docs\`).
- No workflow YAML changes — all three consumers already read \`secrets.STRATEGY_SUBMODULE_PAT\`; only the secret's existence was the gap.
- Branch protection: added \`pointer-check\` to \`required_status_checks.contexts\` on \`main\` via \`gh api repos/smith-horn/skillsmith/branches/main/protection/required_status_checks\` (PATCH, out-of-band of this diff).
- SMI-6337 acceptance criteria: org-secret ambiguity resolved (user provisioned a real credential rather than one existing at the org level), fix confirmed via live re-run (not just secret presence), all three consumers confirmed to share the identical gap and are all fixed by the same secret. Declined to build new stateful "credential appears broken" alerting infra for the three still-graceful-degrade-by-design workflows — the root cause (missing secret) is fixed, and a future rotation/expiry recurrence is a meaningfully separate scope from this fix; documented as a deliberate call, not a silent skip.

[skip-impl-check]