### PR TITLE
fix(ci): match bare docs/internal gitlink in docs-only.yml path filter

### DIFF
--- a/.github/workflows/docs-only.yml
+++ b/.github/workflows/docs-only.yml
@@ -54,6 +54,7 @@ jobs:
           base: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           filters: |
             docs:
+              - 'docs/internal'
               - 'docs/internal/**'
               - '.claude/development/**'
               - '.claude/templates/**'


### PR DESCRIPTION
## Business Summary

**What shipped:** A submodule pointer-bump PR (the most common kind of PR touching \`docs/internal\`) now correctly triggers Markdown Lint's docs-check branch. Previously the path filter only matched \`docs/internal/**\`, which never matches the bare gitlink path itself — the check was silently skipped on exactly the PRs it exists for.

**Quality bar:** One-line change, mirrors an already-shipped, already-proven fix (SMI-5523, applied to \`docs-folder-index.yml\` for the identical bug class).

**Net result:** Done, no follow-up.

---

## Technical detail

\`.github/workflows/docs-only.yml\`: added the literal \`'docs/internal'\` filter entry alongside the existing \`'docs/internal/**'\` glob, matching \`docs-folder-index.yml\`'s precedent (lines 29-30 there).