### PR TITLE
docs: SMI-6312 cross-wave UAT report for SMI-6200 E3 Governance GA

### DIFF
--- a/scripts/staging/smi-6200-e3-orphan-census.sql
+++ b/scripts/staging/smi-6200-e3-orphan-census.sql
@@ -1,0 +1,202 @@
+-- Z0. Orphan census for the SMI-6200 governance surface.
+-- Run: ./scripts/pooler-psql.sh -f - < scripts/staging/smi-6200-e3-orphan-census.sql
+-- (pooler-psql.sh docker-execs; pipe on stdin, do not pass -f <hostpath>.)
+\pset format aligned
+\echo '=== Z0 orphan census ==='
+
+-- 1. Permission grants whose team no longer has SSO configured at all.
+--    These are NOT wrong on their own (grants are independent of SSO) -- the finding is a
+--    grant that was CREATED to shape an SSO-provisioned cohort and now applies to a cohort
+--    that no longer exists. Cross-reference the count with #2.
+SELECT 'grants_on_teams_without_sso_settings' AS metric, count(*) AS n
+  FROM team_permission_grants g
+ WHERE NOT EXISTS (SELECT 1 FROM team_sso_settings s WHERE s.team_id = g.team_id);
+
+-- 2. Permission grants for a (team, role) pair that currently has ZERO members.
+--    A grant nobody holds is inert today and silently re-arms the moment someone is
+--    assigned that role. This is the concrete shape of Round 2 finding #21.
+SELECT 'grants_for_roles_with_no_members' AS metric, count(*) AS n
+  FROM team_permission_grants g
+ WHERE NOT EXISTS (
+   SELECT 1 FROM team_members tm WHERE tm.team_id = g.team_id AND tm.role = g.role);
+
+-- 3. Grants whose creating user is gone (created_by is ON DELETE SET NULL).
+SELECT 'grants_with_null_created_by' AS metric, count(*) AS n
+  FROM team_permission_grants WHERE created_by IS NULL;
+
+-- 4. team_members still tagged provisioned_via='sso' on a team with no SSO settings row.
+--    The inline freshness gate reads a NULL reverify_days and fails closed => these users
+--    hold a membership row that can never grant anything and that the sweep's behaviour
+--    against a missing settings row does not define. Permanently-denied zombies.
+SELECT 'sso_members_without_sso_settings' AS metric, count(*) AS n
+  FROM team_members tm
+ WHERE tm.provisioned_via = 'sso'
+   AND NOT EXISTS (SELECT 1 FROM team_sso_settings s WHERE s.team_id = tm.team_id);
+
+-- 5. team_members tagged 'sso' on a team the expiry sweep will not touch, because
+--    sso_expiry_eligible() is false (settings inactive, or the domain lost DNS
+--    verification). This is the DESIGNED safety valve -- but has_team_permission()'s
+--    freshness gate has no matching pause, so these members are simultaneously
+--    permission-denied and unexpirable. Poison P-8. Expect 0 in steady state; a
+--    persistent non-zero value is a team stuck in that state.
+SELECT 'sso_members_frozen_by_expiry_pause' AS metric, count(*) AS n
+  FROM team_members tm
+ WHERE tm.provisioned_via = 'sso'
+   AND tm.role <> 'owner'
+   AND EXISTS (SELECT 1 FROM team_sso_settings s WHERE s.team_id = tm.team_id)
+   AND NOT sso_expiry_eligible(tm.team_id);
+
+-- 6. SSO-provisioned members with a NULL sso_verified_at (treated as expired, never
+--    refreshable without a login that maps a role).
+SELECT 'sso_members_null_verified_at' AS metric, count(*) AS n
+  FROM team_members WHERE provisioned_via = 'sso' AND sso_verified_at IS NULL;
+
+-- 7. SSO-provisioned members already past their team's reverify window that the daily
+--    04:25 UTC sweep has not removed, EXCLUDING the deliberately-paused population from
+--    #5. A non-zero, non-decreasing value here means the sweep is not running or is
+--    silently no-op'ing. Uses the same two helpers the sweep itself uses, so this query
+--    and the sweep cannot disagree about what "stale" means.
+SELECT 'sso_members_stale_but_not_swept' AS metric, count(*) AS n
+  FROM team_members tm
+ WHERE tm.provisioned_via = 'sso' AND tm.role <> 'owner'
+   AND sso_expiry_eligible(tm.team_id)
+   AND (tm.sso_verified_at IS NULL
+        OR tm.sso_verified_at < now() - make_interval(days => sso_reverify_days(tm.team_id)));
+
+-- 8. Revoked license keys tagged as SWEEP-revoked whose owner is once again an active,
+--    genuinely FRESH member -- i.e. a reissue that should have happened and did not.
+--    Freshness is reproduced from the shipped predicate (per-team sso_reverify_days,
+--    normally 7 days), NOT a hardcoded 1 day: a hardcoded window silently misses every
+--    member between day 1 and their real deadline. Tier-scoped to match
+--    record_sso_login()'s own reissue branch, which only touches team/enterprise keys.
+SELECT 'sso_revoked_keys_for_active_members' AS metric, count(*) AS n
+  FROM license_keys k
+ WHERE k.status = 'revoked'
+   AND k.tier IN ('team', 'enterprise')
+   AND k.metadata->>'revoked_by' = 'sso_expiry'
+   AND EXISTS (
+     SELECT 1 FROM team_members tm
+      WHERE tm.user_id = k.user_id
+        AND tm.provisioned_via = 'sso'
+        AND (tm.role = 'owner'                      -- owner is exempt from the freshness gate
+             OR (tm.sso_verified_at IS NOT NULL
+                 AND tm.sso_verified_at
+                     >= now() - make_interval(days => sso_reverify_days(tm.team_id)))));
+
+-- 9. Revoked license keys carrying NO revoked_by marker at all, belonging to an active
+--    member -- the permanently-unreissuable cohort (poison P-2). Deliberately EXCLUDES
+--    'sso_account_link'-marked keys, which are a separate, also-unreissuable cohort
+--    counted at #9b: link_sso_account() sets that marker explicitly, so treating them as
+--    "unmarked" would both overcount here and hide the distinction the reissue contract
+--    actually turns on. Not automatically a defect (a deliberate admin revocation looks
+--    identical) -- treat a RISE across an SSO lifecycle as the signal, not the absolute.
+SELECT 'revoked_keys_no_marker_active_member' AS metric, count(*) AS n
+  FROM license_keys k
+ WHERE k.status = 'revoked'
+   AND (k.metadata->>'revoked_by') IS NULL
+   AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.user_id = k.user_id);
+
+-- 9b. Keys revoked by an identity link, whose original owner is still an active member
+--     somewhere. Expected and correct after a link (the entitlement moved to the SSO
+--     identity) -- reported so the three revocation cohorts are separable in the census
+--     rather than collapsed into "revoked".
+SELECT 'link_revoked_keys' AS metric, count(*) AS n
+  FROM license_keys
+ WHERE status = 'revoked' AND metadata->>'revoked_by' = 'sso_account_link';
+
+-- 10. Non-revoked license keys whose expires_at is in the past (bound at last login and
+--     never refreshed) -- a key that is "active" and useless.
+SELECT 'active_keys_past_expiry' AS metric, count(*) AS n
+  FROM license_keys
+ WHERE status <> 'revoked' AND expires_at IS NOT NULL AND expires_at < now();
+
+-- 10b. SSO-provisioned members holding an ACTIVE key OUTSIDE ('team','enterprise').
+--      record_sso_login()'s refresh/reissue and expire_stale_sso_members()'s revoke are
+--      both tier-scoped, so a key here is entirely outside the SSO deprovisioning story:
+--      it survives expiry and IdP removal indefinitely. Correct for a genuine personal
+--      Individual subscription; a finding if the SSO fallback path issues keys at that tier.
+SELECT 'sso_members_with_out_of_scope_active_key' AS metric, count(*) AS n
+  FROM license_keys k
+  JOIN team_members tm ON tm.user_id = k.user_id AND tm.provisioned_via = 'sso'
+ WHERE k.status <> 'revoked' AND k.tier NOT IN ('team', 'enterprise');
+
+-- 11. sso_account_links rows whose SSO or legacy user no longer exists.
+SELECT 'link_rows_with_missing_user' AS metric, count(*) AS n
+  FROM sso_account_links l
+ WHERE NOT EXISTS (SELECT 1 FROM auth.users u WHERE u.id = l.sso_user_id)
+    OR NOT EXISTS (SELECT 1 FROM auth.users u WHERE u.id = l.legacy_user_id);
+
+-- 12. sso_account_links rows never linked, whose consent window has lapsed, that nobody
+--     GCs. These stay queryable to both parties' read RPCs forever.
+SELECT 'link_rows_consent_expired_unlinked' AS metric, count(*) AS n
+  FROM sso_account_links
+ WHERE linked_at IS NULL
+   AND consent_expires_at IS NOT NULL AND consent_expires_at < now();
+
+-- 12b. Completed links whose 7-day manual-reversal window has already closed. Not a
+--      defect -- this is the population for whom the product's stated "email support
+--      within 7 days and we'll reverse it by hand" promise no longer applies at all.
+--      Report the number; it is the size of the irreversible cohort.
+SELECT 'links_past_reversible_window' AS metric, count(*) AS n
+  FROM sso_account_links
+ WHERE linked_at IS NOT NULL
+   AND reversible_until IS NOT NULL AND reversible_until < now();
+
+-- 12c. Completed links still inside the reversal window that were never notified --
+--      the recipient does not know the link happened and the clock is running.
+SELECT 'links_reversible_but_unnotified' AS metric, count(*) AS n
+  FROM sso_account_links
+ WHERE linked_at IS NOT NULL AND notified_at IS NULL
+   AND reversible_until IS NOT NULL AND reversible_until >= now();
+
+-- 13. sso_account_links rows pointing at a team that no longer exists.
+--     (team_id is NOT NULL with an ON DELETE CASCADE FK, so a non-zero count here means
+--     the FK is gone -- a structural finding, not a data one.)
+SELECT 'link_rows_orphan_team' AS metric, count(*) AS n
+  FROM sso_account_links l
+ WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = l.team_id);
+
+-- 14. team_sso_domains rows whose team has no settings row (claim without config).
+SELECT 'domains_without_settings' AS metric, count(*) AS n
+  FROM team_sso_domains d
+ WHERE NOT EXISTS (SELECT 1 FROM team_sso_settings s WHERE s.team_id = d.team_id);
+
+-- 14b. THE ONE THAT MATTERS MOST (Z3): a VERIFIED domain claim whose team no longer has
+--      any SSO configuration. Because team_sso_domains FKs to teams -- not to
+--      team_sso_settings -- and team-sso-manage exposes no domain-release action, a
+--      verified claim survives SSO removal and keeps occupying the partial unique index
+--      team_sso_domains_verified_domain_key, permanently blocking every other tenant from
+--      claiming that domain, with no product surface able to free it.
+SELECT 'verified_domains_with_no_sso_config' AS metric, count(*) AS n
+  FROM team_sso_domains d
+ WHERE d.verified_at IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM team_sso_settings s WHERE s.team_id = d.team_id);
+
+-- 15. Unverified domain claims older than the stated 7-day expiry sweep.
+SELECT 'unverified_domain_claims_over_7d' AS metric, count(*) AS n
+  FROM team_sso_domains
+ WHERE verified_at IS NULL AND created_at < now() - interval '7 days';
+
+-- 16. team_sso_settings rows with status='active' but a NULL provider id. The CHECK
+--     should make this impossible; a non-zero count means the constraint is missing.
+SELECT 'active_settings_null_provider' AS metric, count(*) AS n
+  FROM team_sso_settings WHERE status = 'active' AND supabase_provider_id IS NULL;
+
+-- 17. Duplicate PENDING purge-schedule rows for one user IN ONE TEAM (poison P-5).
+--     Keyed by (user_id, departed_team_id) -- a user legitimately departing two different
+--     teams has two rows and is NOT a zombie, which a bare user_id grouping would
+--     miscount. Restricted to pending rows (purged_at IS NULL AND cancelled_reason IS
+--     NULL), since a completed and a subsequent pending row are also legitimate.
+SELECT 'user_team_pairs_with_multiple_pending_purge_rows' AS metric, count(*) AS n
+  FROM (SELECT user_id, departed_team_id
+          FROM team_member_inventory_purge_schedule
+         WHERE purged_at IS NULL AND cancelled_reason IS NULL
+         GROUP BY user_id, departed_team_id HAVING count(*) > 1) q;
+
+-- 18. Shadow accounts: a non-SSO auth.users row sharing an SSO user's email
+--     (the SMI-6206 IdP bypass -- the standing regression check).
+SELECT 'shadow_account_email_pairs' AS metric, count(*) AS n
+  FROM (SELECT lower(email) AS e FROM auth.users WHERE email IS NOT NULL
+         GROUP BY lower(email)
+        HAVING count(*) FILTER (WHERE is_sso_user) > 0
+           AND count(*) FILTER (WHERE NOT is_sso_user) > 0) q;

--- a/scripts/staging/smi-6200-e3-uat-chain.helpers.sh
+++ b/scripts/staging/smi-6200-e3-uat-chain.helpers.sh
@@ -1,0 +1,418 @@
+# smi-6200-e3-uat-chain.helpers.sh -- sourced by smi-6200-e3-uat-chain.sh.
+#
+# Adapted from scripts/staging/smi-6205-sso-uat-e2e.helpers.sh (same mechanics: run_sql,
+# rpc, assert_*, jwt_claim, mock_saml_login, ensure_clean_email, create_user,
+# password_login) but with THIS scenario's own six-identity fixture cast (SMI-6200 E3 UAT
+# matrix, docs/internal/implementation/smi-6200-e3-uat-scenario-matrix.md, section 4) and
+# fixture prefix (_e2e_e3_6200_ / e2e-e3-6200-), and deliberately NO trap-based cleanup:
+# the C1 chain's whole point is fixtures that survive to be read by later Z/R/U/Q-series
+# scenarios in the same matrix, run by a separate session. See the matrix's own cleanup
+# discipline note. Use scripts/staging/smi-6200-e3-uat-chain.sh --cleanup to explicitly
+# tear down when the entire matrix (not just C1) is done.
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+# Persistent (not mktemp) workdir so state (tokens, ids) survives across the several
+# process invocations the C1 chain runs as (paused at B-CP1/B-CP2/B-CP3 for the browser
+# agent). Safe to reuse across days; every write is idempotent / overwrite-in-place.
+WORKDIR="${SMI6200_WORKDIR:-$HOME/.skillsmith-uat/smi6200-e3-chain}"
+mkdir -p "$WORKDIR"
+
+# ============================================================================
+# SAFETY GATES -- identical posture to the SMI-6205 sibling.
+# ============================================================================
+: "${STAGING_SUPABASE_PROJECT_REF:?REFUSING: STAGING_SUPABASE_PROJECT_REF is not set. Run via 'varlock run -- ./scripts/staging/smi-6200-e3-uat-chain.sh'.}"
+: "${STAGING_SUPABASE_URL:?REFUSING: STAGING_SUPABASE_URL is not set.}"
+: "${STAGING_SUPABASE_ANON_KEY:?REFUSING: STAGING_SUPABASE_ANON_KEY is not set.}"
+: "${STAGING_SUPABASE_SERVICE_ROLE_KEY:?REFUSING: STAGING_SUPABASE_SERVICE_ROLE_KEY is not set.}"
+: "${STAGING_SUPABASE_DB_PASSWORD:?REFUSING: STAGING_SUPABASE_DB_PASSWORD is not set.}"
+: "${SUPABASE_ACCESS_TOKEN:?REFUSING: SUPABASE_ACCESS_TOKEN is not set (needed for the Management API saml_enabled check).}"
+
+PROD_REF="vrcnzpmndtroqxxoqkzy"
+STAGING_REF="ovhcifugwqnzoebwfuku"
+
+if [ "$STAGING_SUPABASE_PROJECT_REF" = "$PROD_REF" ]; then
+  echo "REFUSING: STAGING_SUPABASE_PROJECT_REF is set to the PROD ref." >&2
+  exit 1
+fi
+if [ "$STAGING_SUPABASE_PROJECT_REF" != "$STAGING_REF" ]; then
+  echo "REFUSING: STAGING_SUPABASE_PROJECT_REF ($STAGING_SUPABASE_PROJECT_REF) is not the known staging ref ($STAGING_REF)." >&2
+  exit 1
+fi
+case "$STAGING_SUPABASE_URL" in
+  *"$STAGING_REF"*) : ;;
+  *) echo "REFUSING: STAGING_SUPABASE_URL does not contain the staging ref ($STAGING_REF)." >&2; exit 1 ;;
+esac
+case "$STAGING_SUPABASE_URL" in
+  *"$PROD_REF"*) echo "REFUSING: STAGING_SUPABASE_URL contains the PROD ref." >&2; exit 1 ;;
+esac
+
+# ============================================================================
+# FIXTURE CAST (matrix section 4) -- fixed, greppable, `_e2e_e3_6200_`-prefixed (teams) or
+# `e2e-e3-6200-`-prefixed (emails).
+# ============================================================================
+TEAM_ID="_e2e_e3_6200_team"
+OWNER_EMAIL="e2e-e3-6200-owner@smithhorn-test.invalid"
+ADMIN_EMAIL="e2e-e3-6200-admin@smithhorn-test.invalid"
+LEGACY_EMAIL="e2e-e3-6200-legacy@example.com"
+SSO_EMAIL="e2e-e3-6200-ssouser@example.com"
+OUTSIDER_EMAIL="e2e-e3-6200-outsider@smithhorn-test.invalid"
+SAML_DOMAIN="example.com"
+SAML_METADATA_URL="https://mocksaml.com/api/saml/metadata"
+
+PASS=0
+FAIL=0
+UNCOVERED=0
+CHARACTERIZED=0
+ok()  { PASS=$((PASS+1)); printf '[PASS] %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '[FAIL] %s\n' "$1" >&2; }
+uncov() { UNCOVERED=$((UNCOVERED+1)); printf '[UNCOVERED] %s\n' "$1"; }
+charz() { CHARACTERIZED=$((CHARACTERIZED+1)); printf '[CHARACTERIZED] %s\n' "$1"; }
+
+run_sql() {
+  SUPABASE_PROJECT_REF="$STAGING_SUPABASE_PROJECT_REF" \
+  SUPABASE_DB_PASSWORD="$STAGING_SUPABASE_DB_PASSWORD" \
+    "$REPO_ROOT/scripts/pooler-psql.sh" -v ON_ERROR_STOP=1 -t -A "$@"
+}
+run_sql_aligned() {
+  SUPABASE_PROJECT_REF="$STAGING_SUPABASE_PROJECT_REF" \
+  SUPABASE_DB_PASSWORD="$STAGING_SUPABASE_DB_PASSWORD" \
+    "$REPO_ROOT/scripts/pooler-psql.sh" -v ON_ERROR_STOP=1 "$@"
+}
+
+rpc() {
+  local fn="$1" token_file="$2" body="$3"
+  local token; token=$(cat "$token_file")
+  curl -s -o "$WORKDIR/last_body.json" -w '%{http_code}' \
+    -X POST "$STAGING_SUPABASE_URL/rest/v1/rpc/$fn" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    --data-raw "$body"
+}
+last_body() { cat "$WORKDIR/last_body.json"; }
+
+assert_status() {  # expected actual label
+  if [ "$1" = "$2" ]; then ok "$3 (HTTP $2)"; else bad "$3 -- expected HTTP $1, got $2 (body: $(last_body))"; fi
+}
+assert_jq_eq() {  # jq_path expected label
+  local actual
+  actual=$(jq -r "$1" "$WORKDIR/last_body.json" 2>/dev/null || echo '<parse-error>')
+  if [ "$actual" = "$2" ]; then ok "$3 (got $actual)"; else bad "$3 -- expected '$2', got '$actual' (body: $(last_body))"; fi
+}
+assert_jq_in() {  # jq_path space_separated_expected_set label
+  local actual
+  actual=$(jq -r "$1" "$WORKDIR/last_body.json" 2>/dev/null || echo '<parse-error>')
+  local ok_found=0 e
+  for e in $2; do [ "$actual" = "$e" ] && ok_found=1; done
+  if [ "$ok_found" = "1" ]; then ok "$3 (got $actual)"; else bad "$3 -- expected one of [$2], got '$actual' (body: $(last_body))"; fi
+}
+
+ensure_clean_email() {
+  local email="$1"
+  local uids
+  uids=$(curl -s "$STAGING_SUPABASE_URL/auth/v1/admin/users?filter=$email" \
+    -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    | jq -r --arg e "$email" '.users[] | select(.email == $e) | .id')
+  for uid in $uids; do
+    echo "  (self-heal) deleting leftover auth.users row for $email ($uid)"
+    # Fixed (SMI-6200 UAT re-run, 2026-08-31, live finding): a leftover device_codes row
+    # from a prior run's C1.8 device-login flow FK-blocks the auth.users delete
+    # (device_codes_user_id_fkey), and the DELETE below used to discard both body and
+    # status via `-o /dev/null` with no `-w` capture -- so a failed delete printed the
+    # SAME "(self-heal) deleting..." success-looking line as a real one. This silently
+    # left the OLD row in place every run, which is what C1.9's "expected exactly 1 row,
+    # got 2" shadow-account check was actually catching -- a harness cleanup gap, not the
+    # SMI-6206 regression the check's own comment guesses at. Clear device_codes first,
+    # then verify the actual DELETE status instead of swallowing it.
+    curl -s -o /dev/null -X DELETE "$STAGING_SUPABASE_URL/rest/v1/device_codes?user_id=eq.$uid" \
+      -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+      -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY"
+    local del_status
+    del_status=$(curl -s -o "$WORKDIR/self_heal_delete_body.json" -w '%{http_code}' \
+      -X DELETE "$STAGING_SUPABASE_URL/auth/v1/admin/users/$uid" \
+      -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+      -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY")
+    case "$del_status" in
+      2*) : ;;
+      *)
+        echo "REFUSING: self-heal delete of $email ($uid) failed (HTTP $del_status): $(cat "$WORKDIR/self_heal_delete_body.json")" >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+create_user() {  # email password_out_file -> prints new user id
+  local email="$1" pw_file="$2"
+  local pw; pw=$(openssl rand -base64 24)
+  echo "$pw" > "$pw_file"
+  local resp
+  resp=$(curl -s -X POST "$STAGING_SUPABASE_URL/auth/v1/admin/users" \
+    -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Content-Type: application/json" \
+    --data-raw "$(jq -n --arg e "$email" --arg p "$pw" '{email:$e,password:$p,email_confirm:true}')")
+  local uid; uid=$(echo "$resp" | jq -r '.id // empty')
+  if [ -z "$uid" ]; then
+    echo "REFUSING: admin-createUser failed for $email: $resp" >&2
+    exit 1
+  fi
+  echo "$uid"
+}
+
+password_login() {  # email password_file out_token_file
+  local email="$1" pw; pw=$(cat "$2")
+  curl -s -X POST "$STAGING_SUPABASE_URL/auth/v1/token?grant_type=password" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" \
+    -H "Content-Type: application/json" \
+    --data-raw "$(jq -n --arg e "$email" --arg p "$pw" '{email:$e,password:$p}')" \
+    | jq -r '.access_token' > "$3"
+  if [ ! -s "$3" ] || [ "$(cat "$3")" = "null" ]; then
+    echo "REFUSING: password login failed for $email" >&2
+    exit 1
+  fi
+}
+
+jwt_claim() {
+  local token="$1" path="$2"
+  local payload; payload=$(printf '%s' "$token" | cut -d. -f2 | tr -- '-_' '+/')
+  case $(( ${#payload} % 4 )) in
+    2) payload="${payload}==" ;;
+    3) payload="${payload}=" ;;
+  esac
+  printf '%s' "$payload" | base64 -d 2>/dev/null | jq -r "$path"
+}
+
+mock_saml_login() {
+  local login_email="$1" out_token_file="$2"
+
+  local init_headers="$WORKDIR/sso_init_headers.txt"
+  curl -sD "$init_headers" -o /dev/null -X POST "$STAGING_SUPABASE_URL/auth/v1/sso" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" \
+    -H "Content-Type: application/json" \
+    --data-raw "$(jq -n --arg d "$SAML_DOMAIN" '{domain:$d,redirect_to:"https://ovhcifugwqnzoebwfuku.supabase.co/sso-e2e-landing"}')"
+  local mocksaml_sso_url
+  mocksaml_sso_url=$(grep -i '^location:' "$init_headers" | sed 's/^[Ll]ocation: //' | tr -d '\r')
+  [ -n "$mocksaml_sso_url" ] || { echo "REFUSING: /auth/v1/sso did not return a Location header." >&2; exit 1; }
+
+  local login_page_url
+  login_page_url=$(curl -sL -c "$WORKDIR/mocksaml_cookies.txt" -o /dev/null \
+    -w '%{url_effective}' "$mocksaml_sso_url")
+
+  local id audience acsurl relaystate
+  read -r id audience acsurl relaystate < <(python3 - "$login_page_url" <<'PYEOF'
+import sys, urllib.parse
+q = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[1]).query)
+print(q['id'][0], q['audience'][0], q['acsUrl'][0], q['relayState'][0])
+PYEOF
+)
+  [ -n "${id:-}" ] || { echo "REFUSING: could not parse Mock SAML login page query params." >&2; exit 1; }
+
+  local auth_body="$WORKDIR/mocksaml_auth_response.html"
+  curl -s -X POST "https://mocksaml.com/api/saml/auth" \
+    -H "Content-Type: application/json" \
+    -b "$WORKDIR/mocksaml_cookies.txt" \
+    --data-raw "$(jq -n --arg e "$login_email" --arg id "$id" --arg aud "$audience" \
+                        --arg acs "$acsurl" --arg rs "$relaystate" \
+      '{email:$e,id:$id,audience:$aud,acsUrl:$acs,providerName:"undefined",relayState:$rs}')" \
+    -o "$auth_body"
+
+  python3 - "$auth_body" "$WORKDIR/saml_response.txt" "$WORKDIR/relay_state.txt" <<'PYEOF'
+import re, sys
+html = open(sys.argv[1]).read()
+open(sys.argv[2], 'w').write(re.search(r'name="SAMLResponse" value="([^"]+)"', html).group(1))
+open(sys.argv[3], 'w').write(re.search(r'name="RelayState" value="([^"]+)"', html).group(1))
+PYEOF
+
+  local acs_headers="$WORKDIR/acs_headers.txt"
+  curl -sD "$acs_headers" -o /dev/null -X POST "$acsurl" \
+    --data-urlencode "SAMLResponse@$WORKDIR/saml_response.txt" \
+    --data-urlencode "RelayState@$WORKDIR/relay_state.txt"
+
+  local final_location
+  final_location=$(grep -i '^location:' "$acs_headers" | sed 's/^[Ll]ocation: //' | tr -d '\r')
+  case "$final_location" in
+    *access_token=*) : ;;
+    *)
+      echo "REFUSING: Mock SAML login did not yield an access_token. Location: $final_location" >&2
+      exit 1
+      ;;
+  esac
+
+  python3 - "$final_location" "$out_token_file" <<'PYEOF'
+import sys, urllib.parse
+frag = sys.argv[1].split('#', 1)[1]
+params = urllib.parse.parse_qs(frag)
+open(sys.argv[2], 'w').write(params['access_token'][0])
+PYEOF
+
+  jwt_claim "$(cat "$out_token_file")" '.sub'
+}
+
+# ============================================================================
+# G-2 procedure (matrix section 5) -- service-role patch of auth.identities.identity_data
+# to substitute a mapped groups claim, THEN verify the patch landed. Never call this AFTER
+# a login without also re-calling record_sso_login() immediately -- see the matrix's
+# re-priming rule. This function only does steps 2 (patch) + verification; step 1 (login)
+# and step 3 (record_sso_login call) are the caller's responsibility, per-step, since the
+# caller needs the token from step 1 to make step 3's call.
+# ============================================================================
+g2_patch_and_verify() {  # user_id
+  local uid="$1"
+  run_sql -c "
+    UPDATE auth.identities
+       SET identity_data = jsonb_set(
+             identity_data, '{custom_claims,groups}', '[\"skillsmith-admins\"]'::jsonb, true)
+     WHERE user_id = '$uid' AND provider LIKE 'sso:%';
+  " >/dev/null
+  local landed
+  landed=$(run_sql -c "
+    SELECT identity_data->'custom_claims'->'groups' FROM auth.identities
+     WHERE user_id = '$uid' AND provider LIKE 'sso:%';
+  ")
+  if [ "$landed" = '["skillsmith-admins"]' ]; then
+    ok "G-2 patch verified landed for $uid (identity_data.custom_claims.groups=$landed)"
+  else
+    bad "G-2 patch did NOT land for $uid -- got '$landed', expected [\"skillsmith-admins\"]"
+    return 1
+  fi
+}
+
+# ============================================================================
+# Checkpoint/sentinel pause protocol (matrix section 12, "Checkpoint protocol").
+#
+# At B-CP1 (after C1.10), B-CP2 (after C1.12), and B-CP3 (after C1.14) the C1 chain must
+# stop and hand off to a real browser session (mcp__claude-in-chrome__*) that exercises
+# the U-series scenarios the matrix's section-12 table lists, before the chain is allowed
+# to continue -- several browser assertions observe state a later C1 step destroys. A
+# prior run of this harness went straight through C1 into the Z-series and Q-series
+# without ever stopping for that browser verification; this function is the fix.
+#
+# It implements the protocol section 12 specifies literally: "prints a
+# `=== CHECKPOINT <id>: paused ===` banner with the fixture UUIDs and the current session
+# tokens, writes them to $WORKDIR/checkpoint-<id>.json, and blocks on a sentinel file
+# (`until [ -f $WORKDIR/go-<id> ]; do sleep 2; done`). The browser agent does its work,
+# then touches the sentinel."
+#
+# JSON SHAPE -- section 12 names WHAT must be written (fixture UUIDs + session tokens)
+# but not an exact schema. This is this harness's own choice, recorded here rather than
+# left implicit:
+#   {
+#     "checkpoint_id":         "B-CP1" | "B-CP2" | "B-CP3",
+#     "written_at":            ISO-8601 UTC timestamp,
+#     "fires_after":           the matrix's own "Fires after" cell (which C1 step, and why),
+#     "browser_work":          the matrix's own "Browser work" cell (which U-scenarios to run),
+#     "state_handed_off_note": the matrix's own "State handed off" cell, verbatim, so the
+#                               browser agent can cross-check this file's actual contents
+#                               against what the matrix promised it would receive,
+#     "fixtures":              { team_id, owner_id, admin_id, legacy_id, sso_user_id,
+#                                 outsider_id } -- whichever of these exist on disk yet,
+#     "session_tokens":        { <name>_token / sso_token1|2|3 : <raw JWT> } -- only
+#                               tokens actually live at this point in the chain are
+#                               included (e.g. only sso_token1 exists at B-CP1; both
+#                               sso_token1 AND sso_token2 exist at B-CP2, matching the
+#                               matrix's own B-CP2 note "the SAME tokens -- deliberately"),
+#     "keys":                  whatever license_keys ids/tiers are already known at this
+#                               point (e.g. key_a_id/key_b_id/key_b_tier),
+#     "sentinel_file":         absolute path the browser agent must `touch` to resume,
+#     "timeout_seconds":       this invocation's configured ceiling (see --timeout / the
+#                               SMI6200_CHECKPOINT_TIMEOUT_SECONDS env var)
+#   }
+#
+# SENTINEL: $WORKDIR/go-<id> -- an empty marker file. The browser agent (or a human)
+# touches it once the listed browser work is complete; this function polls for it every
+# 2 seconds (matching the matrix's own literal loop) up to the configured timeout, then
+# REFUSES (exit 1) instead of hanging forever -- the safety valve the checkpoint protocol
+# text does not itself specify but any unattended/background invocation needs.
+#
+# DESIGN CHOICE (undocumented by the matrix, recorded here): a stale sentinel left over
+# from an EARLIER invocation is deleted at the top of every call, so a re-run of a phase
+# always blocks for a fresh `touch` rather than instantly passing through on old state --
+# this is deliberately the more conservative reading, given the exact failure this
+# function exists to prevent (a run silently skipping the pause).
+# ============================================================================
+CHECKPOINT_TIMEOUT_SECONDS="${SMI6200_CHECKPOINT_TIMEOUT_SECONDS:-1800}"
+
+checkpoint_pause() {  # id fires_after_desc browser_work_desc state_handed_off_desc
+  local id="$1" fires_after="$2" browser_work="$3" state_handed_off="$4"
+  local cp_file="$WORKDIR/checkpoint-$id.json"
+  local sentinel="$WORKDIR/go-$id"
+  local timeout="${CHECKPOINT_TIMEOUT_SECONDS}"
+
+  rm -f "$sentinel"
+
+  local fixtures_json tokens_json keys_json
+  fixtures_json=$(jq -n \
+    --arg team_id "$TEAM_ID" \
+    --arg owner_id "$(cat "$WORKDIR/owner_id" 2>/dev/null || echo '')" \
+    --arg admin_id "$(cat "$WORKDIR/admin_id" 2>/dev/null || echo '')" \
+    --arg legacy_id "$(cat "$WORKDIR/legacy_id" 2>/dev/null || echo '')" \
+    --arg sso_user_id "$(cat "$WORKDIR/sso_user_id" 2>/dev/null || echo '')" \
+    --arg outsider_id "$(cat "$WORKDIR/outsider_id" 2>/dev/null || echo '')" \
+    '{team_id:$team_id, owner_id:$owner_id, admin_id:$admin_id, legacy_id:$legacy_id,
+      sso_user_id:$sso_user_id, outsider_id:$outsider_id}
+     | with_entries(select(.value != ""))')
+
+  tokens_json=$(jq -n \
+    --arg owner_token "$(cat "$WORKDIR/owner_token.txt" 2>/dev/null || echo '')" \
+    --arg admin_token "$(cat "$WORKDIR/admin_token.txt" 2>/dev/null || echo '')" \
+    --arg legacy_token "$(cat "$WORKDIR/legacy_token.txt" 2>/dev/null || echo '')" \
+    --arg outsider_token "$(cat "$WORKDIR/outsider_token.txt" 2>/dev/null || echo '')" \
+    --arg sso_token1 "$(cat "$WORKDIR/sso_token1.txt" 2>/dev/null || echo '')" \
+    --arg sso_token2 "$(cat "$WORKDIR/sso_token2.txt" 2>/dev/null || echo '')" \
+    --arg sso_token3 "$(cat "$WORKDIR/sso_token3.txt" 2>/dev/null || echo '')" \
+    '{owner_token:$owner_token, admin_token:$admin_token, legacy_token:$legacy_token,
+      outsider_token:$outsider_token, sso_token1:$sso_token1, sso_token2:$sso_token2,
+      sso_token3:$sso_token3}
+     | with_entries(select(.value != ""))')
+
+  keys_json=$(jq -n \
+    --arg key_a_id "$(cat "$WORKDIR/key_a_id" 2>/dev/null || echo '')" \
+    --arg key_b_id "$(cat "$WORKDIR/key_b_id" 2>/dev/null || echo '')" \
+    --arg key_b_tier "$(cat "$WORKDIR/key_b_tier" 2>/dev/null || echo '')" \
+    '{key_a_id:$key_a_id, key_b_id:$key_b_id, key_b_tier:$key_b_tier}
+     | with_entries(select(.value != ""))')
+
+  jq -n \
+    --arg checkpoint_id "$id" \
+    --arg written_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg fires_after "$fires_after" \
+    --arg browser_work "$browser_work" \
+    --arg state_handed_off_note "$state_handed_off" \
+    --argjson fixtures "$fixtures_json" \
+    --argjson session_tokens "$tokens_json" \
+    --argjson keys "$keys_json" \
+    --arg sentinel_file "$sentinel" \
+    --argjson timeout_seconds "$timeout" \
+    '{checkpoint_id:$checkpoint_id, written_at:$written_at, fires_after:$fires_after,
+      browser_work:$browser_work, state_handed_off_note:$state_handed_off_note,
+      fixtures:$fixtures, session_tokens:$session_tokens, keys:$keys,
+      sentinel_file:$sentinel_file, timeout_seconds:$timeout_seconds}' \
+    > "$cp_file"
+
+  echo "=== CHECKPOINT $id: paused ==="
+  echo "  wrote $cp_file"
+  echo "  fires after: $fires_after"
+  echo "  browser work: $browser_work"
+  echo "  state handed off (per matrix sec.12): $state_handed_off"
+  echo "  waiting for sentinel: $sentinel  (touch it to resume; timeout ${timeout}s, poll every 2s)"
+
+  local waited=0
+  until [ -f "$sentinel" ]; do
+    sleep 2
+    waited=$((waited + 2))
+    if [ "$waited" -ge "$timeout" ]; then
+      echo "REFUSING: checkpoint $id timed out after ${timeout}s waiting for $sentinel" >&2
+      echo "  Either the browser work is still in progress -- re-run this phase with a" >&2
+      echo "  larger --timeout=<seconds> (or export SMI6200_CHECKPOINT_TIMEOUT_SECONDS)" >&2
+      echo "  -- or touch $sentinel manually once you have confirmed the browser-side" >&2
+      echo "  work in the matrix's section-12 table is actually done." >&2
+      exit 1
+    fi
+  done
+  echo "  sentinel found after ${waited}s -- resuming chain past $id"
+}
+
+echo "PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED (helpers loaded)"

--- a/scripts/staging/smi-6200-e3-uat-chain.helpers.sh
+++ b/scripts/staging/smi-6200-e3-uat-chain.helpers.sh
@@ -125,10 +125,22 @@ ensure_clean_email() {
     # left the OLD row in place every run, which is what C1.9's "expected exactly 1 row,
     # got 2" shadow-account check was actually catching -- a harness cleanup gap, not the
     # SMI-6206 regression the check's own comment guesses at. Clear device_codes first,
-    # then verify the actual DELETE status instead of swallowing it.
-    curl -s -o /dev/null -X DELETE "$STAGING_SUPABASE_URL/rest/v1/device_codes?user_id=eq.$uid" \
+    # then verify the actual DELETE status instead of swallowing it. (Second fix, same
+    # session: the device_codes DELETE itself still discarded body+status via `-o
+    # /dev/null` -- inconsistent with the fix this comment describes, flagged by NEEDLE's
+    # second-opinion review of the resulting UAT report. Now checked the same way.)
+    local dc_status
+    dc_status=$(curl -s -o "$WORKDIR/self_heal_device_codes_body.json" -w '%{http_code}' \
+      -X DELETE "$STAGING_SUPABASE_URL/rest/v1/device_codes?user_id=eq.$uid" \
       -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
-      -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY"
+      -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY")
+    case "$dc_status" in
+      2*) : ;;
+      *)
+        echo "REFUSING: self-heal device_codes cleanup for $email ($uid) failed (HTTP $dc_status): $(cat "$WORKDIR/self_heal_device_codes_body.json")" >&2
+        exit 1
+        ;;
+    esac
     local del_status
     del_status=$(curl -s -o "$WORKDIR/self_heal_delete_body.json" -w '%{http_code}' \
       -X DELETE "$STAGING_SUPABASE_URL/auth/v1/admin/users/$uid" \

--- a/scripts/staging/smi-6200-e3-uat-chain.phase1.sh
+++ b/scripts/staging/smi-6200-e3-uat-chain.phase1.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# smi-6200-e3-uat-chain.phase1.sh -- phase_chain1 (C1.4-C1.10), split out of
+# smi-6200-e3-uat-chain.sh to stay under the repo's 500-line file limit.
+# Sourced by smi-6200-e3-uat-chain.sh -- never run directly.
+
+phase_chain1() {
+  echo "=== PHASE: chain1 (C1.4 - C1.10) ==="
+  SSO_USER_ID=$(cat "$WORKDIR/sso_user_id")
+  LEGACY_ID=$(cat "$WORKDIR/legacy_id")
+  OWNER_ID=$(cat "$WORKDIR/owner_id")
+
+  echo "--- C1.4: LEGACY joins team_members (deferred from setup, see comment there) ---"
+  run_sql -c "
+    INSERT INTO team_members (team_id, user_id, role, provisioned_via, joined_at)
+    VALUES ('$TEAM_ID', '$LEGACY_ID', 'member', 'manual', now())
+    ON CONFLICT (team_id, user_id) DO UPDATE SET role = EXCLUDED.role;
+    -- Same materialized-tier gap as phase_setup's OWNER/ADMIN calls -- LEGACY now
+    -- belongs to an enterprise team subscription too, but profiles.tier won't reflect
+    -- it until recomputed (live finding, SMI-6200 UAT re-run, 2026-08-31).
+    SELECT recompute_user_tier('$LEGACY_ID');
+  " >/dev/null
+
+  echo "  [MATRIX-VS-REALITY] record_sso_login()'s own step 7 candidate-insert matches"
+  echo "  \"profiles p WHERE lower(p.email) = v_bind.asserted_email\" -- v_bind.asserted_email"
+  echo "  is the SSO SESSION's OWN asserted email (SSO_EMAIL), not any team member's email."
+  echo "  Confirmed live at C1.3: sso_account_links had 0 rows and record_sso_login()'s own"
+  echo "  response carried link_candidate:null, because LEGACY_EMAIL != SSO_EMAIL (as the"
+  echo "  matrix's own fixture cast specifies). This is NOT a G0 failure -- G0 already"
+  echo "  passed. It is a distinct precondition the matrix did not anticipate: the natural"
+  echo "  candidate-creation path in C1.4 cannot fire while LEGACY and SSO use different"
+  echo "  emails, which is unavoidable because C1.9's shadow-account check REQUIRES those"
+  echo "  emails to differ (else C1.9 would misreport legitimate post-link coexistence as a"
+  echo "  regression). Using C1.4's documented service-role fallback instead, labelled a"
+  echo "  substitution -- for a different trigger condition than the matrix names."
+  charz "C1.4 candidate auto-creation via record_sso_login() step 7 does not fire -- distinct LEGACY/SSO emails (matrix fixture-cast tension with C1.9, not a G0 failure or product bug)"
+
+  echo "--- C1.4 (substitution): service-role seed of the candidate row ---"
+  run_sql -c "
+    INSERT INTO sso_account_links (sso_user_id, legacy_user_id, team_id, consent_expires_at)
+    VALUES ('$SSO_USER_ID', '$LEGACY_ID', '$TEAM_ID', now() + interval '7 days')
+    ON CONFLICT (sso_user_id, legacy_user_id) DO UPDATE SET consent_expires_at = EXCLUDED.consent_expires_at;
+  " >/dev/null
+  echo "[SERVICE-ROLE FALLBACK -- C1.4 candidate seed substituted]"
+
+  STATUS=$(rpc get_own_sso_link_candidate "$WORKDIR/sso_token1.txt" '{}')
+  assert_status 200 "$STATUS" "C1.4 get_own_sso_link_candidate callable as SSO"
+  COUNT=$(jq 'length' "$WORKDIR/last_body.json")
+  [ "$COUNT" = "1" ] && ok "C1.4 SSO identity sees 1 candidate" || bad "C1.4 expected 1 candidate, got $COUNT"
+
+  STATUS=$(rpc get_pending_sso_link_requests "$WORKDIR/legacy_token.txt" '{}')
+  assert_status 200 "$STATUS" "C1.4 get_pending_sso_link_requests callable as legacy"
+  assert_jq_eq '.[0].sso_user_id' "$SSO_USER_ID" "C1.4 legacy sees pending request naming the right SSO identity"
+  assert_jq_eq '.[0].team_name' "E2E E3 6200 Team" "C1.4 legacy's pending request names the team"
+
+  STATUS=$(rpc get_pending_sso_link_requests "$WORKDIR/outsider_token.txt" '{}')
+  assert_status 200 "$STATUS" "C1.4 get_pending_sso_link_requests callable as outsider"
+  COUNT=$(jq 'length' "$WORKDIR/last_body.json")
+  [ "$COUNT" = "0" ] && ok "C1.4 OUTSIDER sees 0 candidates" || bad "C1.4 expected 0 for OUTSIDER, got $COUNT"
+
+  echo "--- C1.5: dual consent, wrong order first ---"
+  STATUS=$(rpc link_sso_account "$WORKDIR/sso_token1.txt" "$(jq -n --arg l "$LEGACY_ID" '{p_legacy_user_id:$l}')")
+  assert_status 403 "$STATUS" "C1.5 link before LEGACY consents is refused"
+  echo "  refusal body: $(last_body)"
+  MSG=$(jq -r '.message' "$WORKDIR/last_body.json")
+  case "$MSG" in *link_consent_required*) ok "C1.5 refusal names link_consent_required" ;; *) bad "C1.5 refusal message unexpected: $MSG" ;; esac
+
+  STATUS=$(rpc record_sso_link_consent "$WORKDIR/legacy_token.txt" "$(jq -n --arg s "$SSO_USER_ID" '{p_sso_user_id:$s}')")
+  assert_status 204 "$STATUS" "C1.5 LEGACY consents to the link"
+  STATUS=$(rpc link_sso_account "$WORKDIR/sso_token1.txt" "$(jq -n --arg l "$LEGACY_ID" '{p_legacy_user_id:$l}')")
+  assert_status 204 "$STATUS" "C1.5 SSO identity executes the link"
+
+  echo "--- C1.6: post-link DB state ---"
+  run_sql_aligned -c "SELECT * FROM team_members WHERE team_id = '$TEAM_ID';"
+  MOVED_ROLE=$(run_sql -c "SELECT role FROM team_members WHERE team_id = '$TEAM_ID' AND user_id = '$SSO_USER_ID';")
+  [ "$MOVED_ROLE" = "member" ] && ok "C1.6 SSO team_members row now carries LEGACY's role (member)" \
+    || bad "C1.6 expected role=member after link, got '$MOVED_ROLE'"
+  LEGACY_TM_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id = '$TEAM_ID' AND user_id = '$LEGACY_ID';")
+  [ "$LEGACY_TM_COUNT" = "0" ] && ok "C1.6 LEGACY's own team_members row removed" || bad "C1.6 LEGACY row still present ($LEGACY_TM_COUNT)"
+  SSO_PROVISIONED_VIA=$(run_sql -c "SELECT provisioned_via FROM team_members WHERE team_id = '$TEAM_ID' AND user_id = '$SSO_USER_ID';")
+  echo "  SSO team_members.provisioned_via = $SSO_PROVISIONED_VIA (poison P-4 record)"
+
+  LEGACY_ENT_KEY_ID=$(cat "$WORKDIR/legacy_ent_key_id"); LEGACY_IND_KEY_ID=$(cat "$WORKDIR/legacy_ind_key_id")
+  run_sql_aligned -c "SELECT id,status,tier,metadata FROM license_keys WHERE id IN ('$LEGACY_ENT_KEY_ID','$LEGACY_IND_KEY_ID');"
+  ENT_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id = '$LEGACY_ENT_KEY_ID';")
+  ENT_REVOKED_BY=$(run_sql -c "SELECT metadata->>'revoked_by' FROM license_keys WHERE id = '$LEGACY_ENT_KEY_ID';")
+  [ "$ENT_STATUS" = "revoked" ] && [ "$ENT_REVOKED_BY" = "sso_account_link" ] && \
+    ok "C1.6 LEGACY's enterprise key revoked with revoked_by=sso_account_link" \
+    || bad "C1.6 expected enterprise key revoked/sso_account_link, got status=$ENT_STATUS revoked_by=$ENT_REVOKED_BY"
+  IND_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id = '$LEGACY_IND_KEY_ID';")
+  [ "$IND_STATUS" = "active" ] && ok "C1.6 LEGACY's individual key untouched (still active)" \
+    || bad "C1.6 expected individual key still active, got $IND_STATUS"
+
+  run_sql_aligned -c "SELECT linked_at, reversible_until, consent_expires_at FROM sso_account_links WHERE sso_user_id='$SSO_USER_ID' AND legacy_user_id='$LEGACY_ID';"
+  LINK_AUDIT=$(run_sql -c "SELECT count(*) FROM audit_logs WHERE event_type = 'sso:account_linked' AND actor = '$SSO_USER_ID';")
+  [ "$LINK_AUDIT" -ge "1" ] && ok "C1.6 audit trail recorded sso:account_linked" || bad "C1.6 no sso:account_linked audit row"
+
+  echo "--- C1.6b: sso-link-notify ---"
+  BODY=$(jq -n --arg l "$LEGACY_ID" '{legacy_user_id:$l}')
+  HTTP=$(curl -s -o "$WORKDIR/notify1.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/sso-link-notify" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/sso_token1.txt")" \
+    -H "Content-Type: application/json" --data-raw "$BODY")
+  echo "  first call: HTTP $HTTP body=$(cat "$WORKDIR/notify1.json")"
+  SENT1=$(jq -r '.sent // empty' "$WORKDIR/notify1.json")
+  ERR1=$(jq -r '.error // empty' "$WORKDIR/notify1.json")
+  if [ "$HTTP" = "200" ] && [ "$SENT1" = "true" ]; then
+    ok "C1.6b first notify call sent=true"
+  elif [ "$HTTP" = "200" ] && [ "$ERR1" = "email_send_failed" ]; then
+    # Documented graceful-degradation shape (sso-link-notify/index.ts:35 -- "link stands;
+    # only the notice failed"), not a crash. RESEND_API_KEY IS registered as a secret name
+    # on staging (confirmed via the Management API secrets list), so this is the SECOND
+    # email_send_failed return site (the actual Resend API call itself failing), not the
+    # "key missing" site. Root cause unconfirmed from here (Resend account/domain config
+    # is outside DB/edge-function visibility) -- reporting as UNCOVERED for the
+    # sent:true/already_notified dedupe pair rather than guessing at Resend's cause.
+    charz "C1.6b first notify call hit the documented email_send_failed fallback (RESEND_API_KEY secret name present on staging, but the actual send failed) -- link itself still stands"
+    uncov "C1.6b sent:true -> already_notified dedupe transition: unreachable while every real send fails (notified_at never gets set)"
+  else
+    bad "C1.6b first notify call unexpected: HTTP $HTTP $(cat "$WORKDIR/notify1.json")"
+  fi
+  HTTP=$(curl -s -o "$WORKDIR/notify2.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/sso-link-notify" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/sso_token1.txt")" \
+    -H "Content-Type: application/json" --data-raw "$BODY")
+  echo "  second call: HTTP $HTTP body=$(cat "$WORKDIR/notify2.json")"
+  REASON2=$(jq -r '.reason // empty' "$WORKDIR/notify2.json")
+  if [ "$HTTP" = "200" ] && [ "$REASON2" = "already_notified" ]; then
+    ok "C1.6b second call sent=false reason=already_notified (dedupe)"
+  elif [ "$HTTP" = "200" ] && [ "$(jq -r '.error // empty' "$WORKDIR/notify2.json")" = "email_send_failed" ]; then
+    charz "C1.6b second notify call also hit email_send_failed (consistent with notified_at never having been set by call 1)"
+  else
+    bad "C1.6b second notify call unexpected: HTTP $HTTP $(cat "$WORKDIR/notify2.json")"
+  fi
+  HTTP=$(curl -s -o "$WORKDIR/notify3.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/sso-link-notify" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/outsider_token.txt")" \
+    -H "Content-Type: application/json" --data-raw "$BODY")
+  [ "$HTTP" = "403" ] && [ "$(jq -r '.error' "$WORKDIR/notify3.json")" = "link_not_found" ] && ok "C1.6b OUTSIDER call refused 403 link_not_found" \
+    || bad "C1.6b OUTSIDER call unexpected: HTTP $HTTP $(cat "$WORKDIR/notify3.json")"
+
+  echo "--- C1.7: grant, as OWNER ---"
+  SSO_ROLE_NOW=$(run_sql -c "SELECT role FROM team_members WHERE team_id='$TEAM_ID' AND user_id='$SSO_USER_ID';")
+  echo "  SSO's current role: $SSO_ROLE_NOW"
+  STATUS=$(rpc set_team_role_permission "$WORKDIR/owner_token.txt" "$(jq -n --arg r "$SSO_ROLE_NOW" '{p_team_id:"'"$TEAM_ID"'",p_role:$r,p_permission:"registry:approve",p_effect:"allow"}')")
+  assert_status 204 "$STATUS" "C1.7 OWNER sets registry:approve=allow for role=$SSO_ROLE_NOW"
+  echo "  (representing rbac_create_policy action:create's bulk expansion -- see rbac-tools.action.ts:358, which loops setRolePermission per pair; set_team_role_permission RETURNS VOID -> PostgREST 204)"
+  STATUS=$(rpc set_team_role_permission "$WORKDIR/owner_token.txt" "$(jq -n --arg r "$SSO_ROLE_NOW" '{p_team_id:"'"$TEAM_ID"'",p_role:$r,p_permission:"registry:deprecate",p_effect:"allow"}')")
+  assert_status 204 "$STATUS" "C1.7 bulk-writer-equivalent second set_team_role_permission call (registry:deprecate=allow)"
+
+  GRANT_COUNT=$(run_sql -c "SELECT count(*) FROM team_permission_grants WHERE team_id='$TEAM_ID' AND role='$SSO_ROLE_NOW' AND permission='registry:approve';")
+  [ "$GRANT_COUNT" = "1" ] && ok "C1.7 grant row exists in team_permission_grants" || bad "C1.7 expected 1 grant row, got $GRANT_COUNT"
+
+  STATUS=$(rpc has_team_permission "$WORKDIR/sso_token1.txt" "$(jq -n '{p_team_id:"'"$TEAM_ID"'",p_permission:"registry:approve"}')")
+  assert_status 200 "$STATUS" "C1.7 has_team_permission callable as SSO"
+  assert_jq_eq '.' 'true' "C1.7 has_team_permission(registry:approve) as SSO -> true"
+
+  STATUS=$(rpc team_ids_with_permission "$WORKDIR/sso_token1.txt" "$(jq -n '{p_permission:"registry:approve"}')")
+  assert_status 200 "$STATUS" "C1.7 team_ids_with_permission callable as SSO"
+  echo "  team_ids_with_permission body: $(last_body)"
+  CONTAINS=$(jq -r --arg t "$TEAM_ID" 'if type=="array" then (map(if type=="object" then .team_id else . end) | index($t) != null) else false end' "$WORKDIR/last_body.json" 2>/dev/null || echo false)
+  [ "$CONTAINS" = "true" ] && ok "C1.7 team_ids_with_permission(registry:approve) as SSO contains TEAM" \
+    || bad "C1.7 team_ids_with_permission did not contain TEAM: $(last_body)"
+
+  STATUS=$(rpc get_effective_team_permissions "$WORKDIR/owner_token.txt" "$(jq -n '{p_team_id:"'"$TEAM_ID"'"}')")
+  assert_status 200 "$STATUS" "C1.7 get_effective_team_permissions callable as OWNER"
+  ROWCOUNT=$(jq 'length' "$WORKDIR/last_body.json")
+  [ "$ROWCOUNT" = "8" ] && ok "C1.7 get_effective_team_permissions returns 8 rows (2 roles x 4 perms)" || bad "C1.7 expected 8 rows, got $ROWCOUNT"
+  GRANT_SRC=$(jq -r --arg r "$SSO_ROLE_NOW" '.[] | select(.role==$r and .permission=="registry:approve") | .source' "$WORKDIR/last_body.json")
+  [ "$GRANT_SRC" = "grant" ] && ok "C1.7 granted cell source=grant" || bad "C1.7 expected source=grant for the granted cell, got $GRANT_SRC"
+
+  STATUS=$(rpc get_effective_team_permissions "$WORKDIR/sso_token1.txt" "$(jq -n '{p_team_id:"'"$TEAM_ID"'"}')")
+  # RAISE EXCEPTION ... USING ERRCODE='42501' surfaces as a real PostgREST error response
+  # (HTTP 403), not wrapped inside a 200 body -- matches the 6205 harness's own T6.1 (a 42501
+  # refusal asserted at HTTP 403). Earlier draft of this script incorrectly expected 200 here.
+  assert_status 403 "$STATUS" "C1.7 get_effective_team_permissions as SSO is refused at the HTTP layer"
+  assert_jq_eq '.code' '42501' "C1.7 get_effective_team_permissions as SSO raises 42501 permission_denied (SSO lacks team:manage_rbac)"
+  echo "  [P-3 / Q3] grant is keyed (team_id, role, permission) = ($TEAM_ID, $SSO_ROLE_NOW, registry:approve) -- not scoped to this specific user; will silently apply to whoever else holds role=$SSO_ROLE_NOW next."
+
+  echo "--- C1.8: device login ---"
+  DC_RESP=$(curl -s -X POST "$STAGING_SUPABASE_URL/functions/v1/auth-device-code" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Content-Type: application/json" \
+    --data-raw '{"client_type":"cli"}')
+  echo "  device-code resp: $DC_RESP"
+  DEVICE_CODE=$(echo "$DC_RESP" | jq -r '.device_code')
+  USER_CODE=$(echo "$DC_RESP" | jq -r '.user_code')
+  [ -n "$DEVICE_CODE" ] && [ "$DEVICE_CODE" != "null" ] || { bad "C1.8 auth-device-code did not return a device_code"; }
+
+  HTTP=$(curl -s -o "$WORKDIR/device_approve.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/auth-device-approve" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/sso_token1.txt")" \
+    -H "Content-Type: application/json" --data-raw "$(jq -n --arg u "$USER_CODE" '{user_code:$u}')")
+  echo "  approve: HTTP $HTTP body=$(cat "$WORKDIR/device_approve.json")"
+  APPROVE_ERR=$(jq -r '.error // empty' "$WORKDIR/device_approve.json")
+  if [ "$HTTP" = "403" ] && [ "$APPROVE_ERR" = "sso_unsupported" ]; then
+    ok "C1.8 auth-device-approve refuses SSO caller (403 sso_unsupported)"
+  else
+    # STAGING-IS-BEHIND-MAIN (confirmed live, not a product bug): approve_device_code()'s
+    # LIVE body on staging (pg_get_functiondef) has NO is_sso_user check at all -- the check
+    # exists only in supabase/migrations/20260830060000_auth_device_approve_sso_refusal.sql,
+    # which has NOT been applied to staging. Evidence: mark_device_code_sso_refused() (added
+    # by that same migration) does not exist on staging; device_codes lacks
+    # refusal_reason/refused_at; schema_version's newest row (108, applied 2026-08-29
+    # 20:41:31 UTC) predates the migration's own 20260830060000 (2026-08-30 06:00:00) UTC
+    # timestamp. Per the matrix's own P3 instruction ("staging is behind main -- stop and
+    # say so; do not shim it in"), this is UNCOVERED, not a product FAIL -- the fix exists
+    # correctly on main, just not deployed here. NOTE: P3 as literally specified in the
+    # matrix did not catch this, because its fixed function-name list never named
+    # approve_device_code/mark_device_code_sso_refused -- a real gap in P3's own coverage,
+    # worth folding into a future revision of this matrix.
+    uncov "C1.8 auth-device-approve: staging is behind main for 20260830060000_auth_device_approve_sso_refusal.sql -- approve_device_code()'s live body lacks the is_sso_user gate entirely (confirmed via pg_get_functiondef + absence of mark_device_code_sso_refused() + schema_version timing). Got HTTP $HTTP $APPROVE_ERR instead of sso_unsupported."
+    echo "  [LIVE-VERIFIED IMPACT] With the SSO user's profile completed (profile_completed_at set as part of this investigation), a retry returned HTTP 200 {\"status\":\"approved\"} at the APPROVE step -- the first-gate SSO refusal is genuinely absent on staging. However the SUBSEQUENT token poll still correctly refused with 403 sso_unsupported (an independent, already-deployed mintSession()/isSsoProvisioned() guard inside auth-device-token), so no CLI token was actually minted. Net: a redundant defense-in-depth layer is missing on staging; the final security boundary held in this test, but the approve-time UX now falsely reports \"approved\" to a polling CLI before it is refused."
+  fi
+  cp "$WORKDIR/device_approve.json" "$WORKDIR/c1_8_approve_body.json"
+
+  HTTP=$(curl -s -o "$WORKDIR/device_token.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/auth-device-token" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Content-Type: application/json" \
+    --data-raw "$(jq -n --arg d "$DEVICE_CODE" '{device_code:$d}')")
+  echo "  token poll: HTTP $HTTP body=$(cat "$WORKDIR/device_token.json")"
+  TOKEN_ERR=$(jq -r '.error // empty' "$WORKDIR/device_token.json")
+  if [ "$HTTP" = "403" ] && [ "$TOKEN_ERR" = "sso_unsupported" ]; then
+    ok "C1.8 auth-device-token poll ALSO surfaces sso_unsupported (persisted via mark_device_code_sso_refused)"
+  elif [ "$HTTP" = "428" ] && [ "$TOKEN_ERR" = "authorization_pending" ]; then
+    uncov "C1.8 auth-device-token poll: got 428 authorization_pending, not sso_unsupported -- downstream consequence of the same staging-behind-main gap (approve never persisted an sso-refused device_codes row because it returned profile_incomplete, not sso_unsupported, on this attempt)"
+  else
+    bad "C1.8 token poll unexpected: HTTP $HTTP $(cat "$WORKDIR/device_token.json")"
+  fi
+  cp "$WORKDIR/device_token.json" "$WORKDIR/c1_8_token_body.json"
+
+  echo "--- C1.9: shadow-account regression check ---"
+  run_sql_aligned -c "SELECT id, email, is_sso_user, created_at FROM auth.users WHERE email = '$SSO_EMAIL' ORDER BY created_at;"
+  ROWCOUNT=$(run_sql -c "SELECT count(*) FROM auth.users WHERE email = '$SSO_EMAIL';")
+  [ "$ROWCOUNT" = "1" ] && ok "C1.9 exactly one auth.users row for SSO's email (no shadow account)" \
+    || bad "C1.9 expected exactly 1 row for $SSO_EMAIL, got $ROWCOUNT -- possible SMI-6206 regression"
+
+  echo "--- C1.9b: no-marker key fixture (regenerate, never revoke-a-second-key) ---"
+  HTTP=$(curl -s -o "$WORKDIR/key_a.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/generate-license" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/sso_token1.txt")" \
+    -H "Content-Type: application/json" --data-raw '{"name":"CLI Token (fixture)"}')
+  echo "  generate-license: HTTP $HTTP body=$(jq -c 'del(.key)' "$WORKDIR/key_a.json" 2>/dev/null || cat "$WORKDIR/key_a.json")"
+  [ "$HTTP" = "200" ] || [ "$HTTP" = "201" ] && ok "C1.9b generate-license issued key A" || bad "C1.9b generate-license unexpected HTTP $HTTP: $(cat "$WORKDIR/key_a.json")"
+  KEY_A_ID=$(jq -r '.id' "$WORKDIR/key_a.json"); echo "$KEY_A_ID" > "$WORKDIR/key_a_id"
+  KEY_A_TIER=$(jq -r '.tier' "$WORKDIR/key_a.json"); echo "  key A id=$KEY_A_ID tier=$KEY_A_TIER"
+
+  HTTP=$(curl -s -o "$WORKDIR/key_b.json" -w '%{http_code}' -X POST "$STAGING_SUPABASE_URL/functions/v1/regenerate-license" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/sso_token1.txt")" \
+    -H "Content-Type: application/json" --data-raw '{"name":"CLI Token (fixture B)"}')
+  echo "  regenerate-license: HTTP $HTTP body=$(jq -c 'del(.key)' "$WORKDIR/key_b.json" 2>/dev/null || cat "$WORKDIR/key_b.json")"
+  KEY_B_ID=$(jq -r '.id' "$WORKDIR/key_b.json"); echo "$KEY_B_ID" > "$WORKDIR/key_b_id"
+  # [DOC-DRIFT] regenerate-license/index.ts's own header comment documents the response
+  # field as singular `revokedKeyId: string`, but the LIVE response carries a plural
+  # `revokedKeyIds: string[]` array (confirmed live) -- consistent with the function's real
+  # "revoke ALL active keys" behavior (see the C1.9b table note / SMI-6315). Doc, not
+  # behavior, is what's stale; not filing a separate Linear issue since SMI-6315 already
+  # captures the underlying multi-key-revocation gap this field exists to describe.
+  REVOKED_KEY_IDS=$(jq -r '.revokedKeyIds // empty | @json' "$WORKDIR/key_b.json")
+  CONTAINS_A=$(jq -r --arg a "$KEY_A_ID" '(.revokedKeyIds // []) | index($a) != null' "$WORKDIR/key_b.json")
+  [ "$CONTAINS_A" = "true" ] && ok "C1.9b regenerate-license revoked key A (revokedKeyIds=$REVOKED_KEY_IDS), issued key B ($KEY_B_ID)" \
+    || bad "C1.9b expected revokedKeyIds to contain $KEY_A_ID, got $REVOKED_KEY_IDS"
+
+  run_sql_aligned -c "SELECT id,status,tier,metadata FROM license_keys WHERE id IN ('$KEY_A_ID','$KEY_B_ID');"
+  A_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$KEY_A_ID';")
+  A_REASON=$(run_sql -c "SELECT metadata->>'revoked_reason' FROM license_keys WHERE id='$KEY_A_ID';")
+  A_REVOKED_BY=$(run_sql -c "SELECT metadata->>'revoked_by' FROM license_keys WHERE id='$KEY_A_ID';")
+  [ "$A_STATUS" = "revoked" ] && [ "$A_REASON" = "regenerated" ] && [ -z "$A_REVOKED_BY" ] && \
+    ok "C1.9b key A: status=revoked revoked_reason=regenerated revoked_by=NULL (the no-marker cohort)" \
+    || bad "C1.9b key A unexpected: status=$A_STATUS reason=$A_REASON revoked_by='$A_REVOKED_BY'"
+  B_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$KEY_B_ID';")
+  B_TIER=$(run_sql -c "SELECT tier FROM license_keys WHERE id='$KEY_B_ID';")
+  ACTIVE_COUNT=$(run_sql -c "SELECT count(*) FROM license_keys WHERE user_id='$SSO_USER_ID' AND status='active';")
+  [ "$B_STATUS" = "active" ] && [ "$ACTIVE_COUNT" = "1" ] && [ "$B_TIER" = "$KEY_A_TIER" ] && \
+    ok "C1.9b key B active, sole key, same tier as A ($B_TIER)" \
+    || bad "C1.9b key B unexpected: status=$B_STATUS tier=$B_TIER active_count=$ACTIVE_COUNT"
+
+  echo "--- C1.10 (G0): API key refresh branch ---"
+  ACTIVE_COUNT=$(run_sql -c "SELECT count(*) FROM license_keys WHERE user_id='$SSO_USER_ID' AND status='active';")
+  [ "$ACTIVE_COUNT" = "1" ] && ok "C1.10 key B confirmed sole active key before refresh call" || bad "C1.10 expected 1 active key, got $ACTIVE_COUNT"
+  BEFORE_EXPIRES=$(run_sql -c "SELECT expires_at FROM license_keys WHERE id='$KEY_B_ID';")
+  echo "  key B before refresh: tier=$B_TIER expires_at=$BEFORE_EXPIRES"
+
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token1.txt" '{}')
+  assert_status 200 "$STATUS" "C1.10 record_sso_login callable (reusing C1.1's still-valid session, C1.3's G-2 patch still live -- no login has happened since)"
+  echo "[G-2 SUBSTITUTED CLAIM] C1.10"
+  STATUS_VAL=$(jq -r '.status' "$WORKDIR/last_body.json")
+  if [ "$STATUS_VAL" = "ok" ]; then ok "C1.10 record_sso_login returns status=ok (refresh branch reachable)"; else
+    bad "C1.10 expected status=ok, got $STATUS_VAL -- refresh branch not reached (body: $(last_body))"
+  fi
+
+  AFTER_EXPIRES=$(run_sql -c "SELECT expires_at FROM license_keys WHERE id='$KEY_B_ID';")
+  AFTER_META=$(run_sql -c "SELECT metadata FROM license_keys WHERE id='$KEY_B_ID';")
+  echo "  key B after refresh: tier=$B_TIER expires_at=$AFTER_EXPIRES metadata=$AFTER_META"
+  case "$B_TIER" in
+    team|enterprise)
+      ok "C1.10 key B's tier ($B_TIER) IS in the refresh-eligible set (team,enterprise)"
+      if [ "$AFTER_EXPIRES" != "$BEFORE_EXPIRES" ] && [ -n "$AFTER_EXPIRES" ]; then
+        ok "C1.10 expires_at changed after refresh (bound to sso_verified_at+reverify_days, not left as-is)"
+      else
+        bad "C1.10 expected expires_at to change/bind after the refresh branch fired, before=$BEFORE_EXPIRES after=$AFTER_EXPIRES"
+      fi
+      ;;
+    *)
+      bad "C1.10 FINDING: key B's tier ($B_TIER) is OUTSIDE (team,enterprise) -- the Wave-5 refresh/reissue/deprovisioning story does not apply to it; this key would outlive expiry indefinitely. Recording as a finding per the matrix's own instruction."
+      ;;
+  esac
+  echo "$B_TIER" > "$WORKDIR/key_b_tier"
+
+  echo "=== end phase chain1 === PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED"
+
+  checkpoint_pause "B-CP1" \
+    "C1.10 (key B active and refresh-bound, membership fresh, grant live)" \
+    "U1.1-U1.4 (provenance rendering, the member viewer's payload check), U3.1-U3.3 (key page as an SSO user), U7.1 \"before\" (approve/deprecate controls enabled under the C1.7 grant)" \
+    "SSO + LEGACY + OWNER session tokens; the sk_live_* key string; the fixture team id"
+}
+

--- a/scripts/staging/smi-6200-e3-uat-chain.phase234.sh
+++ b/scripts/staging/smi-6200-e3-uat-chain.phase234.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# smi-6200-e3-uat-chain.phase234.sh -- phase_chain2/3/4 (C1.11-C1.16), split out of
+# smi-6200-e3-uat-chain.sh to stay under the repo's 500-line file limit.
+# Sourced by smi-6200-e3-uat-chain.sh -- never run directly.
+
+phase_chain2() {
+  echo "=== PHASE: chain2 (C1.11 - C1.12) ==="
+  SSO_USER_ID=$(cat "$WORKDIR/sso_user_id")
+  KEY_B_ID=$(cat "$WORKDIR/key_b_id")
+
+  echo "--- C1.11 (G0): second live session ---"
+  SSO_USER_ID2=$(mock_saml_login "$SSO_EMAIL" "$WORKDIR/sso_token2.txt")
+  [ "$SSO_USER_ID2" = "$SSO_USER_ID" ] && ok "C1.11 second login resolves to the SAME SSO identity" \
+    || bad "C1.11 second login resolved to a DIFFERENT user id: $SSO_USER_ID2 != $SSO_USER_ID"
+  echo "  [identity_data overwritten by this login -- C1.13's re-prime is NOT optional]"
+
+  for name in sso_token1 sso_token2; do
+    HTTP=$(curl -s -o /dev/null -w '%{http_code}' "$STAGING_SUPABASE_URL/rest/v1/profiles?select=id" \
+      -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/$name.txt")")
+    [ "$HTTP" = "200" ] && ok "C1.11 $name still authenticates (HTTP 200 on /profiles)" || bad "C1.11 $name failed to authenticate: HTTP $HTTP"
+  done
+
+  echo "--- C1.12 (G0): removal/expiry with a live session present ---"
+  run_sql -c "
+    UPDATE team_sso_settings SET reverify_days = 1 WHERE team_id = '$TEAM_ID';
+    UPDATE team_members SET sso_verified_at = now() - interval '2 days'
+     WHERE team_id = '$TEAM_ID' AND user_id = '$SSO_USER_ID';
+  " >/dev/null
+  echo "  reverify_days=1, sso_verified_at backdated 2 days"
+
+  ELIGIBLE=$(run_sql -c "SELECT sso_expiry_eligible('$TEAM_ID');")
+  [ "$ELIGIBLE" = "t" ] && ok "C1.12(b) sso_expiry_eligible(TEAM) = true before sweeping" \
+    || bad "C1.12(b) expected sso_expiry_eligible=true, got '$ELIGIBLE'"
+
+  echo "--- P-8 interlude (between C1.12b and C1.12c): the expiry-pause safety valve ---"
+  run_sql -c "UPDATE team_sso_settings SET status = 'inactive' WHERE team_id = '$TEAM_ID';" >/dev/null
+  ELIGIBLE_PAUSED=$(run_sql -c "SELECT sso_expiry_eligible('$TEAM_ID');")
+  [ "$ELIGIBLE_PAUSED" = "f" ] && ok "P-8 sso_expiry_eligible(TEAM) = false once settings.status='inactive' (safety valve engaged)" \
+    || bad "P-8 expected sso_expiry_eligible=false with inactive settings, got '$ELIGIBLE_PAUSED'"
+  SWEPT_PAUSED=$(run_sql -c "SELECT expire_stale_sso_members();")
+  [ "$SWEPT_PAUSED" = "0" ] && ok "P-8 sweep returns 0 while the team's own SSO is broken (paused, not silently expiring everyone)" \
+    || bad "P-8 expected sweep to return 0 while paused, got $SWEPT_PAUSED"
+  STATUS=$(rpc has_team_permission "$WORKDIR/sso_token2.txt" "$(jq -n '{p_team_id:"'"$TEAM_ID"'",p_permission:"registry:approve"}')")
+  assert_status 200 "$STATUS" "P-8 has_team_permission callable as SSO while settings paused"
+  PERM_VAL=$(jq -r '.' "$WORKDIR/last_body.json")
+  [ "$PERM_VAL" = "false" ] && ok "P-8 has_team_permission still denies the stale member (frozen: denied AND unexpirable) while paused" \
+    || charz "P-8 has_team_permission returned $PERM_VAL while paused -- SSO's role is currently 'admin' (re-derived at C1.10, see the P-1 note below), which may hold registry:approve via the unrelated DEFAULT admin grant rather than the C1.7 grant (scoped to role=member, now orphaned) -- recording the live value rather than assuming"
+  run_sql -c "UPDATE team_sso_settings SET status = 'active' WHERE team_id = '$TEAM_ID';" >/dev/null
+  echo "  restored status='active'"
+
+  echo "  [P-1 LIVE FINDING, discovered at C1.10, relevant here] SSO's role was 'member' right"
+  echo "  after C1.6's link (matching LEGACY's role, and what C1.7's grant was scoped to)."
+  echo "  C1.10's own record_sso_login() call -- required by the matrix to exercise the key-"
+  echo "  refresh branch -- re-derived role from the (G-2 substituted) group mapping and"
+  echo "  silently reverted it to 'admin'. This is DOCUMENTED, intentional product design"
+  echo "  (20260829230000_sso_member_lifecycle.sql's own comment: \"on an sso-provisioned row"
+  echo "  the moved role IS still re-derived from IdP groups at the member's next login... the"
+  echo "  IdP is the authority on role\"), not a bug -- but it means poison P-1's real trigger"
+  echo "  is broader than the matrix's own text implies: ANY subsequent record_sso_login()"
+  echo "  call for an sso-provisioned row re-derives role, not only a SECOND LINK. The C1.7"
+  echo "  grant (scoped to role='member') is now orphaned per poison P-3 -- it applies to"
+  echo "  nobody, since SSO no longer holds 'member' and nobody else does either."
+  charz "P-1's real trigger condition is broader than the matrix's C1.7/P-1 narrative -- any post-link record_sso_login() call re-derives role from current group mapping and can silently orphan a role-scoped grant, not only a second identity-link"
+  run_sql_aligned -c "SELECT role, provisioned_via, sso_verified_at FROM team_members WHERE team_id='$TEAM_ID' AND user_id='$SSO_USER_ID';"
+  GRANT_STILL_EXISTS=$(run_sql -c "SELECT count(*) FROM team_permission_grants WHERE team_id='$TEAM_ID' AND role='member' AND permission='registry:approve';")
+  echo "  team_permission_grants row for (TEAM, member, registry:approve) still exists: $GRANT_STILL_EXISTS (P-3: grant survives, now applies to nobody)"
+
+  echo "--- C1.12(c): sweep, with session 2 still live ---"
+  SWEPT=$(run_sql -c "SELECT expire_stale_sso_members();")
+  echo "  expire_stale_sso_members() returned: $SWEPT"
+  [ "${SWEPT:-0}" -ge "1" ] 2>/dev/null && ok "C1.12(c) sweep returns >=1" || bad "C1.12(c) expected sweep to return >=1, got '$SWEPT'"
+
+  TM_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id='$TEAM_ID' AND user_id='$SSO_USER_ID';")
+  [ "$TM_COUNT" = "0" ] && ok "C1.12(c) SSO's team_members row is gone" || bad "C1.12(c) expected 0 team_members rows, got $TM_COUNT"
+
+  STATUS=$(rpc has_team_permission "$WORKDIR/sso_token2.txt" "$(jq -n '{p_team_id:"'"$TEAM_ID"'",p_permission:"registry:approve"}')")
+  assert_status 200 "$STATUS" "C1.12(c) has_team_permission callable as SSO (session 2, still valid JWT) after expiry"
+  assert_jq_eq '.' 'false' "C1.12(c) has_team_permission denies SSO for registry:approve after expiry"
+  for perm in registry:deprecate team:manage_rbac team:manage_sso; do
+    STATUS=$(rpc has_team_permission "$WORKDIR/sso_token2.txt" "$(jq -n --arg p "$perm" '{p_team_id:"'"$TEAM_ID"'",p_permission:$p}')")
+    assert_status 200 "$STATUS" "C1.12(c) has_team_permission callable for $perm"
+    assert_jq_eq '.' 'false' "C1.12(c) has_team_permission denies SSO for $perm after expiry"
+  done
+
+  ENT_KEY_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$KEY_B_ID';")
+  ENT_KEY_REVOKED_BY=$(run_sql -c "SELECT metadata->>'revoked_by' FROM license_keys WHERE id='$KEY_B_ID';")
+  [ "$ENT_KEY_STATUS" = "revoked" ] && [ "$ENT_KEY_REVOKED_BY" = "sso_expiry" ] && \
+    ok "C1.12(c) key B (enterprise) revoked with revoked_by=sso_expiry" \
+    || bad "C1.12(c) expected key B revoked/sso_expiry, got status=$ENT_KEY_STATUS revoked_by=$ENT_KEY_REVOKED_BY"
+
+  PURGE_COUNT=$(run_sql -c "SELECT count(*) FROM team_member_inventory_purge_schedule WHERE user_id='$SSO_USER_ID' AND departed_team_id='$TEAM_ID';")
+  [ "${PURGE_COUNT:-0}" -ge "1" ] 2>/dev/null && ok "C1.12(c) team_member_inventory_purge_schedule row exists for SSO" \
+    || bad "C1.12(c) expected >=1 purge-schedule row, got $PURGE_COUNT"
+
+  AUDIT_COUNT=$(run_sql -c "SELECT count(*) FROM audit_logs WHERE event_type='sso:expired' AND metadata->>'user_id'='$SSO_USER_ID';")
+  [ "${AUDIT_COUNT:-0}" -ge "1" ] 2>/dev/null && ok "C1.12(c) sso:expired audit_logs row exists" || bad "C1.12(c) expected an sso:expired audit row, got $AUDIT_COUNT"
+
+  HTTP=$(curl -s -o /dev/null -w '%{http_code}' "$STAGING_SUPABASE_URL/rest/v1/profiles?select=id" \
+    -H "apikey: $STAGING_SUPABASE_ANON_KEY" -H "Authorization: Bearer $(cat "$WORKDIR/sso_token2.txt")")
+  [ "$HTTP" = "200" ] && ok "C1.12(c) session 2's JWT STILL authenticates post-expiry (the acknowledged gap -- confirmed to be the ONLY thing that survives)" \
+    || bad "C1.12(c) expected session 2 to still authenticate, got HTTP $HTTP"
+
+  echo "  production cadence note: expire_stale_sso_members runs via pg_cron 'daily-expire-stale-sso-members' at 04:25 UTC, deliberately after sso-domain-reverify at 04:07 UTC."
+
+  echo "=== end phase chain2 === PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED"
+
+  checkpoint_pause "B-CP2" \
+    "C1.12 (sweep has run; membership gone; key revoked)" \
+    "U1.5 (expired member's card gone), U7.1 \"after\" (same controls now disabled), U7.2/U7.3 (unconverted surfaces)" \
+    "The same tokens -- deliberately, since the point is that the JWT still authenticates while the membership does not"
+}
+
+phase_chain3() {
+  echo "=== PHASE: chain3 (C1.13 - C1.14) ==="
+  SSO_USER_ID=$(cat "$WORKDIR/sso_user_id")
+  LEGACY_ID=$(cat "$WORKDIR/legacy_id")
+  KEY_A_ID=$(cat "$WORKDIR/key_a_id")
+  KEY_B_ID=$(cat "$WORKDIR/key_b_id")
+  LEGACY_ENT_KEY_ID=$(cat "$WORKDIR/legacy_ent_key_id")
+  LEGACY_IND_KEY_ID=$(cat "$WORKDIR/legacy_ind_key_id")
+
+  echo "--- C1.13 (G0): re-authentication after expiry, from the stale session (session 2) ---"
+  echo "  [TIMING LIMITATION, stated up front] The matrix's C1.13 precondition is a token"
+  echo "  'whose amr timestamp predates the sweep'. record_sso_login()'s fresh-INSERT path"
+  echo "  (20260829230000_sso_member_lifecycle.sql:1043, step 5) stamps sso_verified_at from"
+  echo "  v_bind.authenticated_at -- the JWT's OWN signed amr timestamp, confirmed via source,"
+  echo "  NEVER now(). Session 2 (C1.11) authenticated only minutes before this step in a"
+  echo "  same-session compressed execution -- its REAL amr timestamp therefore postdates the"
+  echo "  artificial backdating this harness applied directly to the team_members ROW for"
+  echo "  C1.12's sweep (a raw SQL UPDATE, not a JWT property). A genuinely stale JWT would"
+  echo "  require real elapsed time >= reverify_days (minimum 1 day, the column's own CHECK"
+  echo "  floor) between C1.11's login and this step, which a single continuous session cannot"
+  echo "  produce, and forging a JWT would defeat the whole point of using real GoTrue-issued"
+  echo "  tokens. Running the call for real below and reporting the ACTUAL outcome, then"
+  echo "  separately reconstructing the P-5 duplicate-purge-row concern via direct backdating"
+  echo "  (the same technique C1.12 already used), which does not depend on JWT freshness."
+  uncov "C1.13's own headline assertion (member row re-created with a STALE sso_verified_at, producing zero permissions) -- session 2's real amr timestamp is fresh in this compressed execution, not stale; see timing-limitation note"
+
+  g2_patch_and_verify "$SSO_USER_ID"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token2.txt" '{}')
+  assert_status 200 "$STATUS" "C1.13 record_sso_login callable with session 2's token, re-primed"
+  echo "[G-2 SUBSTITUTED CLAIM] C1.13"
+  echo "  actual response: $(last_body)"
+  C13_STATUS=$(jq -r '.status' "$WORKDIR/last_body.json")
+  if [ "$C13_STATUS" = "ok" ]; then ok "C1.13 record_sso_login returns status=ok (re-prime succeeded)"; else
+    bad "C1.13 expected status=ok after re-prime, got $C13_STATUS"
+  fi
+  run_sql_aligned -c "SELECT role, provisioned_via, sso_verified_at FROM team_members WHERE team_id='$TEAM_ID' AND user_id='$SSO_USER_ID';"
+  TM_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id='$TEAM_ID' AND user_id='$SSO_USER_ID';")
+  [ "$TM_COUNT" = "1" ] && ok "C1.13 a team_members row was re-created for SSO" || bad "C1.13 expected exactly 1 re-created row, got $TM_COUNT"
+  STATUS=$(rpc has_team_permission "$WORKDIR/sso_token2.txt" "$(jq -n '{p_team_id:"'"$TEAM_ID"'",p_permission:"registry:approve"}')")
+  PERM_NOW=$(jq -r '.' "$WORKDIR/last_body.json")
+  echo "  [OBSERVED, not the matrix's expected precondition] has_team_permission(registry:approve) as SSO right after re-creation = $PERM_NOW (expected true here, since sso_verified_at is genuinely fresh in this run -- the mirror image of the matrix's stale-token scenario, still a valid confirmation that the freshness gate reads the real stamp rather than always denying a re-created row)"
+
+  echo "--- P-5 reconstruction: duplicate purge-schedule rows across a SECOND expire cycle ---"
+  echo "  Simulating the passage of time directly on the freshly re-created row (same"
+  echo "  technique C1.12 used), so this exercises P-5's real concern -- does an"
+  echo "  expire -> re-login -> expire cycle produce a SECOND purge-schedule row -- without"
+  echo "  depending on a naturally stale JWT."
+  run_sql -c "UPDATE team_members SET sso_verified_at = now() - interval '2 days' WHERE team_id='$TEAM_ID' AND user_id='$SSO_USER_ID';" >/dev/null
+  SWEPT2=$(run_sql -c "SELECT expire_stale_sso_members();")
+  echo "  second sweep returned: $SWEPT2"
+  PURGE_COUNT2=$(run_sql -c "SELECT count(*) FROM team_member_inventory_purge_schedule WHERE user_id='$SSO_USER_ID' AND departed_team_id='$TEAM_ID';")
+  echo "  team_member_inventory_purge_schedule rows for (SSO,TEAM) after the second sweep: $PURGE_COUNT2"
+  if [ "${PURGE_COUNT2:-0}" -gt "1" ] 2>/dev/null; then
+    bad "P-5 CONFIRMED: >1 purge-schedule rows for the same (user,team) pair after a second expire cycle ($PURGE_COUNT2 rows) -- expire_stale_sso_members() does not de-duplicate against an existing pending purge-schedule row for the same departure pair"
+  else
+    ok "P-5 not reproduced: $PURGE_COUNT2 purge-schedule row(s) for (SSO,TEAM) after a second expire cycle"
+  fi
+  run_sql_aligned -c "SELECT id, scheduled_purge_at, purged_at, cancelled_reason FROM team_member_inventory_purge_schedule WHERE user_id='$SSO_USER_ID' AND departed_team_id='$TEAM_ID' ORDER BY created_at;"
+
+  echo "--- C1.14 (G0): re-authentication after expiry, from a FRESH session ---"
+  SSO_USER_ID3=$(mock_saml_login "$SSO_EMAIL" "$WORKDIR/sso_token3.txt")
+  [ "$SSO_USER_ID3" = "$SSO_USER_ID" ] && ok "C1.14 fresh login resolves to the same SSO identity" || bad "C1.14 fresh login user id mismatch"
+  g2_patch_and_verify "$SSO_USER_ID"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.14 record_sso_login callable with the fresh session, re-primed"
+  echo "[G-2 SUBSTITUTED CLAIM] C1.14"
+  C14_STATUS=$(jq -r '.status' "$WORKDIR/last_body.json")
+  [ "$C14_STATUS" = "ok" ] && ok "C1.14 record_sso_login returns status=ok" || bad "C1.14 expected status=ok, got $C14_STATUS (body: $(last_body))"
+
+  TIER_AFTER=$(run_sql -c "SELECT tier FROM profiles WHERE id='$SSO_USER_ID';")
+  echo "  profiles.tier after C1.14's login: $TIER_AFTER"
+  [ "$TIER_AFTER" = "enterprise" ] && ok "C1.14 profiles.tier restored to enterprise via recompute_user_tier()" \
+    || bad "C1.14 expected tier=enterprise restored, got $TIER_AFTER"
+
+  KEY_B_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$KEY_B_ID';")
+  KEY_B_REVOKED_BY=$(run_sql -c "SELECT metadata->>'revoked_by' FROM license_keys WHERE id='$KEY_B_ID';")
+  [ "$KEY_B_STATUS" = "active" ] && [ -z "$KEY_B_REVOKED_BY" ] && \
+    ok "C1.14 key B un-revoked (status=active, revoked_by marker cleared) -- reissue via UPDATE, matched on revoked_by=sso_expiry" \
+    || bad "C1.14 expected key B active with revoked_by cleared, got status=$KEY_B_STATUS revoked_by=$KEY_B_REVOKED_BY"
+
+  echo "--- C1.14 three negative assertions (one per revocation-marker cohort) ---"
+  LEGACY_ENT_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$LEGACY_ENT_KEY_ID';")
+  LEGACY_ENT_REVOKED_BY=$(run_sql -c "SELECT metadata->>'revoked_by' FROM license_keys WHERE id='$LEGACY_ENT_KEY_ID';")
+  [ "$LEGACY_ENT_STATUS" = "revoked" ] && [ "$LEGACY_ENT_REVOKED_BY" = "sso_account_link" ] && \
+    ok "C1.14(a) LEGACY's enterprise key STILL revoked (revoked_by=sso_account_link, wrong marker for reissue)" \
+    || bad "C1.14(a) expected LEGACY enterprise key still revoked/sso_account_link, got status=$LEGACY_ENT_STATUS revoked_by=$LEGACY_ENT_REVOKED_BY"
+
+  LEGACY_IND_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$LEGACY_IND_KEY_ID';")
+  [ "$LEGACY_IND_STATUS" = "active" ] && ok "C1.14(b) LEGACY's individual key never touched (still active)" \
+    || bad "C1.14(b) expected LEGACY individual key still active, got $LEGACY_IND_STATUS"
+
+  KEY_A_STATUS=$(run_sql -c "SELECT status FROM license_keys WHERE id='$KEY_A_ID';")
+  KEY_A_REVOKED_BY=$(run_sql -c "SELECT metadata->>'revoked_by' FROM license_keys WHERE id='$KEY_A_ID';")
+  [ "$KEY_A_STATUS" = "revoked" ] && [ -z "$KEY_A_REVOKED_BY" ] && \
+    ok "C1.14(c) key A (C1.9b's no-marker fixture) STILL revoked, no marker at all -- pinned by id, not 'some revoked key'" \
+    || bad "C1.14(c) expected key A still revoked with no revoked_by, got status=$KEY_A_STATUS revoked_by='$KEY_A_REVOKED_BY'"
+
+  echo "=== end phase chain3 === PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED"
+
+  checkpoint_pause "B-CP3" \
+    "C1.14 (re-authenticated, tier and key restored)" \
+    "U3.4 (revoke via the UI here, not earlier -- this is the last checkpoint, so the revocation lands after C1.14's assertions are already made and cannot corrupt them; note it revokes AND regenerates, per the endpoint's real behavior), U2.x if the link UI is being re-walked" \
+    "Fresh post-restore session token; the post-U3.4 key id, since it differs from key B"
+}
+
+phase_chain4() {
+  echo "=== PHASE: chain4 (C1.15 - C1.16) ==="
+  SSO2_EMAIL="e2e-e3-6200-ssouser2@example.com"
+  OWNER_ID=$(cat "$WORKDIR/owner_id")
+
+  echo "--- C1.15 (G0): seat guard under real pressure ---"
+  MEMBER_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id='$TEAM_ID';")
+  echo "  current team_members count: $MEMBER_COUNT (max_members=3)"
+  [ "$MEMBER_COUNT" = "3" ] && ok "C1.15 team already at max_members=3 (no artificial pressure needed)" \
+    || bad "C1.15 expected team already at capacity (3), got $MEMBER_COUNT"
+
+  ensure_clean_email "$SSO2_EMAIL"
+  run_sql -c "
+    INSERT INTO team_invitations (team_id, invited_email, role, token, invited_by)
+    VALUES ('$TEAM_ID', 'e2e-e3-6200-pending-invite@example.com', 'member',
+            encode(gen_random_bytes(32), 'hex'), '$OWNER_ID')
+    ON CONFLICT (team_id, invited_email) WHERE status='pending' DO NOTHING;
+  " >/dev/null
+  PENDING_COUNT=$(run_sql -c "SELECT count(*) FROM team_invitations WHERE team_id='$TEAM_ID' AND status='pending' AND expires_at > now();")
+  echo "  pending non-expired invitations: $PENDING_COUNT"
+
+  SSO2_USER_ID=$(mock_saml_login "$SSO2_EMAIL" "$WORKDIR/sso2_token.txt")
+  echo "  JIT-attempt identity: $SSO2_USER_ID"
+  g2_patch_and_verify "$SSO2_USER_ID"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso2_token.txt" '{}')
+  assert_status 200 "$STATUS" "C1.15 record_sso_login callable for the new identity"
+  echo "[G-2 SUBSTITUTED CLAIM] C1.15"
+  echo "  response: $(last_body)"
+  assert_jq_eq '.status' 'refused' "C1.15 new SSO identity refused (seat pressure)"
+  assert_jq_eq '.reason' 'seat_limit_reached' "C1.15 refusal reason is seat_limit_reached"
+  NEW_TM_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id='$TEAM_ID' AND user_id='$SSO2_USER_ID';")
+  [ "$NEW_TM_COUNT" = "0" ] && ok "C1.15 no team_members row created for the refused new identity" || bad "C1.15 expected 0 rows, got $NEW_TM_COUNT"
+
+  echo "  confirming the guard is NEW-member-only: existing SSO identity still refreshes fine under the same pressure"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.15 existing SSO member's record_sso_login still callable"
+  assert_jq_eq '.status' 'ok' "C1.15 existing member refresh NOT refused by the seat guard"
+
+  echo "--- C1.16: closed refusal vocabulary ---"
+  echo "--- (a) settings status=inactive -> sso_inactive ---"
+  run_sql -c "UPDATE team_sso_settings SET status='inactive' WHERE team_id='$TEAM_ID';" >/dev/null
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.16(a) record_sso_login callable"
+  assert_jq_eq '.status' 'refused' "C1.16(a) refused"
+  assert_jq_eq '.reason' 'sso_inactive' "C1.16(a) reason=sso_inactive"
+  STATUS=$(rpc sso_login_refusal_reason "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.16(a) sso_login_refusal_reason callable"
+  assert_jq_eq '.' 'sso_inactive' "C1.16(a) sso_login_refusal_reason() agrees with the RPC's own reason"
+  run_sql -c "UPDATE team_sso_settings SET status='active' WHERE team_id='$TEAM_ID';" >/dev/null
+
+  echo "--- (b) domain verified_at=NULL -> domain_not_verified ---"
+  run_sql -c "UPDATE team_sso_domains SET verified_at=NULL WHERE team_id='$TEAM_ID' AND domain='$SAML_DOMAIN';" >/dev/null
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.16(b) record_sso_login callable"
+  assert_jq_eq '.status' 'refused' "C1.16(b) refused"
+  assert_jq_eq '.reason' 'domain_not_verified' "C1.16(b) reason=domain_not_verified"
+  STATUS=$(rpc sso_login_refusal_reason "$WORKDIR/sso_token3.txt" '{}')
+  assert_jq_eq '.' 'domain_not_verified' "C1.16(b) sso_login_refusal_reason() agrees"
+  run_sql -c "UPDATE team_sso_domains SET verified_at=now() WHERE team_id='$TEAM_ID' AND domain='$SAML_DOMAIN';" >/dev/null
+
+  echo "--- (c) team_sso_settings row deleted -> provider_not_registered ---"
+  run_sql -c "DELETE FROM team_sso_settings WHERE team_id='$TEAM_ID';" >/dev/null
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.16(c) record_sso_login callable"
+  assert_jq_eq '.status' 'refused' "C1.16(c) refused"
+  assert_jq_eq '.reason' 'provider_not_registered' "C1.16(c) reason=provider_not_registered"
+  STATUS=$(rpc sso_login_refusal_reason "$WORKDIR/sso_token3.txt" '{}')
+  assert_jq_eq '.' 'provider_not_registered' "C1.16(c) sso_login_refusal_reason() agrees"
+  # restore (temp table does not survive across psql invocations -- reinsert from the values
+  # setup already established, rather than depending on the temp table across calls).
+  SAML_PROVIDER_ID=$(cat "$WORKDIR/saml_provider_id")
+  run_sql -c "
+    INSERT INTO team_sso_settings (team_id, supabase_provider_id, reverify_days, role_mapping, status, configured_by)
+    VALUES ('$TEAM_ID', '$SAML_PROVIDER_ID', 1,
+            '{\"admin\":[\"skillsmith-admins\"],\"member\":[\"skillsmith-members\"]}'::jsonb,
+            'active', '$OWNER_ID')
+    ON CONFLICT (team_id) DO UPDATE SET supabase_provider_id = EXCLUDED.supabase_provider_id, status='active';
+  " >/dev/null
+
+  echo "--- (d) non-SSO session (LEGACY's password token) -> not_an_sso_session ---"
+  STATUS=$(rpc record_sso_login "$WORKDIR/legacy_token.txt" '{}')
+  assert_status 200 "$STATUS" "C1.16(d) record_sso_login callable as LEGACY"
+  assert_jq_eq '.status' 'refused' "C1.16(d) refused"
+  assert_jq_eq '.reason' 'not_an_sso_session' "C1.16(d) reason=not_an_sso_session"
+  STATUS=$(rpc sso_login_refusal_reason "$WORKDIR/legacy_token.txt" '{}')
+  assert_jq_eq '.' 'not_an_sso_session' "C1.16(d) sso_login_refusal_reason() agrees"
+
+  echo "--- (e) no_authentication_timestamp ---"
+  uncov "C1.16(e) no_authentication_timestamp is not reachable against Mock SAML -- its amr always carries a real timestamp (per the matrix's own note); recorded as unreached, not silently skipped"
+
+  echo "  confirming the vocabulary re-confirms after full lifecycle (post-restore, real login still works)"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token3.txt" '{}')
+  assert_status 200 "$STATUS" "C1.16 post-restore record_sso_login callable"
+  assert_jq_eq '.status' 'ok' "C1.16 post-restore login succeeds again (settings/domain fully restored)"
+
+  echo "=== end phase chain4 === PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED"
+}
+

--- a/scripts/staging/smi-6200-e3-uat-chain.sh
+++ b/scripts/staging/smi-6200-e3-uat-chain.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# smi-6200-e3-uat-chain.sh -- SMI-6200 E3 UAT scenario matrix, C1 chained lifecycle (Lane A).
+# See docs/internal/implementation/smi-6200-e3-uat-scenario-matrix.md section 5.
+#
+# Usage: varlock run -- ./scripts/staging/smi-6200-e3-uat-chain.sh <phase> [--timeout=<seconds>]
+# Phases run in order; state persists across invocations via $WORKDIR (see helpers).
+#   setup   -- fixture cast + SAML provider/domain + C1.1 (login) + C1.2 (unmapped) + C1.3 (G0/G-2)
+#   chain1  -- C1.4 - C1.10 (link, notify, grant, device-login, shadow check, key fixture, refresh)
+#             then PAUSES at checkpoint B-CP1 (matrix sec.12)
+#   chain2  -- C1.11 - C1.12 (second session, expiry sweep)
+#             then PAUSES at checkpoint B-CP2 (matrix sec.12)
+#   chain3  -- C1.13 - C1.14 (re-auth from stale/fresh session)
+#             then PAUSES at checkpoint B-CP3 (matrix sec.12)
+#   chain4  -- C1.15 - C1.16 (seat guard, refusal vocabulary) -- no checkpoint
+#
+# Checkpoint/sentinel pause protocol (matrix sec.12): chain1/chain2/chain3 each end by
+# writing $WORKDIR/checkpoint-<B-CPn>.json (fixture UUIDs + live session tokens + the
+# matrix's own "fires after"/"browser work"/"state handed off" text) and then BLOCKING,
+# polling every 2s, until a browser agent (or a human) `touch`es the matching
+# $WORKDIR/go-<B-CPn> sentinel file. This is what stops the chain from racing straight
+# through C1 into the Z-series/Q-series without the required browser verification (see
+# smi-6200-e3-uat-chain.helpers.sh's checkpoint_pause() for the exact JSON shape and the
+# rationale for each design choice). Each pause has a safety-valve timeout, default 30
+# minutes (1800s), configurable via `--timeout=<seconds>` on this invocation or the
+# SMI6200_CHECKPOINT_TIMEOUT_SECONDS env var (the flag wins if both are given) -- past
+# the timeout the phase REFUSES (exit 1) rather than hanging forever.
+set -euo pipefail
+
+# Parse args before sourcing helpers: --timeout, if given, must be exported as
+# SMI6200_CHECKPOINT_TIMEOUT_SECONDS before helpers.sh reads it into
+# CHECKPOINT_TIMEOUT_SECONDS at source time.
+PHASE=""
+for arg in "$@"; do
+  case "$arg" in
+    --timeout=*)
+      export SMI6200_CHECKPOINT_TIMEOUT_SECONDS="${arg#--timeout=}"
+      ;;
+    --timeout)
+      echo "usage: --timeout=<seconds> (equals form only, e.g. --timeout=900)" >&2
+      exit 2
+      ;;
+    -*)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      [ -z "$PHASE" ] && PHASE="$arg"
+      ;;
+  esac
+done
+: "${PHASE:?usage: smi-6200-e3-uat-chain.sh <setup|chain1|chain2|chain3|chain4> [--timeout=<seconds>]}"
+
+source "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/smi-6200-e3-uat-chain.helpers.sh"
+
+phase_setup() {
+  echo "=== PHASE: setup ==="
+  echo "--- pre-flight self-heal ---"
+  for email in "$OWNER_EMAIL" "$ADMIN_EMAIL" "$LEGACY_EMAIL" "$SSO_EMAIL" "$OUTSIDER_EMAIL"; do
+    ensure_clean_email "$email"
+  done
+  run_sql -c "DELETE FROM teams WHERE id = '$TEAM_ID';" >/dev/null
+  LEFTOVER_PROVIDERS=$(curl -s "$STAGING_SUPABASE_URL/auth/v1/admin/sso/providers" \
+    -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    | jq -r --arg d "$SAML_DOMAIN" '.items[] | select(.domains[]?.domain == $d) | .id')
+  for pid in $LEFTOVER_PROVIDERS; do
+    # only remove one WE registered before (tracked in $WORKDIR/saml_provider_id from a
+    # prior partial run) -- never blindly delete every provider on example.com, since a
+    # DIFFERENT concurrent harness (e.g. smi-6205's own run) could legitimately hold one.
+    if [ -f "$WORKDIR/saml_provider_id" ] && [ "$pid" = "$(cat "$WORKDIR/saml_provider_id")" ]; then
+      echo "  (self-heal) deleting our own leftover SAML provider $pid"
+      curl -s -o /dev/null -X DELETE "$STAGING_SUPABASE_URL/auth/v1/admin/sso/providers/$pid" \
+        -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+        -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY"
+    fi
+  done
+
+  echo "--- setup: fixture cast ---"
+  OWNER_ID=$(create_user "$OWNER_EMAIL" "$WORKDIR/owner_pw.txt"); echo "$OWNER_ID" > "$WORKDIR/owner_id"
+  ADMIN_ID=$(create_user "$ADMIN_EMAIL" "$WORKDIR/admin_pw.txt"); echo "$ADMIN_ID" > "$WORKDIR/admin_id"
+  LEGACY_ID=$(create_user "$LEGACY_EMAIL" "$WORKDIR/legacy_pw.txt"); echo "$LEGACY_ID" > "$WORKDIR/legacy_id"
+  OUTSIDER_ID=$(create_user "$OUTSIDER_EMAIL" "$WORKDIR/outsider_pw.txt"); echo "$OUTSIDER_ID" > "$WORKDIR/outsider_id"
+  password_login "$OWNER_EMAIL" "$WORKDIR/owner_pw.txt" "$WORKDIR/owner_token.txt"
+  password_login "$ADMIN_EMAIL" "$WORKDIR/admin_pw.txt" "$WORKDIR/admin_token.txt"
+  password_login "$LEGACY_EMAIL" "$WORKDIR/legacy_pw.txt" "$WORKDIR/legacy_token.txt"
+  password_login "$OUTSIDER_EMAIL" "$WORKDIR/outsider_pw.txt" "$WORKDIR/outsider_token.txt"
+  echo "  owner=$OWNER_ID admin=$ADMIN_ID legacy=$LEGACY_ID outsider=$OUTSIDER_ID"
+
+  echo "--- setup: team + members + LEGACY's two license keys ---"
+  LEGACY_ENT_KEY_ID=$(run_sql -c "SELECT gen_random_uuid()::text;")
+  LEGACY_IND_KEY_ID=$(run_sql -c "SELECT gen_random_uuid()::text;")
+  run_sql -c "
+    INSERT INTO teams (id, name, owner_id, max_members)
+    VALUES ('$TEAM_ID', 'E2E E3 6200 Team', '$OWNER_ID', 3)
+    ON CONFLICT (id) DO UPDATE SET max_members = EXCLUDED.max_members;
+
+    -- LEGACY is deliberately NOT inserted as a team_members row here. max_members=3 and
+    -- OWNER+ADMIN already = 2; if LEGACY joined now the team would already be AT capacity
+    -- before C1.3's own SSO JIT provisioning runs, and record_sso_login()'s seat guard
+    -- (v_member_count + v_pending_count >= v_max_members) would refuse SSO's own
+    -- provisioning with seat_limit_reached -- tripped this live during harness
+    -- construction. LEGACY's team_members row is inserted at the start of chain1, AFTER
+    -- C1.3/G0 has already succeeded with only 2 members, and BEFORE C1.5's link (which is
+    -- what actually needs it, to have a role to move onto the SSO identity).
+    INSERT INTO team_members (team_id, user_id, role, provisioned_via, joined_at)
+    VALUES
+      ('$TEAM_ID', '$OWNER_ID', 'owner', 'manual', now()),
+      ('$TEAM_ID', '$ADMIN_ID', 'admin', 'manual', now())
+    ON CONFLICT (team_id, user_id) DO UPDATE SET role = EXCLUDED.role;
+
+    INSERT INTO license_keys (id, user_id, key_hash, key_prefix, name, tier, status)
+    VALUES
+      ('$LEGACY_ENT_KEY_ID', '$LEGACY_ID', md5('$LEGACY_ENT_KEY_ID'||'ent'), 'sk_e2e_ent', 'E2E fixture (enterprise)', 'enterprise', 'active'),
+      ('$LEGACY_IND_KEY_ID', '$LEGACY_ID', md5('$LEGACY_IND_KEY_ID'||'ind'), 'sk_e2e_ind', 'E2E fixture (individual)', 'individual', 'active')
+    ON CONFLICT (id) DO NOTHING;
+
+    -- FIXTURE FIX (found live during harness construction): a real Enterprise SSO team has
+    -- an active enterprise subscription -- without one, recompute_user_tier() legitimately
+    -- falls back to 'community' for every member (own subs UNION team subs, both filtered to
+    -- active/trialing/past_due; NULL teams.subscription_id contributes nothing), which would
+    -- make C1.9b/C1.10's issued key land at tier=community -- outside the ('team','enterprise')
+    -- set every downstream refresh/reissue/revoke branch is scoped to. This is a fixture gap,
+    -- not a product bug: the product's fallback-to-community behavior is correct given no
+    -- subscription exists.
+    INSERT INTO subscriptions (user_id, tier, status, billing_period, seat_count, current_period_start, current_period_end)
+    VALUES ('$OWNER_ID', 'enterprise', 'active', 'monthly', 10, now(), now() + interval '30 days')
+    ON CONFLICT DO NOTHING;
+
+    -- Fixed (SMI-6200 UAT re-run, 2026-08-31): the original \gset-based capture of the
+    -- just-inserted subscription id doesn't survive run_sql's single -c invocation (psql
+    -- returned a plain SQL syntax error on the literal backslash -- run_sql pipes through
+    -- pooler-psql.sh non-interactively, which does not parse psql meta-commands the way an
+    -- interactive/script session does). Dropped \gset entirely and rely solely on the
+    -- subquery fallback below, which already correctly finds the row whether it was just
+    -- inserted or pre-existing from a prior run -- the COALESCE's first arm was always
+    -- redundant with the second once ON CONFLICT DO NOTHING can no-op.
+    UPDATE teams SET subscription_id = (SELECT id FROM subscriptions WHERE user_id = '$OWNER_ID' AND tier='enterprise' LIMIT 1)
+     WHERE id = '$TEAM_ID' AND subscription_id IS NULL;
+
+    -- Fixed (SMI-6200 UAT re-run, 2026-08-31, live finding): profiles.tier is a
+    -- MATERIALIZED column -- recompute_user_tier() only runs (and only WRITES the new
+    -- value) when explicitly called; it is never triggered automatically by an INSERT
+    -- into subscriptions or teams. The comment above this block assumed inserting the
+    -- subscription would be enough for recompute_user_tier() to '(legitimately) resolve
+    -- to enterprise' -- true of the SELECT the function runs, false of profiles.tier
+    -- actually reflecting that until this call lands. Without it, OWNER/ADMIN/LEGACY's
+    -- own account pages (and C1.9b/C1.10's key issuance) see a stale tier='community'
+    -- despite a genuinely active enterprise subscription -- confirmed live via
+    -- /account/subscription showing "Community Plan" + a not_team_tier gate banner for
+    -- OWNER immediately after this phase, with the DB showing subscription_id correctly
+    -- linked and status='active' the whole time. Call it for every member already on the
+    -- team at this point (owner+admin here; legacy/sso join later and get their own calls
+    -- at their respective join points in chain1).
+    SELECT recompute_user_tier('$OWNER_ID');
+    SELECT recompute_user_tier('$ADMIN_ID');
+  " >/dev/null
+  echo "$LEGACY_ENT_KEY_ID" > "$WORKDIR/legacy_ent_key_id"
+  echo "$LEGACY_IND_KEY_ID" > "$WORKDIR/legacy_ind_key_id"
+  echo "  team ready (max_members=3, 3 members: owner/admin/legacy). legacy keys: ent=$LEGACY_ENT_KEY_ID ind=$LEGACY_IND_KEY_ID"
+
+  echo "--- setup: register Mock SAML provider + SSO settings + verified domain ---"
+  PROVIDER_JSON=$(curl -s -X POST "$STAGING_SUPABASE_URL/auth/v1/admin/sso/providers" \
+    -H "apikey: $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Authorization: Bearer $STAGING_SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Content-Type: application/json" \
+    --data-raw "$(jq -n --arg u "$SAML_METADATA_URL" --arg d "$SAML_DOMAIN" '{type:"saml",metadata_url:$u,domains:[$d]}')")
+  SAML_PROVIDER_ID=$(echo "$PROVIDER_JSON" | jq -r '.id')
+  [ -n "$SAML_PROVIDER_ID" ] && [ "$SAML_PROVIDER_ID" != "null" ] || {
+    echo "REFUSING: SAML provider registration failed: $PROVIDER_JSON" >&2; exit 1; }
+  echo "$SAML_PROVIDER_ID" > "$WORKDIR/saml_provider_id"
+  echo "  registered SAML provider $SAML_PROVIDER_ID"
+
+  run_sql -c "
+    INSERT INTO team_sso_settings (team_id, supabase_provider_id, reverify_days, role_mapping, status, configured_by)
+    VALUES ('$TEAM_ID', '$SAML_PROVIDER_ID', 7,
+            '{\"admin\":[\"skillsmith-admins\"],\"member\":[\"skillsmith-members\"]}'::jsonb,
+            'active', '$OWNER_ID')
+    ON CONFLICT (team_id) DO UPDATE SET supabase_provider_id = EXCLUDED.supabase_provider_id,
+      status = 'active', role_mapping = EXCLUDED.role_mapping;
+
+    INSERT INTO team_sso_domains (team_id, domain, verification_token, verified_at, last_verified_at)
+    VALUES ('$TEAM_ID', '$SAML_DOMAIN', 'e2e-6200-fixture-token', now(), now())
+    ON CONFLICT (team_id, domain) DO UPDATE SET verified_at = now(), last_verified_at = now();
+  " >/dev/null
+  echo "  team_sso_settings + verified domain ready (reverify_days=7)"
+
+  echo "--- C1.1: real Mock SAML login (SSO identity) ---"
+  SSO_USER_ID=$(mock_saml_login "$SSO_EMAIL" "$WORKDIR/sso_token1.txt")
+  echo "$SSO_USER_ID" > "$WORKDIR/sso_user_id"
+  echo "  JIT-provisioned SSO identity: $SSO_USER_ID"
+  PROVIDER_CLAIM=$(jwt_claim "$(cat "$WORKDIR/sso_token1.txt")" '.app_metadata.provider')
+  AMR_METHOD=$(jwt_claim "$(cat "$WORKDIR/sso_token1.txt")" '.amr[0].method')
+  AMR_TS=$(jwt_claim "$(cat "$WORKDIR/sso_token1.txt")" '.amr[0].timestamp')
+  SUB_CLAIM=$(jwt_claim "$(cat "$WORKDIR/sso_token1.txt")" '.sub')
+  echo "$AMR_TS" > "$WORKDIR/c1_amr_ts"
+  echo "  provider=$PROVIDER_CLAIM amr.method=$AMR_METHOD amr.timestamp=$AMR_TS sub=$SUB_CLAIM"
+  [ "$PROVIDER_CLAIM" = "sso:$SAML_PROVIDER_ID" ] && ok "C1.1 provider claim equals team_sso_settings.supabase_provider_id" \
+    || bad "C1.1 provider claim '$PROVIDER_CLAIM' != expected 'sso:$SAML_PROVIDER_ID'"
+  [ "$AMR_METHOD" = "sso/saml" ] && ok "C1.1 amr[0].method == sso/saml" || bad "C1.1 amr[0].method got '$AMR_METHOD'"
+  [ "$SUB_CLAIM" = "$SSO_USER_ID" ] && ok "C1.1 sub claim matches JIT-provisioned user id" || bad "C1.1 sub mismatch"
+
+  echo "--- C1.2: record_sso_login() before G-2 patch (groups-claim ceiling) ---"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token1.txt" '{}')
+  assert_status 200 "$STATUS" "C1.2 record_sso_login callable by real SSO session"
+  assert_jq_eq '.status' 'unmapped' "C1.2 first login with no group match returns status=unmapped"
+  assert_jq_eq '.team_id' "$TEAM_ID" "C1.2 binding resolved the correct team despite unmapped role"
+  TM_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id = '$TEAM_ID' AND user_id = '$SSO_USER_ID';")
+  [ "$TM_COUNT" = "0" ] && ok "C1.2 no team_members row created for unmapped login" \
+    || bad "C1.2 expected 0 team_members rows, got $TM_COUNT"
+  AUDIT_EVENT=$(run_sql -c "SELECT event_type FROM audit_logs WHERE actor = '$SSO_USER_ID' ORDER BY created_at DESC LIMIT 1;")
+  [ "$AUDIT_EVENT" = "sso:login_unmapped" ] && ok "C1.2 audit newest row is sso:login_unmapped" \
+    || bad "C1.2 expected sso:login_unmapped, got '$AUDIT_EVENT'"
+
+  echo "--- C1.3 (G0): G-2 procedure -- patch identity_data, verify, call record_sso_login() with C1.1's token ---"
+  g2_patch_and_verify "$SSO_USER_ID"
+  STATUS=$(rpc record_sso_login "$WORKDIR/sso_token1.txt" '{}')
+  assert_status 200 "$STATUS" "C1.3 record_sso_login callable with G-2 substituted claim"
+  echo "[G-2 SUBSTITUTED CLAIM] C1.3"
+  G0_STATUS=$(jq -r '.status' "$WORKDIR/last_body.json")
+  G0_ROLE=$(jq -r '.role' "$WORKDIR/last_body.json")
+  echo "  G0 result: status=$G0_STATUS role=$G0_ROLE"
+  if [ "$G0_STATUS" = "ok" ] && { [ "$G0_ROLE" = "admin" ] || [ "$G0_ROLE" = "member" ]; }; then
+    ok "G0 PASSED: status=ok role=$G0_ROLE"
+  else
+    bad "G0 FAILED: status=$G0_STATUS role=$G0_ROLE (body: $(last_body))"
+    echo "REFUSING: G0 did not pass -- per the matrix, stop the chain here." >&2
+    echo "PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED"
+    exit 1
+  fi
+  TM_ROW=$(run_sql_aligned -c "SELECT role, provisioned_via, sso_verified_at FROM team_members WHERE team_id = '$TEAM_ID' AND user_id = '$SSO_USER_ID';")
+  echo "$TM_ROW"
+  TM_COUNT=$(run_sql -c "SELECT count(*) FROM team_members WHERE team_id = '$TEAM_ID' AND user_id = '$SSO_USER_ID' AND provisioned_via = 'sso';")
+  [ "$TM_COUNT" = "1" ] && ok "C1.3 exactly one team_members row with provisioned_via='sso'" \
+    || bad "C1.3 expected exactly 1 sso-provisioned team_members row, got $TM_COUNT"
+  echo "$G0_ROLE" > "$WORKDIR/sso_role_after_c13"
+
+  echo "=== end phase setup === PASS=$PASS FAIL=$FAIL UNCOVERED=$UNCOVERED CHARACTERIZED=$CHARACTERIZED"
+}
+
+
+source "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/smi-6200-e3-uat-chain.phase1.sh"
+source "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/smi-6200-e3-uat-chain.phase234.sh"
+
+case "$PHASE" in
+  setup) phase_setup ;;
+  chain1) phase_chain1 ;;
+  chain2) phase_chain2 ;;
+  chain3) phase_chain3 ;;
+  chain4) phase_chain4 ;;
+  *) echo "phase $PHASE not yet implemented in this invocation of the script" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Business Summary

**What shipped:** The final cross-wave UAT report for SMI-6200 E3 Governance GA (SMI-6312), covering the full C1 chained multi-wave journey (JIT SSO provisioning through key re-issuance), browser-verified at all three checkpoints against real staging. Also ships the staging harness scripts that produced it: a real checkpoint-pause mechanism so the chain actually stops for browser verification instead of racing straight through, and five harness bugs fixed along the way — including one in this report's own first draft.

**Quality bar:** The mandatory NEEDLE/GPT-5.6-Sol second-opinion review caught a serious problem in the first draft: four "missing UI" findings were checked against the main checkout while its git `HEAD` sat on a stale, unrelated detached branch, not current `main` — the pages and markup exist and are wired correctly on real `main`. All four were re-verified live this session before the report was corrected, and the corresponding Linear issues were canceled with a plain explanation, not quietly closed. Every finding that remains in the report is either browser-verified live, confirmed via direct SQL/API against staging, or explicitly marked as source-verified-but-not-live-reproduced with the reason stated.

**Found along the way:** The three fix PRs from the earlier half of this same UAT pass (SMI-6318/6319/6321) were merged but sat undeployed to prod for hours — found by post-merge governance retros, deployed and verified live this session. 9 more findings from those retros filed as SMI-6348 through SMI-6352 and SMI-6355 through SMI-6357. The four false "missing UI" findings (originally filed as SMI-6338/6339/6340/6341) were retracted and canceled after the correction above.

**Net result:** SMI-6312's UAT pass is complete, and this report reflects the corrected, verified state. This is the closing deliverable; SMI-6312 itself will be marked Done once the (re-run) NEEDLE second-opinion review and the GitHub tracking issue are also in place.

---

## Technical detail

- `docs/internal/reports/smi-6200-e3-cross-wave-uat-2026-09-01.md` — the report, now including a "Correction" section documenting the false-positive root cause and fix, plus corrected Results/Findings-summary/Harness-quality sections.
- `scripts/staging/smi-6200-e3-uat-chain.sh` split into three files (main + `phase1` + `phase234`) to stay under the 500-line limit; the checkpoint-pause mechanism lives in `smi-6200-e3-uat-chain.helpers.sh`'s `checkpoint_pause()`.
- Harness fixes: dropped a non-functional `\gset` psql meta-command (root cause: `psql -c` never runs its argument through psql's own meta-command parser — confirmed empirically, not an interactivity issue); added missing `recompute_user_tier()` calls after fixture subscription inserts (materialized-column staleness); fixed `ensure_clean_email()`'s self-heal delete (both the `auth.users` delete and, as of this correction, the `device_codes` delete that precedes it) to actually check its own HTTP status instead of silently masking an FK-constraint failure.
- `scripts/staging/smi-6200-e3-orphan-census.sql` — the Z0 orphan-census query set, re-run clean against the freshly-rebuilt C1 fixture.
