### PR TITLE
fix(core,mcp-server,cli): SMI-6343 Wave 2 -- repair content-hash comparison

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skills-directory.ts`'s `hasUpdates` computation (read by `sklx list --outdated`)
+  previously read a nonexistent `contentHash`/`originalContentHash` field off the *parsed
+  SKILL.md* object instead of the manifest entry, so it always fell back to comparing a fresh
+  on-disk hash against `skill_versions`' pre-fix metadata-proxy hash and could not correctly
+  report `hasUpdates: true` (SMI-6343 Wave 2). Now reads the manifest's real recorded install
+  hash and compares it via the shared `compareSkillContentHashes()` comparator, matching the
+  MCP server's `skill_outdated`/`skill_updates` tools.
 - **Fix**: `utils/manifest.ts`'s `saveManifest()` — a homedir-derived manifest write with no
   path-override parameter — now refuses to touch a manifest inside the real user home while
   running under vitest, via `@skillsmith/core`'s newly-exported `assertNotRealUserHome()`

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -12,6 +12,7 @@ import {
   SkillVersionRepository,
   manifestKeyFor,
   compareSkillContentHashes,
+  firstNonBlankHash,
   type Database,
   type SkillManifestEntry,
   type SkillVersionRow,
@@ -132,8 +133,13 @@ export function computeHasUpdates(
   latestVersion: SkillVersionRow | null
 ): boolean {
   if (!latestVersion) return false
-  const manifestHash = manifestEntry?.contentHash ?? manifestEntry?.originalContentHash
-  const installedHash = manifestHash ?? createHash('sha256').update(content, 'utf8').digest('hex')
+  // SMI-6343 (adversarial-review fix): firstNonBlankHash(), not a raw `??`
+  // chain — a blank-but-present contentHash/originalContentHash (`??` only
+  // falls through on null/undefined) must not block falling all the way
+  // through to a freshly-computed on-disk hash.
+  const installedHash =
+    firstNonBlankHash(manifestEntry?.contentHash, manifestEntry?.originalContentHash) ??
+    createHash('sha256').update(content, 'utf8').digest('hex')
   return compareSkillContentHashes(installedHash, latestVersion.content_hash).outcome === 'outdated'
 }
 

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -11,7 +11,10 @@ import {
   SkillParser,
   SkillVersionRepository,
   manifestKeyFor,
+  compareSkillContentHashes,
   type Database,
+  type SkillManifestEntry,
+  type SkillVersionRow,
   type TrustTier,
 } from '@skillsmith/core'
 import { openCliDatabase } from './open-database.js'
@@ -108,6 +111,32 @@ export interface InstalledSkill {
  * the full `Dirent` interface — those mocks never claim to be a symlink, so
  * treating a missing method as `false` preserves their existing behavior.
  */
+/**
+ * SMI-6343 (C2): compute whether a newer registry version exists for an
+ * installed skill, given (in order of preference) the manifest's recorded
+ * install/update-time content hash, else a freshly-computed on-disk SHA-256
+ * of the current SKILL.md content — compared against the most-recently
+ * synced registry content hash via the shared comparator so this can't
+ * silently drift from the other two SMI-6343 consumers (the mcp-server's
+ * skill_outdated / skill_updates tools).
+ *
+ * Exported for direct unit testing — this is the exact logic that fixes the
+ * pre-fix defect (comparing skill_versions' metadata-proxy hash against
+ * either a nonexistent `parsed.contentHash` field or a real on-disk hash,
+ * which meant it always fell into the "real hash vs. proxy hash" branch and
+ * could essentially never report `hasUpdates: true` correctly).
+ */
+export function computeHasUpdates(
+  manifestEntry: SkillManifestEntry | undefined,
+  content: string,
+  latestVersion: SkillVersionRow | null
+): boolean {
+  if (!latestVersion) return false
+  const manifestHash = manifestEntry?.contentHash ?? manifestEntry?.originalContentHash
+  const installedHash = manifestHash ?? createHash('sha256').update(content, 'utf8').digest('hex')
+  return compareSkillContentHashes(installedHash, latestVersion.content_hash).outcome === 'outdated'
+}
+
 async function resolvesToDirectory(
   entryPath: string,
   isDirectory: boolean,
@@ -157,13 +186,22 @@ export async function getSkillsFromDirectory(
   // rather than per-entry — a corrupt/unreadable manifest degrades to
   // "everything in this directory is untracked" rather than throwing
   // during what is otherwise a read-only `list` scan.
+  //
+  // SMI-6343 (C2): also keeps the full entries (not just their keys) around
+  // so `computeHasUpdates()` can read each entry's recorded
+  // contentHash/originalContentHash — the real installed hash, previously
+  // never actually reached (it was mistakenly read off the *parsed SKILL.md*
+  // object below, which has no such fields).
   let manifestKeys: Set<string> | null = null
+  let manifestEntries: Record<string, SkillManifestEntry> = {}
   if (manifestPath) {
     try {
       const manifest = await new ManifestManager(manifestPath).load()
-      manifestKeys = new Set(Object.keys(manifest.installedSkills ?? {}))
+      manifestEntries = manifest.installedSkills ?? {}
+      manifestKeys = new Set(Object.keys(manifestEntries))
     } catch {
       manifestKeys = new Set()
+      manifestEntries = {}
     }
   }
 
@@ -215,27 +253,19 @@ export async function getSkillsFromDirectory(
           const parser = new SkillParser()
           const parsed = parser.parse(content)
 
-          // Determine hasUpdates by comparing the current SKILL.md hash to the
-          // most-recently recorded hash in skill_versions for this skill id.
+          // SMI-6343 (C2): determine hasUpdates via the shared comparator,
+          // preferring the manifest's recorded installed hash over a fresh
+          // on-disk hash — see computeHasUpdates()'s doc comment for why the
+          // pre-fix version of this block never actually reached the
+          // manifest's stored hash.
           let hasUpdates = false
           if (versionRepo && parsed) {
             try {
               const parsedAny = parsed as unknown as Record<string, unknown>
               const skillId = (parsedAny['id'] as string | undefined) ?? entry.name
               const latestVersion = await versionRepo.getLatestVersion(skillId)
-              if (latestVersion) {
-                const currentHash = createHash('sha256').update(content, 'utf8').digest('hex')
-                const storedHash =
-                  (parsedAny['contentHash'] as string | undefined) ??
-                  (parsedAny['originalContentHash'] as string | undefined) ??
-                  ''
-                // hasUpdates = latest recorded hash differs from what we have locally
-                hasUpdates = storedHash !== '' && latestVersion.content_hash !== storedHash
-                // If we have no stored hash, compare against current content hash
-                if (!storedHash) {
-                  hasUpdates = latestVersion.content_hash !== currentHash
-                }
-              }
+              const manifestEntry = manifestEntries[manifestKeyFor(entry.name, effectiveClient)]
+              hasUpdates = computeHasUpdates(manifestEntry, content, latestVersion)
             } catch {
               // Version check failed — safe to ignore, fall back to false
               hasUpdates = false

--- a/packages/cli/tests/skills-directory.hash-comparison.test.ts
+++ b/packages/cli/tests/skills-directory.hash-comparison.test.ts
@@ -118,6 +118,46 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
     ).toBe(true)
   })
 
+  it('falls through a BLANK (whitespace-only) contentHash to originalContentHash (adversarial-review regression)', () => {
+    // The bug this guards: a raw `entry.contentHash ?? entry.originalContentHash`
+    // chain only falls through on null/undefined — a blank-but-present
+    // contentHash would incorrectly "win" with a value the comparator
+    // itself treats as absent, discarding a legitimate originalContentHash.
+    const entry = makeManifestEntry({
+      contentHash: '   ',
+      originalContentHash: sha256('install-time-content'),
+    })
+    expect(
+      computeHasUpdates(
+        entry,
+        'irrelevant on-disk content',
+        makeVersionRow({ content_hash: sha256('install-time-content') })
+      )
+    ).toBe(false)
+    expect(
+      computeHasUpdates(
+        entry,
+        'irrelevant on-disk content',
+        makeVersionRow({ content_hash: sha256('different-registry-content') })
+      )
+    ).toBe(true)
+  })
+
+  it('falls through a BLANK contentHash all the way to a fresh on-disk hash when originalContentHash is also blank/absent', () => {
+    const entry = makeManifestEntry({ contentHash: '   ' })
+    const onDiskContent = 'exact on-disk SKILL.md content'
+    expect(
+      computeHasUpdates(entry, onDiskContent, makeVersionRow({ content_hash: sha256(onDiskContent) }))
+    ).toBe(false)
+    expect(
+      computeHasUpdates(
+        entry,
+        onDiskContent,
+        makeVersionRow({ content_hash: sha256('different-registry-content') })
+      )
+    ).toBe(true)
+  })
+
   it('falls back to a fresh on-disk SHA-256 when there is no manifest entry at all (untracked skill)', () => {
     const onDiskContent = 'untracked skill content'
     expect(

--- a/packages/cli/tests/skills-directory.hash-comparison.test.ts
+++ b/packages/cli/tests/skills-directory.hash-comparison.test.ts
@@ -55,7 +55,11 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
     const registryHash = sha256('registry-content')
     const entry = makeManifestEntry({ contentHash: registryHash })
     expect(
-      computeHasUpdates(entry, 'irrelevant on-disk content', makeVersionRow({ content_hash: registryHash }))
+      computeHasUpdates(
+        entry,
+        'irrelevant on-disk content',
+        makeVersionRow({ content_hash: registryHash })
+      )
     ).toBe(false)
   })
 
@@ -147,7 +151,11 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
     const entry = makeManifestEntry({ contentHash: '   ' })
     const onDiskContent = 'exact on-disk SKILL.md content'
     expect(
-      computeHasUpdates(entry, onDiskContent, makeVersionRow({ content_hash: sha256(onDiskContent) }))
+      computeHasUpdates(
+        entry,
+        onDiskContent,
+        makeVersionRow({ content_hash: sha256(onDiskContent) })
+      )
     ).toBe(false)
     expect(
       computeHasUpdates(
@@ -161,7 +169,11 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
   it('falls back to a fresh on-disk SHA-256 when there is no manifest entry at all (untracked skill)', () => {
     const onDiskContent = 'untracked skill content'
     expect(
-      computeHasUpdates(undefined, onDiskContent, makeVersionRow({ content_hash: sha256(onDiskContent) }))
+      computeHasUpdates(
+        undefined,
+        onDiskContent,
+        makeVersionRow({ content_hash: sha256(onDiskContent) })
+      )
     ).toBe(false)
     expect(
       computeHasUpdates(

--- a/packages/cli/tests/skills-directory.hash-comparison.test.ts
+++ b/packages/cli/tests/skills-directory.hash-comparison.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Unit tests for computeHasUpdates() — SMI-6343 Wave 2 (C2)
+ *
+ * Direct unit tests for the extracted pure comparison helper used by
+ * `getSkillsFromDirectory()` (the function `sklx list --outdated` actually
+ * reads, via `getInstalledSkills()`/`getInstalledSkillsForClient()` ->
+ * `manage.action.ts`). Kept as pure-function tests (no fs/db harness)
+ * because the exact defect this wave fixes — a hand-rolled comparison that
+ * read a nonexistent `contentHash` field off the *parsed SKILL.md* object
+ * instead of the manifest entry, and so always fell back to comparing a
+ * fresh on-disk hash against skill_versions' pre-fix metadata-proxy hash —
+ * lives entirely inside this one function's decision logic.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createHash } from 'crypto'
+import { computeHasUpdates } from '../src/utils/skills-directory.js'
+import type { SkillManifestEntry, SkillVersionRow } from '@skillsmith/core'
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex')
+}
+
+function makeManifestEntry(overrides: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+  return {
+    id: 'community/test-skill',
+    name: 'test-skill',
+    version: '1.0.0',
+    source: 'registry',
+    installPath: '/tmp/skills/test-skill',
+    installedAt: '2026-01-01T00:00:00Z',
+    lastUpdated: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeVersionRow(overrides: Partial<SkillVersionRow> = {}): SkillVersionRow {
+  return {
+    id: 1,
+    skill_id: 'community/test-skill',
+    content_hash: sha256('registry-content'),
+    recorded_at: 1000,
+    semver: '1.0.0',
+    metadata: null,
+    ...overrides,
+  }
+}
+
+describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
+  it('returns false when there is no latest registry version at all', () => {
+    expect(computeHasUpdates(makeManifestEntry(), 'on-disk content', null)).toBe(false)
+  })
+
+  it('returns false when the manifest-recorded contentHash matches the latest registry hash', () => {
+    const registryHash = sha256('registry-content')
+    const entry = makeManifestEntry({ contentHash: registryHash })
+    expect(
+      computeHasUpdates(entry, 'irrelevant on-disk content', makeVersionRow({ content_hash: registryHash }))
+    ).toBe(false)
+  })
+
+  it('returns true when the manifest-recorded contentHash differs from the latest registry hash', () => {
+    const entry = makeManifestEntry({ contentHash: sha256('installed-content') })
+    expect(
+      computeHasUpdates(
+        entry,
+        'irrelevant on-disk content',
+        makeVersionRow({ content_hash: sha256('newer-registry-content') })
+      )
+    ).toBe(true)
+  })
+
+  it('falls back to originalContentHash when contentHash is absent', () => {
+    const entry = makeManifestEntry({
+      originalContentHash: sha256('install-time-content'),
+    })
+    expect(
+      computeHasUpdates(
+        entry,
+        'irrelevant on-disk content',
+        makeVersionRow({ content_hash: sha256('install-time-content') })
+      )
+    ).toBe(false)
+  })
+
+  it('prefers contentHash over originalContentHash when both are present', () => {
+    const entry = makeManifestEntry({
+      contentHash: sha256('latest-installed-content'),
+      originalContentHash: sha256('stale-install-time-content'),
+    })
+    // Registry now matches the ORIGINAL install-time hash, not the latest
+    // update — proves contentHash (not originalContentHash) wins.
+    expect(
+      computeHasUpdates(
+        entry,
+        'irrelevant on-disk content',
+        makeVersionRow({ content_hash: sha256('stale-install-time-content') })
+      )
+    ).toBe(true)
+  })
+
+  it('falls back to a fresh on-disk SHA-256 when the manifest entry has no recorded hash at all', () => {
+    const entry = makeManifestEntry()
+    const onDiskContent = 'exact on-disk SKILL.md content'
+    expect(
+      computeHasUpdates(
+        entry,
+        onDiskContent,
+        makeVersionRow({ content_hash: sha256(onDiskContent) })
+      )
+    ).toBe(false)
+    expect(
+      computeHasUpdates(
+        entry,
+        onDiskContent,
+        makeVersionRow({ content_hash: sha256('different-registry-content') })
+      )
+    ).toBe(true)
+  })
+
+  it('falls back to a fresh on-disk SHA-256 when there is no manifest entry at all (untracked skill)', () => {
+    const onDiskContent = 'untracked skill content'
+    expect(
+      computeHasUpdates(undefined, onDiskContent, makeVersionRow({ content_hash: sha256(onDiskContent) }))
+    ).toBe(false)
+    expect(
+      computeHasUpdates(
+        undefined,
+        onDiskContent,
+        makeVersionRow({ content_hash: sha256('something-else') })
+      )
+    ).toBe(true)
+  })
+})

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skill_versions.content_hash` (`SyncEngine.upsertSkills()`) now records the
+  registry's real SKILL.md content hash instead of a hash of a JSON metadata proxy
+  (`{id, name, description, updated_at}`) — the proxy meant every reader comparing against
+  this column (`skill_outdated`, `skill_updates`, the CLI's `skills-directory.ts`) was
+  structurally unable to detect a real content change (SMI-6343 Wave 2). New migration v18
+  purges pre-fix rows rather than leaving the two incompatible hash spaces mixed in the same
+  table, which would otherwise make every skill with prior history report a universal false
+  "update available". Adds a shared `compareSkillContentHashes()` comparator
+  (`@skillsmith/core`) so the three readers cannot drift apart on this comparison again.
 - **Fix**: `ManifestManager` (`@skillsmith/core/services/skill-manifest`) now refuses to lock
   or write a manifest located inside the real user home while running under vitest
   (SMI-6343 Wave 1). This closes a class of leak evidenced by fixture rows found in a real

--- a/packages/core/src/db/migration-runner.ts
+++ b/packages/core/src/db/migration-runner.ts
@@ -27,6 +27,7 @@ import { MIGRATION_V12_SQL } from './migrations/v12-risk-score-history.js'
 import { MIGRATION_V13_SQL } from './migrations/v13-team-tables.js'
 import { applyMigrationV16 } from './migrations/v16-skill-source.js'
 import { applyMigrationV17 } from './migrations/v17-curated-trust-tier.js'
+import { MIGRATION_V18_SQL } from './migrations/v18-skill-versions-real-content-hash.js'
 import { SCHEMA_SQL, FTS5_MIGRATION_SQL } from './schema-sql.js'
 
 /**
@@ -122,6 +123,12 @@ export const MIGRATIONS: Migration[] = [
     version: 17,
     description: "SMI-4917: widen trust_tier CHECK to allow 'curated'",
     apply: applyMigrationV17,
+  },
+  {
+    version: 18,
+    description:
+      'SMI-6343: skill_versions.content_hash is now a real SKILL.md hash; purge incomparable proxy-hash rows',
+    sql: MIGRATION_V18_SQL,
   },
 ]
 

--- a/packages/core/src/db/migrations/v18-skill-versions-real-content-hash.ts
+++ b/packages/core/src/db/migrations/v18-skill-versions-real-content-hash.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Migration v18 — purge proxy-hash skill_versions history
+ * @module @skillsmith/core/db/migrations/v18-skill-versions-real-content-hash
+ * @see SMI-6343 Wave 2 — repair the content-hash comparison
+ *
+ * `skill_versions.content_hash`'s MEANING changed, not its shape. It used to
+ * be a SHA-256 hash of a JSON metadata proxy (`{id, name, description,
+ * updated_at}`), written by `SyncEngine.upsertSkills()` — never a hash of
+ * real SKILL.md content, even though three consumers (`skill_updates`,
+ * `skill_outdated`, and the CLI's `skills-directory.ts`) all compared against
+ * it as if it were one. As of this migration's companion code change
+ * (`SyncEngine.ts`), it is a real SHA-256 hash of the registry's SKILL.md
+ * content at index time — `ApiSearchResult.content_hash`, already present on
+ * every sync-registry response and previously ignored by the sync writer.
+ *
+ * This migration purges every existing row rather than leaving old
+ * (proxy-hash) and new (real-hash) rows mixed in the same table. Purging is
+ * safe: `skill_versions` carries no FK on `skill_id` — `v5-skill-versions.ts`
+ * documents this as a deliberate soft reference so version history survives
+ * even when a skill is removed from the registry — the table is a
+ * regenerable local cache, and it fully rebuilds on the very next registry
+ * sync (`SyncEngine.sync()` re-records a version for every skill it
+ * upserts).
+ *
+ * Mixing the two hash spaces is NOT safe. A skill with a pre-existing proxy
+ * row would get a new real-hash row on the next sync while its OLDEST
+ * recorded row stays a proxy hash — `skill-updates.ts`'s
+ * `oldest.content_hash !== latest.content_hash` comparison (pre-fix) would
+ * then read `true` for EVERY such skill: a universal false "update
+ * available" regression on a paid Individual+ tool. Purging avoids this
+ * entirely — every row recorded from this point forward is a real content
+ * hash, so any two rows for the same skill are directly, meaningfully
+ * comparable again.
+ */
+export const MIGRATION_V18_SQL = `
+DELETE FROM skill_versions;
+`

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -42,7 +42,9 @@ export type DatabaseType = Database
 // v14, v15: reserved (RBAC, integrations)
 // v16: SMI-4665 source column + extend trust_tier CHECK to allow 'local'
 // v17: SMI-4917 widen trust_tier CHECK to allow 'curated'
-export const SCHEMA_VERSION = 17
+// v18: SMI-6343 skill_versions.content_hash is now a real SKILL.md hash;
+//      purges incomparable proxy-hash rows
+export const SCHEMA_VERSION = 18
 
 /**
  * Initialize the database with the complete schema.

--- a/packages/core/src/exports/services.ts
+++ b/packages/core/src/exports/services.ts
@@ -424,6 +424,16 @@ export { getRegisteredMcpServers } from '../services/skill-installation.helpers.
 // wholesale (as manage.update's suite does) cannot satisfy.
 export { hashContent, manifestKeyFor } from '../services/skill-installation.helpers.js'
 
+// SMI-6343 Wave 2: shared content-hash comparator — consumed by
+// skill_outdated, skill_updates, and the CLI's skills-directory.ts so the
+// three "is this skill outdated" readers can't drift apart on what
+// current/outdated/unknown means.
+export {
+  compareSkillContentHashes,
+  type ContentComparisonOutcome,
+  type ContentComparisonResult,
+} from '../services/skill-content-comparison.js'
+
 // Install/adoption, discovery-tool-consistency, and the billing-relocation
 // notice all live in the sibling services.install.ts (SMI-6274 Wave 4,
 // file-length gate) — re-exported here so the root barrel's own public

--- a/packages/core/src/exports/services.ts
+++ b/packages/core/src/exports/services.ts
@@ -430,6 +430,7 @@ export { hashContent, manifestKeyFor } from '../services/skill-installation.help
 // current/outdated/unknown means.
 export {
   compareSkillContentHashes,
+  firstNonBlankHash,
   type ContentComparisonOutcome,
   type ContentComparisonResult,
 } from '../services/skill-content-comparison.js'

--- a/packages/core/src/services/skill-content-comparison.test.ts
+++ b/packages/core/src/services/skill-content-comparison.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { compareSkillContentHashes } from './skill-content-comparison.js'
+import { compareSkillContentHashes, firstNonBlankHash } from './skill-content-comparison.js'
 
 describe('compareSkillContentHashes', () => {
   it('returns current when both hashes match exactly', () => {
@@ -63,5 +63,37 @@ describe('compareSkillContentHashes', () => {
   it('trims surrounding whitespace before comparing', () => {
     const result = compareSkillContentHashes('  abc123  ', 'abc123')
     expect(result.outcome).toBe('current')
+  })
+})
+
+describe('firstNonBlankHash (adversarial-review addition, SMI-6343)', () => {
+  it('returns the first candidate when it is non-blank', () => {
+    expect(firstNonBlankHash('abc123', 'def456')).toBe('abc123')
+  })
+
+  it('falls through past null/undefined to the next candidate', () => {
+    expect(firstNonBlankHash(null, 'def456')).toBe('def456')
+    expect(firstNonBlankHash(undefined, 'def456')).toBe('def456')
+  })
+
+  it('falls through past a BLANK (whitespace-only) first candidate — the exact case a raw `??` chain gets wrong', () => {
+    // `'   ' ?? 'def456'` would incorrectly return '   ' (?? only falls
+    // through on null/undefined) — this is the whole reason this helper
+    // exists instead of a raw `??` chain at each call site.
+    expect(firstNonBlankHash('   ', 'def456')).toBe('def456')
+    expect(firstNonBlankHash('', 'def456')).toBe('def456')
+  })
+
+  it('trims a winning candidate', () => {
+    expect(firstNonBlankHash('  abc123  ')).toBe('abc123')
+  })
+
+  it('returns null when every candidate is blank/null/undefined', () => {
+    expect(firstNonBlankHash(null, undefined, '   ', '')).toBeNull()
+    expect(firstNonBlankHash()).toBeNull()
+  })
+
+  it('supports three or more candidates (on-disk-hash fallback chains)', () => {
+    expect(firstNonBlankHash('   ', undefined, 'on-disk-hash')).toBe('on-disk-hash')
   })
 })

--- a/packages/core/src/services/skill-content-comparison.test.ts
+++ b/packages/core/src/services/skill-content-comparison.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Unit tests for the shared skill content-hash comparator
+ * @see SMI-6343 Wave 2 — repair the content-hash comparison
+ */
+
+import { describe, it, expect } from 'vitest'
+import { compareSkillContentHashes } from './skill-content-comparison.js'
+
+describe('compareSkillContentHashes', () => {
+  it('returns current when both hashes match exactly', () => {
+    const result = compareSkillContentHashes('abc123', 'abc123')
+    expect(result.outcome).toBe('current')
+    expect(result.reason).toBeUndefined()
+  })
+
+  it('returns outdated when the hashes differ', () => {
+    const result = compareSkillContentHashes('abc123', 'def456')
+    expect(result.outcome).toBe('outdated')
+    expect(result.reason).toBeUndefined()
+  })
+
+  it('returns unknown with a reason when the installed hash is missing', () => {
+    const result = compareSkillContentHashes(null, 'def456')
+    expect(result.outcome).toBe('unknown')
+    expect(result.reason).toMatch(/no installed content hash/i)
+  })
+
+  it('returns unknown with a reason when the installed hash is undefined', () => {
+    const result = compareSkillContentHashes(undefined, 'def456')
+    expect(result.outcome).toBe('unknown')
+    expect(result.reason).toMatch(/no installed content hash/i)
+  })
+
+  it('returns unknown with a reason when the registry hash is missing', () => {
+    const result = compareSkillContentHashes('abc123', null)
+    expect(result.outcome).toBe('unknown')
+    expect(result.reason).toMatch(/no registry content hash/i)
+  })
+
+  it('returns unknown with a reason when the registry hash is undefined', () => {
+    const result = compareSkillContentHashes('abc123', undefined)
+    expect(result.outcome).toBe('unknown')
+    expect(result.reason).toMatch(/no registry content hash/i)
+  })
+
+  it('returns unknown when both hashes are missing', () => {
+    const result = compareSkillContentHashes(null, null)
+    expect(result.outcome).toBe('unknown')
+    expect(result.reason).toMatch(/no installed content hash and no registry content hash/i)
+  })
+
+  it('treats a blank/whitespace-only hash the same as missing', () => {
+    expect(compareSkillContentHashes('   ', 'abc123').outcome).toBe('unknown')
+    expect(compareSkillContentHashes('abc123', '   ').outcome).toBe('unknown')
+    expect(compareSkillContentHashes('', '').outcome).toBe('unknown')
+  })
+
+  it('is case-sensitive — differently-cased hex digests are treated as different hashes', () => {
+    const result = compareSkillContentHashes('ABC123', 'abc123')
+    expect(result.outcome).toBe('outdated')
+  })
+
+  it('trims surrounding whitespace before comparing', () => {
+    const result = compareSkillContentHashes('  abc123  ', 'abc123')
+    expect(result.outcome).toBe('current')
+  })
+})

--- a/packages/core/src/services/skill-content-comparison.ts
+++ b/packages/core/src/services/skill-content-comparison.ts
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview Shared skill content-hash comparator
+ * @module @skillsmith/core/services/skill-content-comparison
+ * @see SMI-6343 Wave 2 — repair the content-hash comparison
+ *
+ * A single comparison function, consumed by every "is this skill outdated"
+ * reader in the codebase (`packages/mcp-server/src/tools/outdated.ts`,
+ * `packages/mcp-server/src/tools/skill-updates.ts`,
+ * `packages/cli/src/utils/skills-directory.ts`) so they cannot drift apart
+ * on what "current" / "outdated" / "unknown" means again — exactly the class
+ * of bug an adversarial review caught in SMI-6343 Wave 1, where one
+ * implementation was fixed and its siblings were left broken.
+ *
+ * Deliberately narrow: this function only adjudicates "do these two hashes
+ * agree," given whatever installed-side and registry-side hash the caller
+ * already resolved (manifest-recorded hash, on-disk SHA-256, live registry
+ * lookup, cached `skill_versions` row — the callers differ on where the
+ * hash comes from, not on how two hashes are compared). Richer per-caller
+ * diagnosis (offline, quota-exhausted, network-error, identity-mismatch,
+ * etc.) is caller-specific context this function has no visibility into —
+ * callers layer their own explanation on top of the `reason` this returns.
+ */
+
+/** The three possible outcomes of comparing an installed hash to a registry hash. */
+export type ContentComparisonOutcome = 'current' | 'outdated' | 'unknown'
+
+/**
+ * Result of {@link compareSkillContentHashes}.
+ */
+export interface ContentComparisonResult {
+  /** current: hashes match. outdated: hashes differ. unknown: no comparison could be made. */
+  outcome: ContentComparisonOutcome
+  /**
+   * Populated only when `outcome === 'unknown'` — explains why no
+   * comparison could be made (missing installed hash, missing registry
+   * hash, or both). Always `undefined` for `current`/`outdated`.
+   */
+  reason?: string
+}
+
+/**
+ * Normalize a hash value: `null`/`undefined`/non-string/blank all collapse
+ * to `null` so every caller's "I don't have this" shape (a missing manifest
+ * field, an absent DB row, an `undefined` API response field) is handled
+ * uniformly regardless of how the caller spells "nothing here."
+ */
+function normalizeHash(hash: string | null | undefined): string | null {
+  if (typeof hash !== 'string') return null
+  const trimmed = hash.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Compare an installed-side content hash against a registry-side content
+ * hash and return a comparison outcome plus (when `unknown`) the reason no
+ * comparison could be made.
+ *
+ * @param installedHash SHA-256 hex digest of what is actually installed —
+ *   e.g. a manifest's recorded `contentHash`/`originalContentHash`, or a
+ *   freshly-computed hash of the on-disk SKILL.md.
+ * @param registryHash  SHA-256 hex digest of the registry's current SKILL.md
+ *   content — e.g. a live `lookupSkillFromRegistry()` result's
+ *   `contentHash`, or the most-recently-synced `skill_versions.content_hash`.
+ */
+export function compareSkillContentHashes(
+  installedHash: string | null | undefined,
+  registryHash: string | null | undefined
+): ContentComparisonResult {
+  const installed = normalizeHash(installedHash)
+  const registry = normalizeHash(registryHash)
+
+  if (installed === null && registry === null) {
+    return {
+      outcome: 'unknown',
+      reason: 'No installed content hash and no registry content hash available for comparison.',
+    }
+  }
+  if (installed === null) {
+    return {
+      outcome: 'unknown',
+      reason: 'No installed content hash recorded — cannot compare against the registry.',
+    }
+  }
+  if (registry === null) {
+    return {
+      outcome: 'unknown',
+      reason: 'No registry content hash available — cannot compare against the installed skill.',
+    }
+  }
+
+  return installed === registry ? { outcome: 'current' } : { outcome: 'outdated' }
+}

--- a/packages/core/src/services/skill-content-comparison.ts
+++ b/packages/core/src/services/skill-content-comparison.ts
@@ -62,9 +62,7 @@ export function normalizeHash(hash: string | null | undefined): string | null {
  * manifest's `contentHash`/`originalContentHash` (or an on-disk fallback)
  * should route through this instead of raw `??` chaining.
  */
-export function firstNonBlankHash(
-  ...candidates: Array<string | null | undefined>
-): string | null {
+export function firstNonBlankHash(...candidates: Array<string | null | undefined>): string | null {
   for (const candidate of candidates) {
     const normalized = normalizeHash(candidate)
     if (normalized !== null) return normalized

--- a/packages/core/src/services/skill-content-comparison.ts
+++ b/packages/core/src/services/skill-content-comparison.ts
@@ -44,10 +44,32 @@ export interface ContentComparisonResult {
  * field, an absent DB row, an `undefined` API response field) is handled
  * uniformly regardless of how the caller spells "nothing here."
  */
-function normalizeHash(hash: string | null | undefined): string | null {
+export function normalizeHash(hash: string | null | undefined): string | null {
   if (typeof hash !== 'string') return null
   const trimmed = hash.trim()
   return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * SMI-6343 (adversarial-review fix): return the first candidate that
+ * normalizes to a non-blank value, else `null`.
+ *
+ * Exists because a bare `a ?? b` precedence chain (the original shape at
+ * both call sites) only falls through on `null`/`undefined` — a blank
+ * string (`''`, whitespace-only) is neither, so `a ?? b` incorrectly
+ * "wins" with a value `normalizeHash()` would itself treat as absent,
+ * silently discarding a legitimate `b`. Every caller selecting between a
+ * manifest's `contentHash`/`originalContentHash` (or an on-disk fallback)
+ * should route through this instead of raw `??` chaining.
+ */
+export function firstNonBlankHash(
+  ...candidates: Array<string | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    const normalized = normalizeHash(candidate)
+    if (normalized !== null) return normalized
+  }
+  return null
 }
 
 /**

--- a/packages/core/src/sync/SyncEngine.ts
+++ b/packages/core/src/sync/SyncEngine.ts
@@ -6,24 +6,12 @@
  * on updated_at timestamps.
  */
 
-import { createHash } from 'crypto'
 import type { SkillsmithApiClient, ApiSearchResult } from '../api/client.js'
 import type { SkillRepository } from '../repositories/SkillRepository.js'
 import type { SyncConfigRepository } from '../repositories/SyncConfigRepository.js'
 import type { SyncHistoryRepository } from '../repositories/SyncHistoryRepository.js'
 import type { SkillVersionRepository } from '../repositories/SkillVersionRepository.js'
 import type { AdvisoryRepository } from '../repositories/AdvisoryRepository.js'
-
-/**
- * Hash a content string using SHA-256 and return the hex digest.
- *
- * NOTE: Duplicated from packages/mcp-server/src/tools/install.conflict-helpers.ts
- * to avoid a circular dependency (core → mcp-server). Implementation is identical.
- * If the hashing algorithm is ever changed it must be updated in both locations.
- */
-function hashContent(content: string): string {
-  return createHash('sha256').update(content, 'utf8').digest('hex')
-}
 
 /**
  * Sync options
@@ -429,14 +417,14 @@ export class SyncEngine {
           })
           updated++
 
-          // Record version hash after successful update
-          const contentProxy = JSON.stringify({
-            id: skill.id,
-            name: skill.name,
-            description: skill.description ?? null,
-            updated_at: skill.updated_at ?? null,
-          })
-          await this.skillVersionRepo.recordVersion(skill.id, hashContent(contentProxy))
+          // SMI-6343 Wave 2: record the registry's real SKILL.md content
+          // hash — never a metadata proxy. When the registry didn't supply
+          // one, skip recordVersion entirely rather than falling back to a
+          // proxy: a missing row is honestly "unknown" to every downstream
+          // comparator, while a proxy row is a lie that reads as a verdict.
+          if (skill.content_hash) {
+            await this.skillVersionRepo.recordVersion(skill.id, skill.content_hash)
+          }
         } else {
           unchanged++
         }
@@ -453,14 +441,11 @@ export class SyncEngine {
         })
         added++
 
-        // Record version hash after successful create
-        const contentProxy = JSON.stringify({
-          id: skill.id,
-          name: skill.name,
-          description: skill.description ?? null,
-          updated_at: skill.updated_at ?? null,
-        })
-        await this.skillVersionRepo.recordVersion(skill.id, hashContent(contentProxy))
+        // SMI-6343 Wave 2: same real-hash-or-skip rule as the update branch
+        // above.
+        if (skill.content_hash) {
+          await this.skillVersionRepo.recordVersion(skill.id, skill.content_hash)
+        }
       }
 
       onProgress?.(i + 1)

--- a/packages/core/src/sync/SyncEngine.ts
+++ b/packages/core/src/sync/SyncEngine.ts
@@ -416,17 +416,28 @@ export class SyncEngine {
             tags: skill.tags,
           })
           updated++
-
-          // SMI-6343 Wave 2: record the registry's real SKILL.md content
-          // hash — never a metadata proxy. When the registry didn't supply
-          // one, skip recordVersion entirely rather than falling back to a
-          // proxy: a missing row is honestly "unknown" to every downstream
-          // comparator, while a proxy row is a lie that reads as a verdict.
-          if (skill.content_hash) {
-            await this.skillVersionRepo.recordVersion(skill.id, skill.content_hash)
-          }
         } else {
           unchanged++
+        }
+
+        // SMI-6343 Wave 2 (adversarial-review fix): record the registry's
+        // real SKILL.md content hash on EVERY sync pass for this skill,
+        // independent of whether its other metadata changed. Originally
+        // this only ran inside the `updated` branch above, which meant a
+        // skill whose `updated_at` doesn't change between syncs (the common
+        // steady-state case for most of the catalog most of the time) would
+        // never regain a skill_versions row after migration v18's purge —
+        // contradicting the migration's own "fully rebuilds on the next
+        // registry sync" rationale. recordVersion() is idempotent
+        // (INSERT OR IGNORE on skill_id+content_hash), so calling it here
+        // unconditionally for an unchanged skill is a no-op once the hash
+        // is already recorded, not a source of duplicate rows or wasted
+        // syncs. Skip entirely (never a proxy fallback) when the registry
+        // didn't supply a content_hash — a missing row is honestly
+        // "unknown" to every downstream comparator, while a proxy row is a
+        // lie that reads as a verdict.
+        if (skill.content_hash) {
+          await this.skillVersionRepo.recordVersion(skill.id, skill.content_hash)
         }
       } else {
         this.skillRepo.create({

--- a/packages/core/src/types/skill.ts
+++ b/packages/core/src/types/skill.ts
@@ -90,7 +90,15 @@ export interface Skill {
   createdAt: string
   updatedAt: string
   // SMI-skill-version-tracking Wave 1: version tracking fields
-  /** SHA-256 hex of the most recently recorded content proxy (optional, populated by SkillVersionRepository) */
+  /**
+   * SHA-256 hex of the most-recently-synced `skill_versions.content_hash`
+   * row for this skill — as of SMI-6343 Wave 2, a real hash of the
+   * registry's SKILL.md content at index time, never a metadata proxy (the
+   * original meaning this comment described). Currently declared but not
+   * populated anywhere in the codebase (no writer/reader references it) —
+   * a future consumer should source it via `SkillVersionRepository`, not
+   * assume it is already wired up.
+   */
   latestContentHash?: string
   /** Number of distinct content hashes recorded for this skill */
   versionCount?: number

--- a/packages/core/tests/db/migration-runner-race.test.ts
+++ b/packages/core/tests/db/migration-runner-race.test.ts
@@ -29,6 +29,7 @@ import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createDatabaseSync } from '../../src/db/createDatabase.js'
 import { SCHEMA_SQL } from '../../src/db/schema-sql.js'
+import { MIGRATION_V5_SQL } from '../../src/db/migrations/v5-skill-versions.js'
 import { closeDatabase } from '../../src/db/schema.js'
 import { isBetterSqlite3Available } from '../../src/db/drivers/betterSqlite3Driver.js'
 
@@ -68,18 +69,27 @@ describe.skipIf(skipIfNoSqlite)('SMI-6003 runMigrations concurrent-migration rac
     mkdirSync(dir, { recursive: true })
     const dbPath = path.join(dir, 'race.db')
 
-    // Set up a "fresh" DB already stamped at v16 — only migration v17 (the
-    // last entry in MIGRATIONS) is pending, so BOTH children will race to
-    // apply and INSERT the exact same version row. This isolates the test
-    // to the check-then-act bug itself (one contested INSERT) rather than
-    // incidental concurrent DDL from re-running the full 17-migration chain
-    // (which would also happen to trip the same bug, just less
-    // deterministically — v17's own apply() short-circuits to a cheap SELECT
-    // probe on a fresh SCHEMA_SQL base, since the base schema already
-    // includes 'curated' in the trust_tier CHECK — see
+    // Set up a "fresh" DB already stamped at v16 — migrations v17 AND v18
+    // (SMI-6343 Wave 2, the last two entries in MIGRATIONS) are pending, so
+    // BOTH children will race to apply and INSERT the same version rows.
+    // This isolates the test to the check-then-act bug itself (contested
+    // INSERTs) rather than incidental concurrent DDL from re-running the
+    // full migration chain (which would also happen to trip the same bug,
+    // just less deterministically — v17's own apply() short-circuits to a
+    // cheap SELECT probe on a fresh SCHEMA_SQL base, since the base schema
+    // already includes 'curated' in the trust_tier CHECK — see
     // migrations/v17-curated-trust-tier.ts).
+    //
+    // v18's `DELETE FROM skill_versions` needs that table to exist, and
+    // SCHEMA_SQL (migration v1's own baseline) never included it — it's
+    // created by migration v5, which this setup deliberately skips (along
+    // with the rest of v2-v16) to keep the race window minimal. Explicitly
+    // replay v5's (idempotent, `CREATE TABLE IF NOT EXISTS`) SQL here so
+    // v18 has a real table to race against, without pulling in the full
+    // v2-v16 chain this test is designed to avoid.
     const setupDb = createDatabaseSync(dbPath)
     setupDb.exec(SCHEMA_SQL)
+    setupDb.exec(MIGRATION_V5_SQL)
     setupDb.prepare('INSERT INTO schema_version (version) VALUES (16)').run()
     closeDatabase(setupDb)
 

--- a/packages/core/tests/sync/SyncEngine.test.ts
+++ b/packages/core/tests/sync/SyncEngine.test.ts
@@ -533,7 +533,10 @@ describe('SyncEngine', () => {
       })
 
       const skillVersionRepo = createMockSkillVersionRepo()
-      const skill = createMockSkill('test/no-hash-update', new Date(Date.now() + 1000).toISOString())
+      const skill = createMockSkill(
+        'test/no-hash-update',
+        new Date(Date.now() + 1000).toISOString()
+      )
       const apiClient = createMockApiClient({ skills: [skill] })
       const engine = new SyncEngine(
         apiClient,

--- a/packages/core/tests/sync/SyncEngine.test.ts
+++ b/packages/core/tests/sync/SyncEngine.test.ts
@@ -549,5 +549,87 @@ describe('SyncEngine', () => {
       expect(result.skillsUpdated).toBe(1)
       expect(skillVersionRepo.recordVersion).not.toHaveBeenCalled()
     })
+
+    it('records the registry content_hash for an UNCHANGED skill (adversarial-review regression)', async () => {
+      // The bug this guards: recordVersion() originally lived only inside
+      // the branch where existing.updatedAt !== skill.updated_at, so a
+      // skill whose metadata hasn't changed since last sync would never
+      // regain a skill_versions row after migration v18's purge —
+      // contradicting the migration's own "fully rebuilds on the next
+      // registry sync" claim for the common case where most of the catalog
+      // doesn't change every sync.
+      const timestamp = new Date().toISOString()
+      skillRepo.create({
+        id: 'test/unchanged-hash',
+        name: 'Skill test/unchanged-hash',
+        trustTier: 'community',
+        tags: ['test'],
+      })
+      db.prepare('UPDATE skills SET updated_at = ? WHERE id = ?').run(
+        timestamp,
+        'test/unchanged-hash'
+      )
+
+      const skillVersionRepo = createMockSkillVersionRepo()
+      const skill: ApiSearchResult = {
+        ...createMockSkill('test/unchanged-hash', timestamp),
+        content_hash: 'realsha256contenthash-unchanged',
+      }
+      const apiClient = createMockApiClient({ skills: [skill] })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        skillVersionRepo
+      )
+
+      const result = await engine.sync()
+
+      expect(result.success).toBe(true)
+      expect(result.skillsUnchanged).toBe(1)
+      expect(result.skillsUpdated).toBe(0)
+      expect(skillVersionRepo.recordVersion).toHaveBeenCalledWith(
+        'test/unchanged-hash',
+        'realsha256contenthash-unchanged'
+      )
+    })
+
+    it('does not record a version for a locally-imported skill even when unchanged', async () => {
+      // SMI-4665's local-import skip must still be honored — the fix above
+      // widens WHEN recordVersion runs, but must not reach past the
+      // pre-existing `existing.source === 'local'` early-continue.
+      const timestamp = new Date().toISOString()
+      skillRepo.create({
+        id: 'test/local-unchanged',
+        name: 'Local Skill',
+        trustTier: 'community',
+        tags: ['test'],
+        source: 'local',
+      })
+      db.prepare('UPDATE skills SET updated_at = ? WHERE id = ?').run(
+        timestamp,
+        'test/local-unchanged'
+      )
+
+      const skillVersionRepo = createMockSkillVersionRepo()
+      const skill: ApiSearchResult = {
+        ...createMockSkill('test/local-unchanged', timestamp),
+        content_hash: 'realsha256contenthash-local',
+      }
+      const apiClient = createMockApiClient({ skills: [skill] })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        skillVersionRepo
+      )
+
+      const result = await engine.sync()
+
+      expect(result.success).toBe(true)
+      expect(skillVersionRepo.recordVersion).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core/tests/sync/SyncEngine.test.ts
+++ b/packages/core/tests/sync/SyncEngine.test.ts
@@ -444,4 +444,110 @@ describe('SyncEngine', () => {
       expect(syncRegistryMock).toHaveBeenCalledWith(expect.objectContaining({ since: undefined }))
     })
   })
+
+  // ===========================================================================
+  // SMI-6343 Wave 2: real content_hash recording (never a metadata proxy)
+  // ===========================================================================
+  describe('recordVersion — real content hash, never a metadata proxy', () => {
+    it('records the registry real content_hash on create, not a metadata proxy', async () => {
+      const skillVersionRepo = createMockSkillVersionRepo()
+      const skill: ApiSearchResult = {
+        ...createMockSkill('test/hash-on-create'),
+        content_hash: 'realsha256contenthash1',
+      }
+      const apiClient = createMockApiClient({ skills: [skill] })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        skillVersionRepo
+      )
+
+      const result = await engine.sync()
+
+      expect(result.success).toBe(true)
+      expect(skillVersionRepo.recordVersion).toHaveBeenCalledWith(
+        'test/hash-on-create',
+        'realsha256contenthash1'
+      )
+    })
+
+    it('records the registry real content_hash on update, not a metadata proxy', async () => {
+      skillRepo.create({
+        id: 'test/hash-on-update',
+        name: 'Old Name',
+        trustTier: 'community',
+        tags: ['old'],
+      })
+
+      const skillVersionRepo = createMockSkillVersionRepo()
+      const skill: ApiSearchResult = {
+        ...createMockSkill('test/hash-on-update', new Date(Date.now() + 1000).toISOString()),
+        content_hash: 'realsha256contenthash2',
+      }
+      const apiClient = createMockApiClient({ skills: [skill] })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        skillVersionRepo
+      )
+
+      const result = await engine.sync()
+
+      expect(result.success).toBe(true)
+      expect(result.skillsUpdated).toBe(1)
+      expect(skillVersionRepo.recordVersion).toHaveBeenCalledWith(
+        'test/hash-on-update',
+        'realsha256contenthash2'
+      )
+    })
+
+    it('skips recordVersion entirely when the registry provides no content_hash (create path)', async () => {
+      const skillVersionRepo = createMockSkillVersionRepo()
+      // createMockSkill() does not set content_hash.
+      const apiClient = createMockApiClient({ skills: [createMockSkill('test/no-hash-create')] })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        skillVersionRepo
+      )
+
+      const result = await engine.sync()
+
+      expect(result.success).toBe(true)
+      expect(result.skillsAdded).toBe(1)
+      expect(skillVersionRepo.recordVersion).not.toHaveBeenCalled()
+    })
+
+    it('skips recordVersion entirely when the registry provides no content_hash (update path)', async () => {
+      skillRepo.create({
+        id: 'test/no-hash-update',
+        name: 'Old Name',
+        trustTier: 'community',
+        tags: ['old'],
+      })
+
+      const skillVersionRepo = createMockSkillVersionRepo()
+      const skill = createMockSkill('test/no-hash-update', new Date(Date.now() + 1000).toISOString())
+      const apiClient = createMockApiClient({ skills: [skill] })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        skillVersionRepo
+      )
+
+      const result = await engine.sync()
+
+      expect(result.success).toBe(true)
+      expect(result.skillsUpdated).toBe(1)
+      expect(skillVersionRepo.recordVersion).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/core/tests/unit/migrations/migration-v18.test.ts
+++ b/packages/core/tests/unit/migrations/migration-v18.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @fileoverview Tests for migration v18 — purge proxy-hash skill_versions history
+ * @see SMI-6343 Wave 2 — repair the content-hash comparison
+ *
+ * Coverage:
+ *  - MIGRATIONS registers v18 with the documented SQL.
+ *  - SCHEMA_VERSION is at least 18.
+ *  - MIGRATION_V18_SQL empties skill_versions of any pre-existing (proxy-hash
+ *    era) rows.
+ *  - A v17 fixture DB upgrades to v18 cleanly via runMigrations, purging a
+ *    legacy row planted before the upgrade.
+ *  - A post-migration registry sync (SyncEngine) repopulates skill_versions
+ *    with a real SKILL.md content hash — never a metadata proxy.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createTestDatabase, closeDatabase, type Database } from '../../helpers/database.js'
+import {
+  getSchemaVersion,
+  SCHEMA_VERSION,
+  runMigrations,
+  MIGRATIONS,
+  createDatabaseAsync,
+  initializeSchema,
+  SCHEMA_SQL,
+} from '../../../src/db/schema.js'
+import { MIGRATION_V18_SQL } from '../../../src/db/migrations/v18-skill-versions-real-content-hash.js'
+import { SyncEngine } from '../../../src/sync/SyncEngine.js'
+import { SkillRepository } from '../../../src/repositories/SkillRepository.js'
+import { SyncConfigRepository } from '../../../src/repositories/SyncConfigRepository.js'
+import { SyncHistoryRepository } from '../../../src/repositories/SyncHistoryRepository.js'
+import { SkillVersionRepository } from '../../../src/repositories/SkillVersionRepository.js'
+import type { SkillsmithApiClient, ApiSearchResult } from '../../../src/api/client.js'
+// The BARE factory (creates no tables) — needed to build a pristine fixture DB
+// whose schema_version table starts empty.
+import { createDatabaseAsync as createBareDatabaseAsync } from '../../../src/db/createDatabase.js'
+
+/**
+ * Build a fixture DB stamped at exactly `targetVersion` by running the base
+ * schema then every migration up to (and including) `targetVersion`. Mirrors
+ * the pattern in migration-v17.test.ts's fixtureAtVersion().
+ */
+async function fixtureAtVersion(targetVersion: number): Promise<Database> {
+  const db = (await createBareDatabaseAsync(':memory:')) as Database
+  db.exec(SCHEMA_SQL)
+  for (const migration of MIGRATIONS) {
+    if (migration.version === 1 || migration.version > targetVersion) continue
+    try {
+      if (migration.apply) {
+        migration.apply(db)
+      } else if (migration.sql !== undefined) {
+        db.exec(migration.sql)
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      if (!msg.includes('duplicate column')) throw error
+    }
+    db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (?)').run(migration.version)
+  }
+  return db
+}
+
+function countSkillVersions(db: Database): number {
+  return (db.prepare('SELECT COUNT(*) as c FROM skill_versions').get() as { c: number }).c
+}
+
+function buildMockApiClient(skills: ApiSearchResult[]): SkillsmithApiClient {
+  return {
+    isOffline: vi.fn().mockReturnValue(false),
+    checkHealth: vi.fn().mockResolvedValue({ status: 'healthy' }),
+    syncRegistry: vi.fn().mockResolvedValue({ data: skills, meta: {} }),
+    search: vi.fn(),
+    getSkill: vi.fn(),
+    getHealthStatus: vi.fn(),
+  } as unknown as SkillsmithApiClient
+}
+
+describe('Migration v18: purge proxy-hash skill_versions history', () => {
+  let db: Database
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('SCHEMA_VERSION is at least 18', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(18)
+  })
+
+  it('MIGRATIONS registers v18 with the expected SQL', () => {
+    const v18 = MIGRATIONS.find((m) => m.version === 18)
+    expect(v18).toBeDefined()
+    expect(v18?.sql).toBe(MIGRATION_V18_SQL)
+    expect(v18?.description).toContain('SMI-6343')
+  })
+
+  it('MIGRATION_V18_SQL empties skill_versions of pre-existing (proxy-hash) rows', () => {
+    db.prepare(`INSERT INTO skill_versions (skill_id, content_hash) VALUES (?, ?)`).run(
+      'legacy/skill',
+      'deadbeef-proxy-hash'
+    )
+    expect(countSkillVersions(db)).toBe(1)
+
+    db.exec(MIGRATION_V18_SQL)
+
+    expect(countSkillVersions(db)).toBe(0)
+  })
+
+  it('is idempotent — running it again on an already-empty table is a no-op', () => {
+    db.exec(MIGRATION_V18_SQL)
+    expect(countSkillVersions(db)).toBe(0)
+    expect(() => db.exec(MIGRATION_V18_SQL)).not.toThrow()
+    expect(countSkillVersions(db)).toBe(0)
+  })
+
+  it('a v17 fixture DB upgrades to v18 cleanly, purging a legacy proxy-hash row planted before the upgrade', async () => {
+    const v17 = await fixtureAtVersion(17)
+    expect(getSchemaVersion(v17)).toBe(17)
+
+    // Plant a legacy (pre-fix) proxy-hash row, as a real pre-migration DB would have.
+    v17
+      .prepare(`INSERT INTO skill_versions (skill_id, content_hash) VALUES (?, ?)`)
+      .run('legacy/proxy-hash-skill', 'legacy-proxy-hash-value')
+    expect(countSkillVersions(v17)).toBe(1)
+
+    const ran = runMigrations(v17)
+    expect(ran).toBeGreaterThanOrEqual(1)
+    expect(getSchemaVersion(v17)).toBe(SCHEMA_VERSION)
+    expect(countSkillVersions(v17)).toBe(0)
+
+    closeDatabase(v17)
+  })
+
+  it('post-migration registry sync repopulates skill_versions with a real content hash, never a metadata proxy', async () => {
+    db.exec(MIGRATION_V18_SQL)
+    expect(countSkillVersions(db)).toBe(0)
+
+    const skillRepo = new SkillRepository(db)
+    const syncConfigRepo = new SyncConfigRepository(db)
+    const syncHistoryRepo = new SyncHistoryRepository(db)
+    const skillVersionRepo = new SkillVersionRepository(db)
+
+    const realContentHash = 'a'.repeat(64) // shape of a real sha256 hex digest
+    const skill: ApiSearchResult = {
+      id: 'community/real-hash-skill',
+      name: 'Real Hash Skill',
+      description: 'test skill',
+      author: 'test-author',
+      repo_url: 'https://github.com/test/real-hash-skill',
+      quality_score: 0.8,
+      trust_tier: 'community',
+      tags: [],
+      content_hash: realContentHash,
+      updated_at: new Date().toISOString(),
+    }
+
+    const apiClient = buildMockApiClient([skill])
+    const engine = new SyncEngine(
+      apiClient,
+      skillRepo,
+      syncConfigRepo,
+      syncHistoryRepo,
+      skillVersionRepo
+    )
+
+    const result = await engine.sync()
+    expect(result.success).toBe(true)
+    expect(result.skillsAdded).toBe(1)
+
+    const latest = await skillVersionRepo.getLatestVersion('community/real-hash-skill')
+    expect(latest).not.toBeNull()
+    expect(latest?.content_hash).toBe(realContentHash)
+
+    // Never a metadata-proxy hash: the proxy was
+    // sha256(JSON.stringify({id, name, description, updated_at})) — a
+    // completely different value from the registry's real content_hash.
+    const metadataProxyShape = JSON.stringify({
+      id: skill.id,
+      name: skill.name,
+      description: skill.description ?? null,
+      updated_at: skill.updated_at ?? null,
+    })
+    expect(latest?.content_hash).not.toBe(metadataProxyShape)
+  })
+
+  it('post-migration registry sync skips recordVersion entirely when the registry provides no content hash', async () => {
+    db.exec(MIGRATION_V18_SQL)
+
+    const skillRepo = new SkillRepository(db)
+    const syncConfigRepo = new SyncConfigRepository(db)
+    const syncHistoryRepo = new SyncHistoryRepository(db)
+    const skillVersionRepo = new SkillVersionRepository(db)
+
+    const skill: ApiSearchResult = {
+      id: 'community/no-hash-skill',
+      name: 'No Hash Skill',
+      description: 'test skill',
+      author: 'test-author',
+      repo_url: 'https://github.com/test/no-hash-skill',
+      quality_score: 0.8,
+      trust_tier: 'community',
+      tags: [],
+      // content_hash intentionally omitted
+      updated_at: new Date().toISOString(),
+    }
+
+    const apiClient = buildMockApiClient([skill])
+    const engine = new SyncEngine(
+      apiClient,
+      skillRepo,
+      syncConfigRepo,
+      syncHistoryRepo,
+      skillVersionRepo
+    )
+
+    const result = await engine.sync()
+    expect(result.success).toBe(true)
+    expect(result.skillsAdded).toBe(1)
+
+    // No row was recorded — a missing hash is honestly "unknown", never a
+    // proxy fabrication.
+    const latest = await skillVersionRepo.getLatestVersion('community/no-hash-skill')
+    expect(latest).toBeNull()
+  })
+
+  it('H1: the skills table itself is unaffected by v18 (only skill_versions is touched)', () => {
+    db.prepare(
+      "INSERT INTO skills (id, name, trust_tier, source) VALUES ('keep-1', 'keep', 'community', 'registry')"
+    ).run()
+
+    db.exec(MIGRATION_V18_SQL)
+
+    const row = db.prepare('SELECT id FROM skills WHERE id = ?').get('keep-1') as
+      | { id: string }
+      | undefined
+    expect(row?.id).toBe('keep-1')
+  })
+
+  it('fresh-install convergence: a brand-new DB has an empty skill_versions table at the current schema version', async () => {
+    const fresh = await createDatabaseAsync(':memory:')
+    initializeSchema(fresh)
+    expect(getSchemaVersion(fresh)).toBe(SCHEMA_VERSION)
+    expect(countSkillVersions(fresh)).toBe(0)
+    closeDatabase(fresh)
+  })
+})

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skill_outdated` and `skill_updates` now compare real content hashes instead of a
+  structurally meaningless proxy comparison (SMI-6343 Wave 2). `skill_outdated` gains a live
+  registry lookup arm (via `lookupSkillFromRegistry()`) with full offline/network-error/
+  monthly-quota degradation handling — it never fails the call, degrading affected rows to
+  `unknown` instead — and fixes a `latest_hash` echo bug where an unchecked skill's hash
+  visually read as "in sync". `skill_updates` now compares the manifest's own recorded
+  installed hash (not `skill_versions`' oldest row, which was never actually tied to an
+  install event) against the current registry hash.
 - **Fix**: `install.helpers.manifest.ts`'s `saveManifest()`/`acquireManifestLock()` — a
   second, complete manifest write stack parallel to `@skillsmith/core`'s `ManifestManager`,
   homedir-derived with no path-override parameter — now refuse to touch a manifest inside the

--- a/packages/mcp-server/src/tools/install.helpers.ts
+++ b/packages/mcp-server/src/tools/install.helpers.ts
@@ -5,7 +5,13 @@
 
 import type { ToolContext } from '../context.js'
 // SMI-2171: Import parseRepoUrl from @skillsmith/core for shared use
-import { parseRepoUrl, QuarantineRepository, type ParsedRepoUrl } from '@skillsmith/core'
+import {
+  parseRepoUrl,
+  QuarantineRepository,
+  SkillsmithError,
+  ErrorCodes,
+  type ParsedRepoUrl,
+} from '@skillsmith/core'
 import { CANONICAL_CLIENT, CLIENT_DISPLAY_LABELS, type ClientId } from '@skillsmith/core/install'
 import { validateTrustTier, type ParsedSkillId, type RegistrySkillInfo } from './install.types.js'
 
@@ -111,7 +117,22 @@ export function parseSkillId(input: string): ParsedSkillId {
  */
 export async function lookupSkillFromRegistry(
   skillId: string,
-  context: ToolContext
+  context: ToolContext,
+  options?: {
+    /**
+     * SMI-6343: invoked when the live call failed specifically because the
+     * caller's monthly API quota is exhausted (`ErrorCodes.NETWORK_QUOTA_
+     * EXCEEDED`, thrown by `SkillsmithApiClient`'s retry loop on a
+     * `monthly_quota_exceeded` 429 body) — lets a batch caller (e.g.
+     * `skill_outdated`'s live registry arm) stop issuing further live calls
+     * for the rest of its run instead of burning one failed call per
+     * remaining skill. Purely additive: this function's existing
+     * swallow-every-other-error-and-fall-back-to-local-DB behavior is
+     * unchanged, and every existing caller that doesn't pass `options` sees
+     * zero behavior change.
+     */
+    onQuotaExceeded?: () => void
+  }
 ): Promise<RegistrySkillInfo | null> {
   // Try API first (primary data source)
   if (!context.apiClient.isOffline()) {
@@ -131,7 +152,10 @@ export async function lookupSkillFromRegistry(
       }
       // API found skill but no repo_url - it's seed data
       return null
-    } catch {
+    } catch (error) {
+      if (error instanceof SkillsmithError && error.code === ErrorCodes.NETWORK_QUOTA_EXCEEDED) {
+        options?.onQuotaExceeded?.()
+      }
       // API failed, fall through to local DB
     }
   }

--- a/packages/mcp-server/src/tools/install.helpers.ts
+++ b/packages/mcp-server/src/tools/install.helpers.ts
@@ -126,12 +126,33 @@ export async function lookupSkillFromRegistry(
      * `monthly_quota_exceeded` 429 body) — lets a batch caller (e.g.
      * `skill_outdated`'s live registry arm) stop issuing further live calls
      * for the rest of its run instead of burning one failed call per
-     * remaining skill. Purely additive: this function's existing
+     * remaining skill. The `error` argument is the caught `SkillsmithError`
+     * itself — its `.message` already carries the used/limit/tier and the
+     * formatted reset-time text (`client.ts`'s quota-error construction),
+     * so a caller building a user-facing diagnosis should read `.message`
+     * rather than re-deriving reset time from `.details.resetsAt`. Purely
+     * additive: this function's existing
      * swallow-every-other-error-and-fall-back-to-local-DB behavior is
      * unchanged, and every existing caller that doesn't pass `options` sees
      * zero behavior change.
      */
-    onQuotaExceeded?: () => void
+    onQuotaExceeded?: (error: unknown) => void
+    /**
+     * SMI-6343 (pr-reviewer-gate fix): invoked for EVERY caught error
+     * (network error, DNS, timeout, quota exceeded — this fires in addition
+     * to, not instead of, `onQuotaExceeded` for the quota case), before
+     * falling through to the local-DB fallback. This function never
+     * rethrows — it always resolves, either to `null` or to a value from
+     * the local-DB fallback (which itself never carries a `contentHash`) —
+     * so a caller that needs to know "the live attempt failed" cannot infer
+     * that from a thrown exception; it never occurs. Without this signal,
+     * a caller like `skill_outdated`'s live registry arm has no way to
+     * distinguish "the registry genuinely has nothing new" from "the live
+     * call broke and we silently got local-DB data (or nothing) instead" —
+     * confirmed by a pr-reviewer-gate finding that the prior fix's `try/catch`
+     * around this function's call site was dead code for this exact reason.
+     */
+    onLiveLookupFailed?: (error: unknown) => void
   }
 ): Promise<RegistrySkillInfo | null> {
   // Try API first (primary data source)
@@ -154,8 +175,9 @@ export async function lookupSkillFromRegistry(
       return null
     } catch (error) {
       if (error instanceof SkillsmithError && error.code === ErrorCodes.NETWORK_QUOTA_EXCEEDED) {
-        options?.onQuotaExceeded?.()
+        options?.onQuotaExceeded?.(error)
       }
+      options?.onLiveLookupFailed?.(error)
       // API failed, fall through to local DB
     }
   }

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -668,8 +668,9 @@ describe('executeOutdated', () => {
       mockedReadFile.mockResolvedValue('latest-content')
       await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
       mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
-        opts?.onQuotaExceeded?.()
-        opts?.onLiveLookupFailed?.(new Error('monthly_quota_exceeded'))
+        const quotaError = new Error('monthly_quota_exceeded')
+        opts?.onQuotaExceeded?.(quotaError)
+        opts?.onLiveLookupFailed?.(quotaError)
         return null
       })
 

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -585,7 +585,11 @@ describe('executeOutdated', () => {
       const skillId = 'community/flaky-with-history'
       mockedLoadManifest.mockResolvedValue(
         manifestWithSkills([
-          { id: skillId, name: 'flaky-with-history', installPath: '/tmp/skills/flaky-with-history' },
+          {
+            id: skillId,
+            name: 'flaky-with-history',
+            installPath: '/tmp/skills/flaky-with-history',
+          },
         ])
       )
       mockedReadFile.mockResolvedValue('latest-content')

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -575,6 +575,64 @@ describe('executeOutdated', () => {
       expect(result.skills.every((s) => s.status === 'unknown')).toBe(true)
     })
 
+    it('reports unknown on a per-skill network error even when stale historical data would say "current" (adversarial-review regression)', async () => {
+      // The bug this guards: a failed live-arm attempt fell back to
+      // historicalHash, producing a DEFINITIVE verdict from data that might
+      // no longer be true. This test plants a historical row that matches
+      // installed content — the exact shape that would incorrectly render
+      // as 'current' under the pre-fix fallback — so it fails loudly if the
+      // regression returns.
+      const skillId = 'community/flaky-with-history'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: skillId, name: 'flaky-with-history', installPath: '/tmp/skills/flaky-with-history' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      // Stale historical row that HAPPENS to match installed content.
+      await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
+      mockedLookupSkillFromRegistry.mockRejectedValueOnce(new Error('ETIMEDOUT'))
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(mockedLookupSkillFromRegistry).toHaveBeenCalledTimes(1)
+      expect(result.skills[0].status).toBe('unknown')
+      expect(result.skills[0].latest_hash).toBe('--------')
+    })
+
+    it('reports unknown for the skill whose own call revealed quota exhaustion, even with matching stale history (adversarial-review regression)', async () => {
+      // lookupSkillFromRegistry swallows the quota error internally and
+      // returns a local-DB-shaped result (no throw) — the pre-fix code had
+      // no way to distinguish this from "no live data, consult history."
+      const skillId = 'community/quota-trigger-with-history'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          {
+            id: skillId,
+            name: 'quota-trigger-with-history',
+            installPath: '/tmp/skills/quota-trigger-with-history',
+          },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
+      mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
+        opts?.onQuotaExceeded?.()
+        return null
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(result.skills[0].status).toBe('unknown')
+      expect(result.skills[0].latest_hash).toBe('--------')
+    })
+
     it('never fails the whole call when the live arm is unavailable for every skill', async () => {
       mockedLoadManifest.mockResolvedValue(
         manifestWithSkills([

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -1,8 +1,10 @@
 /**
  * @fileoverview Unit tests for skill_outdated MCP tool
  * @see SMI-3138: Wave 5 — Dependency intelligence outdated tool
+ * @see SMI-6343 Wave 2 — real content-hash comparison + live registry arm
  */
 
+import { createHash } from 'crypto'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { SkillVersionRepository, SkillDependencyRepository } from '@skillsmith/core'
 import { createTestDatabase, closeDatabase } from '@skillsmith/core/testkit'
@@ -17,16 +19,17 @@ import type { SkillManifest, SkillManifestEntry } from './install.types.js'
 
 vi.mock('./install.helpers.js', () => ({
   loadManifest: vi.fn(),
+  lookupSkillFromRegistry: vi.fn(),
 }))
 
-vi.mock('./install.conflict-helpers.js', () => ({
-  hashContent: vi.fn((content: string) => {
-    // Simple deterministic mock hash
-    if (content === 'latest-content') return 'aabbccdd11223344'
-    if (content === 'old-content') return '11223344aabbccdd'
-    return '0000000000000000'
-  }),
-}))
+// SMI-6343: hashContent is no longer mocked — the original defect (SyncEngine
+// writing a metadata-proxy hash while outdated.ts hashed real content) was
+// invisible to this suite precisely because it faked hashContent() and fed
+// recordVersion() synthetic matching strings. Assert against real SHA-256
+// hashes computed the same way the SUT computes them.
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs')
@@ -39,20 +42,30 @@ vi.mock('fs', async () => {
   }
 })
 
-import { loadManifest } from './install.helpers.js'
+import { loadManifest, lookupSkillFromRegistry } from './install.helpers.js'
 import { promises as fs } from 'fs'
 
 const mockedLoadManifest = vi.mocked(loadManifest)
 const mockedReadFile = vi.mocked(fs.readFile)
+const mockedLookupSkillFromRegistry = vi.mocked(lookupSkillFromRegistry)
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-function makeContext(db: Database): ToolContext {
+/**
+ * SMI-6343: `apiClient.isOffline()` defaults to `true` so every pre-existing
+ * test (written before the live registry arm existed) keeps exercising the
+ * historical-arm-only path unchanged. Tests exercising the live arm pass
+ * `{ online: true }` explicitly.
+ */
+function makeContext(db: Database, opts: { online?: boolean } = {}): ToolContext {
   return {
     db,
     skillDependencyRepository: new SkillDependencyRepository(db),
+    apiClient: {
+      isOffline: () => !opts.online,
+    },
   } as unknown as ToolContext
 }
 
@@ -119,15 +132,16 @@ describe('executeOutdated', () => {
 
     mockedReadFile.mockResolvedValue('latest-content')
 
-    // Insert a version record with the same hash as hashContent('latest-content')
-    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.2.0')
+    // Insert a version record with the same real hash the SUT will compute
+    // for 'latest-content'.
+    await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.2.0')
 
     const result = await executeOutdated({ include_deps: true }, makeContext(db))
 
     expect(result.skills).toHaveLength(1)
     expect(result.skills[0].status).toBe('current')
-    expect(result.skills[0].installed_hash).toBe('aabbccdd')
-    expect(result.skills[0].latest_hash).toBe('aabbccdd')
+    expect(result.skills[0].installed_hash).toBe(sha256('latest-content').slice(0, 8))
+    expect(result.skills[0].latest_hash).toBe(sha256('latest-content').slice(0, 8))
     expect(result.skills[0].semver).toBe('1.2.0')
     expect(result.summary.up_to_date).toBe(1)
     expect(result.summary.outdated).toBe(0)
@@ -141,36 +155,42 @@ describe('executeOutdated', () => {
       ])
     )
 
-    // Local content is old → hashContent returns '11223344aabbccdd'
+    // Local content is old.
     mockedReadFile.mockResolvedValue('old-content')
 
-    // Registry has a different hash
-    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '2.0.0')
+    // Registry has a different (real) hash.
+    await versionRepo.recordVersion(skillId, sha256('latest-content'), '2.0.0')
 
     const result = await executeOutdated({ include_deps: true }, makeContext(db))
 
     expect(result.skills).toHaveLength(1)
     expect(result.skills[0].status).toBe('outdated')
-    expect(result.skills[0].installed_hash).toBe('11223344')
-    expect(result.skills[0].latest_hash).toBe('aabbccdd')
+    expect(result.skills[0].installed_hash).toBe(sha256('old-content').slice(0, 8))
+    expect(result.skills[0].latest_hash).toBe(sha256('latest-content').slice(0, 8))
     expect(result.skills[0].semver).toBe('2.0.0')
     expect(result.summary.outdated).toBe(1)
     expect(result.summary.up_to_date).toBe(0)
   })
 
-  it('reports unknown when no version history exists', async () => {
+  it('reports unknown when no version history exists, and never echoes installed_hash as latest_hash', async () => {
     const skillId = 'community/new-skill'
     mockedLoadManifest.mockResolvedValue(
       manifestWithSkills([{ id: skillId, name: 'new-skill', installPath: '/tmp/skills/new-skill' }])
     )
     mockedReadFile.mockResolvedValue('latest-content')
 
-    // No version records in DB for this skill
+    // No version records in DB for this skill, and offline (default) means
+    // the live arm never runs either — nothing to compare against at all.
 
     const result = await executeOutdated({ include_deps: true }, makeContext(db))
 
     expect(result.skills).toHaveLength(1)
     expect(result.skills[0].status).toBe('unknown')
+    // SMI-6343: the echo-bug fix — an unchecked skill must never render its
+    // own installed_hash as latest_hash (which used to read visually as "in
+    // sync" for a row that was never actually checked).
+    expect(result.skills[0].installed_hash).toBe(sha256('latest-content').slice(0, 8))
+    expect(result.skills[0].latest_hash).toBe('--------')
     expect(result.summary.unknown).toBe(1)
   })
 
@@ -185,8 +205,8 @@ describe('executeOutdated', () => {
     )
     mockedReadFile.mockResolvedValue('latest-content')
 
-    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.0.0')
-    await versionRepo.recordVersion(depSkillId, 'aabbccdd11223344', '1.0.0')
+    await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
+    await versionRepo.recordVersion(depSkillId, sha256('latest-content'), '1.0.0')
 
     // Add a dependency: dep-skill depends on required-skill (which IS installed)
     const depRepo = new SkillDependencyRepository(db)
@@ -226,7 +246,7 @@ describe('executeOutdated', () => {
     )
     mockedReadFile.mockResolvedValue('latest-content')
 
-    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.0.0')
+    await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
 
     const result = await executeOutdated({ include_deps: false }, makeContext(db))
 
@@ -243,7 +263,7 @@ describe('executeOutdated', () => {
     )
     mockedReadFile.mockResolvedValue('latest-content')
 
-    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.0.0')
+    await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
 
     // Add a dependency on a skill that is NOT installed
     const depRepo = new SkillDependencyRepository(db)
@@ -329,7 +349,7 @@ describe('executeOutdated', () => {
     mockedLoadManifest.mockResolvedValue(manifest)
     mockedReadFile.mockResolvedValue('latest-content')
 
-    await versionRepo.recordVersion('community/good-skill', 'aabbccdd11223344', '1.0.0')
+    await versionRepo.recordVersion('community/good-skill', sha256('latest-content'), '1.0.0')
 
     const result = await executeOutdated({ include_deps: true }, makeContext(db))
 
@@ -386,6 +406,7 @@ describe('executeOutdated', () => {
       },
     }
     mockedLoadManifest.mockResolvedValue(noSourceManifest)
+    mockedReadFile.mockResolvedValue('orphan-content')
 
     const result = await executeOutdated({ include_deps: false }, makeContext(db))
 
@@ -412,11 +433,160 @@ describe('executeOutdated', () => {
       },
     }
     mockedLoadManifest.mockResolvedValue(withSourceManifest)
+    mockedReadFile.mockResolvedValue('tracked-content')
 
     const result = await executeOutdated({ include_deps: false }, makeContext(db))
 
     const skill = result.skills[0]
     expect(skill).toBeDefined()
     expect(skill?.hint).toBeUndefined()
+  })
+
+  // ===========================================================================
+  // SMI-6343 Wave 2: live registry arm + degradation contract (H1)
+  // ===========================================================================
+
+  describe('live registry arm', () => {
+    it('skips the live arm entirely when offline, falling back to the historical arm', async () => {
+      const skillId = 'community/offline-skill'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: skillId, name: 'offline-skill', installPath: '/tmp/skills/offline-skill' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
+
+      // makeContext(db) defaults to offline.
+      const result = await executeOutdated({ include_deps: false }, makeContext(db))
+
+      expect(mockedLookupSkillFromRegistry).not.toHaveBeenCalled()
+      expect(result.skills[0].status).toBe('current')
+    })
+
+    it('compares against the live registry hash when online, taking precedence over stale history', async () => {
+      const skillId = 'community/live-current'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: skillId, name: 'live-current', installPath: '/tmp/skills/live-current' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      // Stale historical row would say "outdated" if consulted alone.
+      await versionRepo.recordVersion(skillId, sha256('stale-history'), '1.0.0')
+      mockedLookupSkillFromRegistry.mockResolvedValue({
+        repoUrl: 'https://github.com/community/live-current',
+        name: 'live-current',
+        trustTier: 'community',
+        contentHash: sha256('latest-content'),
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(mockedLookupSkillFromRegistry).toHaveBeenCalledTimes(1)
+      expect(result.skills[0].status).toBe('current')
+      expect(result.skills[0].latest_hash).toBe(sha256('latest-content').slice(0, 8))
+    })
+
+    it('reports outdated when the live registry hash differs from installed', async () => {
+      const skillId = 'community/live-outdated'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: skillId, name: 'live-outdated', installPath: '/tmp/skills/live-outdated' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('old-content')
+      mockedLookupSkillFromRegistry.mockResolvedValue({
+        repoUrl: 'https://github.com/community/live-outdated',
+        name: 'live-outdated',
+        trustTier: 'community',
+        contentHash: sha256('new-content'),
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(result.skills[0].status).toBe('outdated')
+      expect(result.skills[0].latest_hash).toBe(sha256('new-content').slice(0, 8))
+    })
+
+    it('degrades a single skill to unknown on a per-skill network error, while the batch continues', async () => {
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: 'community/flaky', name: 'flaky', installPath: '/tmp/skills/flaky' },
+          { id: 'community/healthy', name: 'healthy', installPath: '/tmp/skills/healthy' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      mockedLookupSkillFromRegistry
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce({
+          repoUrl: 'https://github.com/community/healthy',
+          name: 'healthy',
+          trustTier: 'community',
+          contentHash: sha256('latest-content'),
+        })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(mockedLookupSkillFromRegistry).toHaveBeenCalledTimes(2)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const flaky = result.skills.find((s: any) => s.id === 'community/flaky')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const healthy = result.skills.find((s: any) => s.id === 'community/healthy')
+      expect(flaky?.status).toBe('unknown')
+      expect(healthy?.status).toBe('current')
+    })
+
+    it('stops the live arm for the rest of the run after a quota-exceeded signal', async () => {
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: 'community/quota-1', name: 'quota-1', installPath: '/tmp/skills/quota-1' },
+          { id: 'community/quota-2', name: 'quota-2', installPath: '/tmp/skills/quota-2' },
+          { id: 'community/quota-3', name: 'quota-3', installPath: '/tmp/skills/quota-3' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      // First call signals quota exhaustion (mirrors lookupSkillFromRegistry's
+      // real contract: it swallows the error internally and invokes
+      // onQuotaExceeded before falling back to a local-DB-shaped result).
+      mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
+        opts?.onQuotaExceeded?.()
+        return null
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      // Only the first skill actually reached the live arm — the remaining
+      // two must never burn a failed call each.
+      expect(mockedLookupSkillFromRegistry).toHaveBeenCalledTimes(1)
+      expect(result.skills).toHaveLength(3)
+      expect(result.skills.every((s) => s.status === 'unknown')).toBe(true)
+    })
+
+    it('never fails the whole call when the live arm is unavailable for every skill', async () => {
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: 'community/always-fails', name: 'always-fails', installPath: '/tmp/skills/x' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      mockedLookupSkillFromRegistry.mockRejectedValue(new Error('DNS failure'))
+
+      await expect(
+        executeOutdated({ include_deps: false }, makeContext(db, { online: true }))
+      ).resolves.toBeDefined()
+    })
   })
 })

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -407,11 +407,19 @@ describe('executeOutdated', () => {
     }
     mockedLoadManifest.mockResolvedValue(noSourceManifest)
     mockedReadFile.mockResolvedValue('orphan-content')
+    // SMI-6343: give this skill a matching historical hash so it resolves
+    // to 'current' (not 'unknown') — isolates this test to the SMI-5407
+    // source-hint behavior it's actually about, independent of the new H1
+    // offline-diagnosis hint (also `hint`-carried) that would otherwise
+    // fire for any offline + no-history + unknown row regardless of
+    // whether a source is tracked.
+    await versionRepo.recordVersion('test/orphan-skill', sha256('orphan-content'), '1.0.0')
 
     const result = await executeOutdated({ include_deps: false }, makeContext(db))
 
     const skill = result.skills[0]
     expect(skill).toBeDefined()
+    expect(skill?.status).toBe('current')
     expect(typeof skill?.hint).toBe('string')
     expect(skill?.hint).toContain('audit sources')
     expect(skill?.hint).toContain('skill_recover_source')
@@ -434,11 +442,18 @@ describe('executeOutdated', () => {
     }
     mockedLoadManifest.mockResolvedValue(withSourceManifest)
     mockedReadFile.mockResolvedValue('tracked-content')
+    // SMI-6343: same reasoning as the sibling test above — a matching
+    // historical hash keeps this row 'current', so the new H1
+    // offline-diagnosis hint (which would otherwise fire for ANY offline +
+    // no-history + unknown row, tracked source or not) never enters the
+    // picture, and this test stays isolated to the SMI-5407 behavior.
+    await versionRepo.recordVersion('test/tracked-skill', sha256('tracked-content'), '1.0.0')
 
     const result = await executeOutdated({ include_deps: false }, makeContext(db))
 
     const skill = result.skills[0]
     expect(skill).toBeDefined()
+    expect(skill?.status).toBe('current')
     expect(skill?.hint).toBeUndefined()
   })
 

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -464,6 +464,22 @@ describe('executeOutdated', () => {
       expect(result.skills[0].status).toBe('current')
     })
 
+    it('names offline mode in the hint when offline AND no historical data resolves the row (H1 diagnosis)', async () => {
+      const skillId = 'community/offline-unknown'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: skillId, name: 'offline-unknown', installPath: '/tmp/skills/offline-unknown' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('latest-content')
+      // No recordVersion() call — no historical data either.
+
+      const result = await executeOutdated({ include_deps: false }, makeContext(db))
+
+      expect(result.skills[0].status).toBe('unknown')
+      expect(result.skills[0].hint).toMatch(/offline/i)
+    })
+
     it('compares against the live registry hash when online, taking precedence over stale history', async () => {
       const skillId = 'community/live-current'
       mockedLoadManifest.mockResolvedValue(
@@ -523,8 +539,16 @@ describe('executeOutdated', () => {
         ])
       )
       mockedReadFile.mockResolvedValue('latest-content')
+      // lookupSkillFromRegistry() never rethrows a network error — it
+      // catches it internally and signals via onLiveLookupFailed before
+      // falling through to its own local-DB fallback (which never carries
+      // a contentHash). A mockRejectedValueOnce here would simulate a
+      // shape production code never produces (pr-reviewer-gate finding).
       mockedLookupSkillFromRegistry
-        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockImplementationOnce(async (_id, _ctx, opts) => {
+          opts?.onLiveLookupFailed?.(new Error('ECONNRESET'))
+          return null
+        })
         .mockResolvedValueOnce({
           repoUrl: 'https://github.com/community/healthy',
           name: 'healthy',
@@ -556,10 +580,18 @@ describe('executeOutdated', () => {
       )
       mockedReadFile.mockResolvedValue('latest-content')
       // First call signals quota exhaustion (mirrors lookupSkillFromRegistry's
-      // real contract: it swallows the error internally and invokes
-      // onQuotaExceeded before falling back to a local-DB-shaped result).
+      // real contract: it swallows the error internally, invokes
+      // onQuotaExceeded AND onLiveLookupFailed unconditionally — every
+      // caught error fires the latter — before falling back to a
+      // local-DB-shaped result). The error object is the same
+      // SkillsmithError shape client.ts throws, whose .message already
+      // carries the used/limit/tier + formatted reset-time text.
+      const quotaError = new Error(
+        'Monthly quota reached (100/100 community tier).\nResets in 5 day(s) on Mon, 08 Sep 2026 00:00:00 UTC.\nUpgrade: https://skillsmith.app/pricing'
+      )
       mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
-        opts?.onQuotaExceeded?.()
+        opts?.onQuotaExceeded?.(quotaError)
+        opts?.onLiveLookupFailed?.(quotaError)
         return null
       })
 
@@ -573,15 +605,21 @@ describe('executeOutdated', () => {
       expect(mockedLookupSkillFromRegistry).toHaveBeenCalledTimes(1)
       expect(result.skills).toHaveLength(3)
       expect(result.skills.every((s) => s.status === 'unknown')).toBe(true)
+      // SMI-6343 (H1): every row past the triggering one is unknown BECAUSE
+      // of quota exhaustion (not offline, not a read failure), so all three
+      // get the quota diagnosis — including the reset-time text carried in
+      // the captured error's own message.
+      expect(result.skills.every((s) => s.hint?.includes('Resets in 5 day(s)'))).toBe(true)
     })
 
-    it('reports unknown on a per-skill network error even when stale historical data would say "current" (adversarial-review regression)', async () => {
+    it('reports unknown on a per-skill network error even when stale historical data would say "current" (pr-reviewer-gate regression)', async () => {
       // The bug this guards: a failed live-arm attempt fell back to
       // historicalHash, producing a DEFINITIVE verdict from data that might
       // no longer be true. This test plants a historical row that matches
       // installed content — the exact shape that would incorrectly render
       // as 'current' under the pre-fix fallback — so it fails loudly if the
-      // regression returns.
+      // regression returns. Signals failure via onLiveLookupFailed, not a
+      // rejected promise — lookupSkillFromRegistry() never rethrows.
       const skillId = 'community/flaky-with-history'
       mockedLoadManifest.mockResolvedValue(
         manifestWithSkills([
@@ -595,7 +633,10 @@ describe('executeOutdated', () => {
       mockedReadFile.mockResolvedValue('latest-content')
       // Stale historical row that HAPPENS to match installed content.
       await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
-      mockedLookupSkillFromRegistry.mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
+        opts?.onLiveLookupFailed?.(new Error('ETIMEDOUT'))
+        return null
+      })
 
       const result = await executeOutdated(
         { include_deps: false },
@@ -607,10 +648,13 @@ describe('executeOutdated', () => {
       expect(result.skills[0].latest_hash).toBe('--------')
     })
 
-    it('reports unknown for the skill whose own call revealed quota exhaustion, even with matching stale history (adversarial-review regression)', async () => {
+    it('reports unknown for the skill whose own call revealed quota exhaustion, even with matching stale history (pr-reviewer-gate regression)', async () => {
       // lookupSkillFromRegistry swallows the quota error internally and
       // returns a local-DB-shaped result (no throw) — the pre-fix code had
       // no way to distinguish this from "no live data, consult history."
+      // Fires both onQuotaExceeded and onLiveLookupFailed, matching the
+      // real function's catch block (every caught error, quota included,
+      // fires onLiveLookupFailed unconditionally).
       const skillId = 'community/quota-trigger-with-history'
       mockedLoadManifest.mockResolvedValue(
         manifestWithSkills([
@@ -625,6 +669,7 @@ describe('executeOutdated', () => {
       await versionRepo.recordVersion(skillId, sha256('latest-content'), '1.0.0')
       mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
         opts?.onQuotaExceeded?.()
+        opts?.onLiveLookupFailed?.(new Error('monthly_quota_exceeded'))
         return null
       })
 

--- a/packages/mcp-server/src/tools/outdated.ts
+++ b/packages/mcp-server/src/tools/outdated.ts
@@ -68,8 +68,14 @@ export interface OutdatedSkillInfo {
   /** Dependency satisfaction details (omitted when include_deps is false) */
   dependencies?: DependencyStatus
   /**
-   * SMI-5407: Present when manifest entry lacks a `source` URL. Directs the
-   * user to `sklx audit sources` / `skill_recover_source` to recover.
+   * SMI-5407: present when manifest entry lacks a `source` URL — directs
+   * the user to `sklx audit sources` / `skill_recover_source` to recover.
+   * SMI-6343 (H1): also present, taking precedence over the source-missing
+   * case, when `status === 'unknown'` because the live registry check was
+   * skipped (offline) or stopped (monthly quota exhausted, reset time
+   * included) — the plan's required "diagnosis naming" text for those two
+   * degradation states. A future wave may promote this into a fuller
+   * structured `diagnosis` field; `hint` is the interim carrier.
    */
   hint?: string
 }
@@ -231,6 +237,13 @@ async function executeOutdatedImpl(
   // retry/backoff and need no handling here.
   const liveArmOffline = context.apiClient.isOffline()
   let quotaExhausted = false
+  // SMI-6343 (H1, pr-reviewer-gate fix): captured once, from whichever call
+  // first revealed quota exhaustion — SkillsmithError's own `.message`
+  // already carries the used/limit/tier and formatted reset-time text
+  // (install.helpers.ts's onQuotaExceeded doc comment), so this is reused
+  // verbatim as the diagnosis for every later row that never even attempts
+  // the live arm because quotaExhausted is already true.
+  let quotaDiagnosis: string | undefined
 
   for (const entry of entries) {
     // SMI-3177: Skip corrupt manifest entries with missing installPath
@@ -264,37 +277,48 @@ async function executeOutdatedImpl(
     // for this run, and there is a local hash worth comparing against (no
     // point spending a call when the installed SKILL.md can't even be read).
     let liveHash: string | null = null
-    // SMI-6343 (adversarial-review fix): true only when the live arm was
-    // actually attempted for THIS skill and came back empty-handed
-    // (network error, or this skill's own call is what revealed quota
-    // exhaustion) — distinct from "never attempted" (offline, already
-    // quota-exhausted from an earlier skill, or no local hash to check).
-    // H1's degradation table requires a failed attempt to degrade THIS
-    // skill to `unknown`, never to silently fall back to potentially-stale
-    // history — falling back to history is correct only when the live arm
-    // was skipped outright, not when it was tried and failed.
+    // SMI-6343 (pr-reviewer-gate fix): true whenever the live arm was
+    // actually attempted for THIS skill and lookupSkillFromRegistry()
+    // reported a failure via onLiveLookupFailed — distinct from "never
+    // attempted" (offline, already quota-exhausted from an earlier skill,
+    // or no local hash to check). H1's degradation table requires a failed
+    // attempt to degrade THIS skill to `unknown`, never to silently fall
+    // back to potentially-stale history — falling back to history is
+    // correct only when the live arm was skipped outright, not when it was
+    // tried and failed.
+    //
+    // Driven by the onLiveLookupFailed callback, NOT a try/catch around
+    // this call: lookupSkillFromRegistry() never rethrows — every caught
+    // error inside it (network, DNS, timeout, quota) falls through to a
+    // local-DB fallback that itself never carries a contentHash, so a
+    // try/catch here observes nothing to catch. A pr-reviewer-gate finding
+    // caught this: the adversarial-review round's fix correctly handled
+    // the quota case (via the quotaExhausted flag) but left the generic
+    // network-error case silently falling back to historicalHash, exactly
+    // the bug this whole block exists to prevent.
     let liveArmFailed = false
     if (!liveArmOffline && !quotaExhausted && localHash !== null) {
-      const quotaExhaustedBefore = quotaExhausted
       try {
         const registryInfo = await lookupSkillFromRegistry(entry.id, context, {
-          onQuotaExceeded: () => {
+          onQuotaExceeded: (error) => {
             quotaExhausted = true
+            if (!quotaDiagnosis) {
+              quotaDiagnosis = error instanceof Error ? error.message : String(error)
+            }
+          },
+          onLiveLookupFailed: () => {
+            liveArmFailed = true
           },
         })
         liveHash = registryInfo?.contentHash ?? null
-        // lookupSkillFromRegistry swallows the quota error internally and
-        // falls through to a local-DB-shaped result (no live contentHash)
-        // rather than throwing — so a quota event revealed by THIS call
-        // must be detected via the before/after flag, not a catch block.
-        if (!quotaExhaustedBefore && quotaExhausted) {
-          liveArmFailed = true
-        }
       } catch {
-        // Per-skill network error / DNS / timeout — degrade this one skill
-        // to unknown (not the historical arm); the batch continues. Matches
-        // skill-recover-source.ts's "429 -> []" per-item degradation
-        // contract.
+        // Defense-in-depth only: lookupSkillFromRegistry() never rethrows
+        // in its current implementation (onLiveLookupFailed above is the
+        // real signal for every error it catches internally), but H1
+        // requires this tool to never fail the whole call for any reason —
+        // an unexpected throw here (a future change to the helper, a bad
+        // mock in a caller's test) must still degrade to unknown, not
+        // propagate.
         liveHash = null
         liveArmFailed = true
       }
@@ -326,6 +350,21 @@ async function executeOutdatedImpl(
       unknownCount++
     }
 
+    // SMI-6343 (H1): the plan's degradation contract requires a diagnosis
+    // naming the reason for an offline- or quota-caused `unknown` row.
+    // Gated on localHash !== null so a row that's unknown for an unrelated
+    // reason (SKILL.md unreadable) doesn't get a misleading offline/quota
+    // explanation — offline/quota only actually explain a row that would
+    // otherwise have attempted the live arm.
+    let degradationHint: string | undefined
+    if (status === 'unknown' && localHash !== null) {
+      if (liveArmOffline) {
+        degradationHint = `Registry offline — skipped live check for ${entry.id}; no prior sync history to compare against either.`
+      } else if (quotaExhausted && quotaDiagnosis) {
+        degradationHint = quotaDiagnosis
+      }
+    }
+
     const skillInfo: OutdatedSkillInfo = {
       id: entry.id,
       installed_hash: localHash?.slice(0, 8) ?? '--------',
@@ -339,12 +378,19 @@ async function executeOutdatedImpl(
       semver: historicalSemver,
       // SMI-5407: surface a recovery hint when the manifest entry has no source.
       // The source is needed by skill_diff / View-Changes to fetch the latest
-      // SKILL.md content. Recovering it requires `sklx audit sources`.
-      ...(typeof entry.source !== 'string' || entry.source.trim().length === 0
-        ? {
-            hint: `Source not tracked for ${entry.id}. Run \`sklx audit sources\` (or MCP skill_recover_source) to recover.`,
-          }
-        : {}),
+      // SKILL.md content. Recovering it requires `sklx audit sources`. The
+      // H1 degradation diagnosis (offline / quota) takes precedence when
+      // both would apply — it explains why THIS run's status couldn't be
+      // determined, which is the more actionable, run-specific fact; the
+      // missing-source condition is a standing one that will still be true
+      // next run regardless.
+      ...(degradationHint
+        ? { hint: degradationHint }
+        : typeof entry.source !== 'string' || entry.source.trim().length === 0
+          ? {
+              hint: `Source not tracked for ${entry.id}. Run \`sklx audit sources\` (or MCP skill_recover_source) to recover.`,
+            }
+          : {}),
     }
 
     // Dependency satisfaction

--- a/packages/mcp-server/src/tools/outdated.ts
+++ b/packages/mcp-server/src/tools/outdated.ts
@@ -264,7 +264,18 @@ async function executeOutdatedImpl(
     // for this run, and there is a local hash worth comparing against (no
     // point spending a call when the installed SKILL.md can't even be read).
     let liveHash: string | null = null
+    // SMI-6343 (adversarial-review fix): true only when the live arm was
+    // actually attempted for THIS skill and came back empty-handed
+    // (network error, or this skill's own call is what revealed quota
+    // exhaustion) — distinct from "never attempted" (offline, already
+    // quota-exhausted from an earlier skill, or no local hash to check).
+    // H1's degradation table requires a failed attempt to degrade THIS
+    // skill to `unknown`, never to silently fall back to potentially-stale
+    // history — falling back to history is correct only when the live arm
+    // was skipped outright, not when it was tried and failed.
+    let liveArmFailed = false
     if (!liveArmOffline && !quotaExhausted && localHash !== null) {
+      const quotaExhaustedBefore = quotaExhausted
       try {
         const registryInfo = await lookupSkillFromRegistry(entry.id, context, {
           onQuotaExceeded: () => {
@@ -272,19 +283,35 @@ async function executeOutdatedImpl(
           },
         })
         liveHash = registryInfo?.contentHash ?? null
+        // lookupSkillFromRegistry swallows the quota error internally and
+        // falls through to a local-DB-shaped result (no live contentHash)
+        // rather than throwing — so a quota event revealed by THIS call
+        // must be detected via the before/after flag, not a catch block.
+        if (!quotaExhaustedBefore && quotaExhausted) {
+          liveArmFailed = true
+        }
       } catch {
         // Per-skill network error / DNS / timeout — degrade this one skill
-        // to the historical arm; the batch continues. Matches
+        // to unknown (not the historical arm); the batch continues. Matches
         // skill-recover-source.ts's "429 -> []" per-item degradation
         // contract.
         liveHash = null
+        liveArmFailed = true
       }
     }
 
-    // Live arm wins when available; otherwise fall back to the historical
-    // arm. `null` (neither available) is what fixes the latest_hash echo
-    // bug below — an unchecked skill no longer echoes installed_hash.
-    const registryHash = liveHash ?? historicalHash
+    // Live arm wins when it has data. When the live arm was never
+    // attempted (offline / already quota-exhausted / no local hash), fall
+    // back to the historical arm — a documented "skip entirely"
+    // degradation, not a failure, so stale-but-real history is a
+    // reasonable secondary signal. When the live arm WAS attempted for
+    // this skill but failed, historicalHash is deliberately NOT consulted
+    // (see liveArmFailed above), so this row honestly resolves to
+    // `unknown` via the comparator rather than a definitive verdict built
+    // on data that might no longer be true. `null` (neither available) is
+    // also what fixes the latest_hash echo bug below — an unchecked skill
+    // no longer echoes installed_hash.
+    const registryHash = liveArmFailed ? null : (liveHash ?? historicalHash)
     const comparison = compareSkillContentHashes(localHash, registryHash)
 
     let status: 'current' | 'outdated' | 'unknown'

--- a/packages/mcp-server/src/tools/outdated.ts
+++ b/packages/mcp-server/src/tools/outdated.ts
@@ -15,12 +15,12 @@
 import { z } from 'zod'
 import { promises as fs } from 'fs'
 import * as path from 'path'
-import { SkillVersionRepository } from '@skillsmith/core'
+import { SkillVersionRepository, compareSkillContentHashes } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import type { SkillDependencyRow } from '@skillsmith/core'
 import type { ToolContext } from '../context.js'
 import { hashContent } from './install.conflict-helpers.js'
-import { loadManifest } from './install.helpers.js'
+import { loadManifest, lookupSkillFromRegistry } from './install.helpers.js'
 import { getManifestInstalledSkillIds } from './manifest-skill-ids.helpers.js'
 import type { SkillManifestEntry } from './install.types.js'
 
@@ -221,6 +221,17 @@ async function executeOutdatedImpl(
   let unknownCount = 0
   let missingDepsCount = 0
 
+  // SMI-6343 (H1): the live registry arm is skipped entirely, for every
+  // skill, when offline — never a per-skill error in that case. Monthly
+  // quota exhaustion is detected the first time it occurs (via
+  // lookupSkillFromRegistry's onQuotaExceeded callback) and likewise stops
+  // the live arm for every remaining skill in this run, so a quota-exhausted
+  // batch never burns one failed call per remaining skill. Per-minute
+  // rate-limit 429s are already handled by the API client's own
+  // retry/backoff and need no handling here.
+  const liveArmOffline = context.apiClient.isOffline()
+  let quotaExhausted = false
+
   for (const entry of entries) {
     // SMI-3177: Skip corrupt manifest entries with missing installPath
     if (!entry.installPath) {
@@ -242,37 +253,63 @@ async function executeOutdatedImpl(
     // Hash the currently installed SKILL.md
     const localHash = await readInstalledHash(entry.installPath)
 
-    // Get latest version from registry cache
+    // Historical arm: the most-recently-synced skill_versions row. Valid as
+    // an "ever matched" signal now that SyncEngine records a real SKILL.md
+    // hash instead of a metadata proxy (SMI-6343 Wave 2).
     const history = await versionRepo.getVersionHistory(entry.id, 1)
+    const historicalHash = history.length > 0 ? history[0].content_hash : null
+    const historicalSemver = history.length > 0 ? history[0].semver : null
+
+    // Live registry arm: only attempted when online, not yet quota-exhausted
+    // for this run, and there is a local hash worth comparing against (no
+    // point spending a call when the installed SKILL.md can't even be read).
+    let liveHash: string | null = null
+    if (!liveArmOffline && !quotaExhausted && localHash !== null) {
+      try {
+        const registryInfo = await lookupSkillFromRegistry(entry.id, context, {
+          onQuotaExceeded: () => {
+            quotaExhausted = true
+          },
+        })
+        liveHash = registryInfo?.contentHash ?? null
+      } catch {
+        // Per-skill network error / DNS / timeout — degrade this one skill
+        // to the historical arm; the batch continues. Matches
+        // skill-recover-source.ts's "429 -> []" per-item degradation
+        // contract.
+        liveHash = null
+      }
+    }
+
+    // Live arm wins when available; otherwise fall back to the historical
+    // arm. `null` (neither available) is what fixes the latest_hash echo
+    // bug below — an unchecked skill no longer echoes installed_hash.
+    const registryHash = liveHash ?? historicalHash
+    const comparison = compareSkillContentHashes(localHash, registryHash)
 
     let status: 'current' | 'outdated' | 'unknown'
-    let latestHash: string
-    let semver: string | null = null
-
-    if (history.length === 0 || localHash === null) {
-      status = 'unknown'
-      latestHash = localHash?.slice(0, 8) ?? '--------'
-      unknownCount++
+    if (comparison.outcome === 'current') {
+      status = 'current'
+      upToDateCount++
+    } else if (comparison.outcome === 'outdated') {
+      status = 'outdated'
+      outdatedCount++
     } else {
-      const latest = history[0]
-      semver = latest.semver
-      latestHash = latest.content_hash.slice(0, 8)
-
-      if (localHash === latest.content_hash) {
-        status = 'current'
-        upToDateCount++
-      } else {
-        status = 'outdated'
-        outdatedCount++
-      }
+      status = 'unknown'
+      unknownCount++
     }
 
     const skillInfo: OutdatedSkillInfo = {
       id: entry.id,
       installed_hash: localHash?.slice(0, 8) ?? '--------',
-      latest_hash: latestHash,
+      // SMI-6343: fixes the echo bug — previously this rendered
+      // installed_hash when there was no comparison data at all, which
+      // visually read as "in sync" for a row that was never actually
+      // checked. Now it only ever reflects a real (live or historical)
+      // registry hash, or the honest '--------' placeholder.
+      latest_hash: registryHash ? registryHash.slice(0, 8) : '--------',
       status,
-      semver,
+      semver: historicalSemver,
       // SMI-5407: surface a recovery hint when the manifest entry has no source.
       // The source is needed by skill_diff / View-Changes to fetch the latest
       // SKILL.md content. Recovering it requires `sklx audit sources`.

--- a/packages/mcp-server/src/tools/skill-updates.test.ts
+++ b/packages/mcp-server/src/tools/skill-updates.test.ts
@@ -37,7 +37,9 @@ function emptyManifest(): SkillManifest {
   return { version: '1', installedSkills: {} }
 }
 
-function manifestWithSkills(entries: Array<{ key: string; id: string }>): SkillManifest {
+function manifestWithSkills(
+  entries: Array<{ key: string; id: string; contentHash?: string; originalContentHash?: string }>
+): SkillManifest {
   const installedSkills: SkillManifest['installedSkills'] = {}
   for (const e of entries) {
     installedSkills[e.key] = {
@@ -48,6 +50,10 @@ function manifestWithSkills(entries: Array<{ key: string; id: string }>): SkillM
       installPath: `/tmp/skills/${e.key}`,
       installedAt: '2026-01-01T00:00:00Z',
       lastUpdated: '2026-01-01T00:00:00Z',
+      ...(e.contentHash !== undefined ? { contentHash: e.contentHash } : {}),
+      ...(e.originalContentHash !== undefined
+        ? { originalContentHash: e.originalContentHash }
+        : {}),
     }
   }
   return { version: '1', installedSkills }
@@ -108,11 +114,16 @@ describe('executeSkillUpdates', () => {
   })
 
   it('bounds the default skillIds to the manifest, ignoring registry-wide skill_versions rows', async () => {
+    // SMI-6343 (C1): the manifest's recorded installed hash ('oldoldold1',
+    // what was actually installed) differs from the latest registry hash
+    // ('newnewnew2') -> update available. Version history itself no longer
+    // drives this — only the manifest-vs-latest-registry comparison does.
     mockedLoadManifest.mockResolvedValue(
-      manifestWithSkills([{ key: 'astro', id: 'community/astro' }])
+      manifestWithSkills([
+        { key: 'astro', id: 'community/astro', contentHash: 'oldoldold1' },
+      ])
     )
 
-    // Installed skill: two version records, hash changes -> update available.
     insertVersionAt(db, 'community/astro', 'oldoldold1', '1.0.0', 1000)
     insertVersionAt(db, 'community/astro', 'newnewnew2', '2.0.0', 2000)
 
@@ -129,18 +140,40 @@ describe('executeSkillUpdates', () => {
     expect(result.updatesAvailable).toBe(1)
   })
 
-  it('honors an explicit skillIds filter without consulting the manifest', async () => {
-    // Manifest is empty/irrelevant -- explicit skillIds is an override, same
-    // as before this fix.
-    mockedLoadManifest.mockResolvedValue(emptyManifest())
+  it('honors an explicit skillIds filter, still consulting the manifest for the real installed hash (SMI-6343 C1)', async () => {
+    // SMI-6343 (C1): the manifest is now always loaded — even for an
+    // explicit skillIds override — because it is the only source of the
+    // real recorded installed hash the comparison needs. This replaces the
+    // pre-fix design, where `skillIds` bypassed the manifest entirely and
+    // the comparison used skill_versions' (meaningless) oldest-vs-latest
+    // hashes instead.
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([{ key: 'explicit', id: 'explicit/skill', contentHash: 'hashhash01' }])
+    )
 
     await versionRepo.recordVersion('explicit/skill', 'hashhash01', '1.0.0')
 
     const result = await executeSkillUpdates({ skillIds: ['explicit/skill'] }, makeContext(db))
 
+    expect(mockedLoadManifest).toHaveBeenCalled()
     expect(result.skills).toHaveLength(1)
     expect(result.skills[0].skillId).toBe('explicit/skill')
-    expect(mockedLoadManifest).not.toHaveBeenCalled()
+    expect(result.skills[0].updateAvailable).toBe(false)
+  })
+
+  it('reports updateAvailable: false for an explicit skillId the manifest has no entry for (unknown, not a false positive)', async () => {
+    mockedLoadManifest.mockResolvedValue(emptyManifest())
+
+    await versionRepo.recordVersion('unmanifested/skill', 'somehash01', '1.0.0')
+
+    const result = await executeSkillUpdates(
+      { skillIds: ['unmanifested/skill'] },
+      makeContext(db)
+    )
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].installedHash).toBe('--------')
+    expect(result.skills[0].updateAvailable).toBe(false)
   })
 
   it('de-duplicates a skill installed under two clients (SMI-5894 name::client keys) to one result', async () => {
@@ -188,15 +221,44 @@ describe('executeSkillUpdates', () => {
     expect(result.updatesAvailable).toBe(0)
   })
 
-  it('reports updateAvailable: false when the oldest and latest hash match', async () => {
+  it('reports updateAvailable: false when the manifest-recorded hash matches the latest registry hash', async () => {
     mockedLoadManifest.mockResolvedValue(
-      manifestWithSkills([{ key: 'stable', id: 'community/stable' }])
+      manifestWithSkills([{ key: 'stable', id: 'community/stable', contentHash: 'samehash01' }])
     )
     await versionRepo.recordVersion('community/stable', 'samehash01', '1.0.0')
 
     const result = await executeSkillUpdates({}, makeContext(db))
 
     expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].updateAvailable).toBe(false)
+    expect(result.updatesAvailable).toBe(0)
+  })
+
+  // SMI-6343 (C1) regression guard: the migration purging skill_versions
+  // (v18) exists specifically to prevent a mixed old/new hash-space table
+  // from making `oldest !== latest` true for EVERY skill with pre-existing
+  // history. Prove the NEW comparison (manifest-vs-latest, not
+  // oldest-vs-latest) doesn't reintroduce that universal false positive by
+  // itself: a skill with several pre-existing (post-migration, real-hash)
+  // version rows whose manifest-recorded hash matches the current latest
+  // registry hash must report updateAvailable: false.
+  it('does not report updateAvailable purely because a skill has pre-existing version history (SMI-6343 universal-false-positive guard)', async () => {
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { key: 'history-rich', id: 'community/history-rich', contentHash: 'currenthash1' },
+      ])
+    )
+
+    // Several real-hash version rows recorded over time, ending at the
+    // exact hash the manifest says is installed.
+    insertVersionAt(db, 'community/history-rich', 'ancienthash0', '1.0.0', 1000)
+    insertVersionAt(db, 'community/history-rich', 'olderhash01', '1.1.0', 2000)
+    insertVersionAt(db, 'community/history-rich', 'currenthash1', '1.2.0', 3000)
+
+    const result = await executeSkillUpdates({}, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].skillId).toBe('community/history-rich')
     expect(result.skills[0].updateAvailable).toBe(false)
     expect(result.updatesAvailable).toBe(0)
   })

--- a/packages/mcp-server/src/tools/skill-updates.test.ts
+++ b/packages/mcp-server/src/tools/skill-updates.test.ts
@@ -161,6 +161,26 @@ describe('executeSkillUpdates', () => {
     expect(result.skills[0].updateAvailable).toBe(false)
   })
 
+  it('falls through a BLANK (whitespace-only) contentHash to originalContentHash (adversarial-review regression)', async () => {
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        {
+          key: 'blank-content-hash',
+          id: 'community/blank-content-hash',
+          contentHash: '   ',
+          originalContentHash: 'real-original-hash',
+        },
+      ])
+    )
+    await versionRepo.recordVersion('community/blank-content-hash', 'newer-registry-hash', '2.0.0')
+
+    const result = await executeSkillUpdates({}, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].installedHash).toBe('real-original-hash'.slice(0, 8))
+    expect(result.skills[0].updateAvailable).toBe(true)
+  })
+
   it('reports updateAvailable: false for an explicit skillId the manifest has no entry for (unknown, not a false positive)', async () => {
     mockedLoadManifest.mockResolvedValue(emptyManifest())
 
@@ -190,6 +210,44 @@ describe('executeSkillUpdates', () => {
 
     expect(result.skills).toHaveLength(1)
     expect(result.skills[0].skillId).toBe('community/astro')
+  })
+
+  it('reports unknown (not a guess) when two clients of the same skill carry conflicting installed hashes (adversarial-review regression)', async () => {
+    // The bug this guards: "first non-empty hash wins" made the verdict
+    // depend on manifest object-iteration order — one client's install is
+    // current, the other is genuinely outdated, and picking either
+    // silently misreports the other. Per ADR-144 §3, a real conflict must
+    // resolve to no-hash-available (comparator -> 'unknown'), never a
+    // guess.
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { key: 'astro', id: 'community/astro', contentHash: 'client-a-hash' },
+        { key: 'astro::cursor', id: 'community/astro', contentHash: 'client-b-hash' },
+      ])
+    )
+    await versionRepo.recordVersion('community/astro', 'client-a-hash', '1.0.0')
+
+    const result = await executeSkillUpdates({}, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].updateAvailable).toBe(false)
+    expect(result.skills[0].installedHash).toBe('--------')
+  })
+
+  it('resolves normally when two clients of the same skill carry the SAME installed hash', async () => {
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { key: 'astro', id: 'community/astro', contentHash: 'agreed-hash' },
+        { key: 'astro::cursor', id: 'community/astro', contentHash: 'agreed-hash' },
+      ])
+    )
+    await versionRepo.recordVersion('community/astro', 'newer-registry-hash', '2.0.0')
+
+    const result = await executeSkillUpdates({}, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].updateAvailable).toBe(true)
+    expect(result.skills[0].installedHash).toBe('agreed-hash'.slice(0, 8))
   })
 
   it('skips manifest entries with no id (corrupt row) without throwing', async () => {

--- a/packages/mcp-server/src/tools/skill-updates.test.ts
+++ b/packages/mcp-server/src/tools/skill-updates.test.ts
@@ -119,9 +119,7 @@ describe('executeSkillUpdates', () => {
     // ('newnewnew2') -> update available. Version history itself no longer
     // drives this — only the manifest-vs-latest-registry comparison does.
     mockedLoadManifest.mockResolvedValue(
-      manifestWithSkills([
-        { key: 'astro', id: 'community/astro', contentHash: 'oldoldold1' },
-      ])
+      manifestWithSkills([{ key: 'astro', id: 'community/astro', contentHash: 'oldoldold1' }])
     )
 
     insertVersionAt(db, 'community/astro', 'oldoldold1', '1.0.0', 1000)
@@ -186,10 +184,7 @@ describe('executeSkillUpdates', () => {
 
     await versionRepo.recordVersion('unmanifested/skill', 'somehash01', '1.0.0')
 
-    const result = await executeSkillUpdates(
-      { skillIds: ['unmanifested/skill'] },
-      makeContext(db)
-    )
+    const result = await executeSkillUpdates({ skillIds: ['unmanifested/skill'] }, makeContext(db))
 
     expect(result.skills).toHaveLength(1)
     expect(result.skills[0].installedHash).toBe('--------')

--- a/packages/mcp-server/src/tools/skill-updates.ts
+++ b/packages/mcp-server/src/tools/skill-updates.ts
@@ -26,7 +26,7 @@
  */
 
 import { z } from 'zod'
-import { SkillVersionRepository, compareSkillContentHashes } from '@skillsmith/core'
+import { SkillVersionRepository, compareSkillContentHashes, firstNonBlankHash } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { loadManifest } from './install.helpers.js'
 import { getManifestInstalledSkillIds } from './manifest-skill-ids.helpers.js'
@@ -118,25 +118,49 @@ export const skillUpdatesToolSchema = {
 // ============================================================================
 
 /**
- * SMI-6343 (C1): build a map of registry skill id -> the manifest's
- * recorded install/update-time content hash (`contentHash` when the skill
- * has been updated since install, else `originalContentHash`) — the real
- * hash of what is actually installed. A skill installed under two clients
- * (SMI-5894) can produce two manifest entries sharing the same id; the
- * first non-empty hash found wins, matching
- * `getManifestInstalledSkillIds()`'s own dedup-by-id precedent.
+ * SMI-6343 (C1, adversarial-review fix): build a map of registry skill id
+ * -> the manifest's recorded install/update-time content hash
+ * (`contentHash` when the skill has been updated since install, else
+ * `originalContentHash`) — the real hash of what is actually installed.
+ *
+ * A skill installed under two clients (SMI-5894) can produce two manifest
+ * entries sharing the same id, and those entries can legitimately carry
+ * DIFFERENT installed hashes — e.g. the Claude Code copy was updated and
+ * the Cursor copy wasn't. Picking "the first hash found" (the original
+ * implementation) makes the verdict depend on manifest iteration order,
+ * silently reporting "no update" for a genuinely-outdated client just
+ * because an up-to-date sibling entry happened to be read first. Per
+ * ADR-144 §3's fail-closed posture ("the system never converts uncertainty
+ * into a registry identity/verdict"), a genuine multi-client conflict
+ * resolves to no-hash-available (comparator reports `unknown`) rather than
+ * guessing which client's state to trust — this is a one-row-per-skill-id
+ * response shape, so there is nowhere honest to put two different verdicts
+ * for one row.
  */
 function buildManifestInstalledHashMap(manifest: SkillManifest): Map<string, string> {
-  const map = new Map<string, string>()
+  const hashesById = new Map<string, Set<string>>()
   if (!manifest.installedSkills || typeof manifest.installedSkills !== 'object') {
-    return map
+    return new Map()
   }
   for (const entry of Object.values(manifest.installedSkills)) {
     if (typeof entry.id !== 'string' || entry.id.trim().length === 0) continue
-    if (map.has(entry.id)) continue
-    const hash = entry.contentHash ?? entry.originalContentHash
-    if (typeof hash === 'string' && hash.trim().length > 0) {
-      map.set(entry.id, hash)
+    // firstNonBlankHash() already trims and rejects blank values, so a
+    // non-null result here is guaranteed non-blank.
+    const hash = firstNonBlankHash(entry.contentHash, entry.originalContentHash)
+    if (hash !== null) {
+      const set = hashesById.get(entry.id) ?? new Set<string>()
+      set.add(hash)
+      hashesById.set(entry.id, set)
+    }
+  }
+  const map = new Map<string, string>()
+  for (const [id, hashes] of hashesById) {
+    // Exactly one distinct hash across every client entry for this id ->
+    // unambiguous. Two or more -> conflicting client state; omit from the
+    // map entirely so the caller's `?? undefined` lookup falls through to
+    // the comparator's honest `unknown` outcome.
+    if (hashes.size === 1) {
+      map.set(id, [...hashes][0])
     }
   }
   return map

--- a/packages/mcp-server/src/tools/skill-updates.ts
+++ b/packages/mcp-server/src/tools/skill-updates.ts
@@ -2,10 +2,22 @@
  * @fileoverview skill_updates MCP tool — check for registry skill updates
  * @module @skillsmith/mcp-server/tools/skill-updates
  * @see SMI-skill-version-tracking Wave 1
+ * @see SMI-6343 Wave 2 — real content-hash comparison (C1)
  *
- * Compares the locally-recorded content hash of each installed skill
- * against the most-recent hash in the skill_versions table to determine
- * whether a newer version has been synced from the registry.
+ * Compares the manifest's recorded install/update-time content hash of each
+ * installed skill against the most-recent hash in the skill_versions table
+ * to determine whether a newer version has been synced from the registry.
+ *
+ * SMI-6343 (C1): previously compared `skill_versions`' OLDEST recorded row
+ * (documented as a stand-in for "what was installed") against its LATEST
+ * row — but `oldest` was never actually tied to a real install event, and
+ * (pre-fix) `skill_versions.content_hash` was a metadata-proxy hash, not a
+ * real SKILL.md hash, making the whole comparison structurally meaningless.
+ * Now compares the manifest's own recorded `contentHash`/`originalContentHash`
+ * (the real hash of what is actually installed) against the latest real
+ * registry hash, via the shared `compareSkillContentHashes()` comparator so
+ * this tool, `skill_outdated`, and the CLI's `skills-directory.ts` cannot
+ * drift apart on what "an update is available" means.
  *
  * Tier gate: Individual (version_tracking feature flag).
  * Community users see a graceful license error response, never a hard throw.
@@ -14,10 +26,11 @@
  */
 
 import { z } from 'zod'
-import { SkillVersionRepository } from '@skillsmith/core'
+import { SkillVersionRepository, compareSkillContentHashes } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { loadManifest } from './install.helpers.js'
 import { getManifestInstalledSkillIds } from './manifest-skill-ids.helpers.js'
+import type { SkillManifest } from './install.types.js'
 import type { ToolContext } from '../context.js'
 
 // ============================================================================
@@ -43,7 +56,14 @@ export type SkillUpdatesInput = z.infer<typeof skillUpdatesInputSchema>
 export interface SkillUpdateInfo {
   /** Registry skill identifier (e.g. "author/skill-name") */
   skillId: string
-  /** 8-char prefix of the oldest recorded hash in skill_versions (earliest registry sync) */
+  /**
+   * SMI-6343: 8-char prefix of the manifest's recorded install/update-time
+   * content hash (`contentHash` ?? `originalContentHash`) — the real
+   * recorded installed hash. Renders as the honest placeholder `'--------'`
+   * (never a stale `skill_versions` row) when the manifest has no entry for
+   * this skill id — `updateAvailable` is `false` for that row too, since an
+   * `unknown` comparator outcome never reports an update.
+   */
   installedHash: string
   /** 8-char prefix of the most-recent recorded hash (current registry state) */
   latestHash: string
@@ -98,13 +118,39 @@ export const skillUpdatesToolSchema = {
 // ============================================================================
 
 /**
+ * SMI-6343 (C1): build a map of registry skill id -> the manifest's
+ * recorded install/update-time content hash (`contentHash` when the skill
+ * has been updated since install, else `originalContentHash`) — the real
+ * hash of what is actually installed. A skill installed under two clients
+ * (SMI-5894) can produce two manifest entries sharing the same id; the
+ * first non-empty hash found wins, matching
+ * `getManifestInstalledSkillIds()`'s own dedup-by-id precedent.
+ */
+function buildManifestInstalledHashMap(manifest: SkillManifest): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!manifest.installedSkills || typeof manifest.installedSkills !== 'object') {
+    return map
+  }
+  for (const entry of Object.values(manifest.installedSkills)) {
+    if (typeof entry.id !== 'string' || entry.id.trim().length === 0) continue
+    if (map.has(entry.id)) continue
+    const hash = entry.contentHash ?? entry.originalContentHash
+    if (typeof hash === 'string' && hash.trim().length > 0) {
+      map.set(entry.id, hash)
+    }
+  }
+  return map
+}
+
+/**
  * Execute the skill_updates tool.
  *
  * Resolves which skills to check either from `input.skillIds` or (SMI-5895
  * Wave 2 Step 2) the local manifest's installed-skill IDs — never an
- * unbounded registry-wide scan — then gets the latest version record for
- * each and compares it to the oldest recorded version (used as a proxy for
- * "what was installed").
+ * unbounded registry-wide scan. The manifest is always loaded (SMI-6343
+ * C1) so each skill's real recorded installed hash is available regardless
+ * of which path resolved its id; `skill_versions`' latest row still
+ * supplies the current registry hash and semver/age display fields.
  *
  * @param input   Validated tool input
  * @param context Tool context with database connection
@@ -115,6 +161,9 @@ async function executeSkillUpdatesImpl(
   context: ToolContext
 ): Promise<CheckUpdatesResponse> {
   const versionRepo = new SkillVersionRepository(context.db)
+
+  const manifest = await loadManifest()
+  const manifestInstalledHashes = buildManifestInstalledHashMap(manifest)
 
   // Determine which skill IDs to check.
   //
@@ -131,7 +180,6 @@ async function executeSkillUpdatesImpl(
   if (input.skillIds && input.skillIds.length > 0) {
     skillIds = input.skillIds
   } else {
-    const manifest = await loadManifest()
     skillIds = getManifestInstalledSkillIds(manifest)
   }
 
@@ -139,18 +187,22 @@ async function executeSkillUpdatesImpl(
   const skillInfos: SkillUpdateInfo[] = []
 
   for (const skillId of skillIds) {
-    // Get the full history to find both the oldest (installed proxy) and latest
-    const history = await versionRepo.getVersionHistory(skillId, 50)
+    // Latest registry-synced version (semver, age, and — when the manifest
+    // has no recorded installed hash — a display-only fallback).
+    const history = await versionRepo.getVersionHistory(skillId, 1)
 
     if (history.length === 0) {
       continue
     }
 
-    // Latest is history[0] (ordered DESC), oldest is history[history.length - 1]
     const latest = history[0]
-    const oldest = history[history.length - 1]
+    const manifestInstalledHash = manifestInstalledHashes.get(skillId)
 
-    const installedHash = oldest.content_hash.slice(0, 8)
+    // SMI-6343 (C1): compare the manifest's real recorded installed hash
+    // (not skill_versions' oldest row) against the current registry hash.
+    const comparison = compareSkillContentHashes(manifestInstalledHash, latest.content_hash)
+
+    const installedHash = manifestInstalledHash ? manifestInstalledHash.slice(0, 8) : '--------'
     const latestHash = latest.content_hash.slice(0, 8)
 
     const ageDays = Math.floor((now - latest.recorded_at) / 86400)
@@ -162,7 +214,11 @@ async function executeSkillUpdatesImpl(
       semver: latest.semver,
       ageDays,
       pinned: false, // Wave 2: pinning support
-      updateAvailable: oldest.content_hash !== latest.content_hash,
+      // SMI-6343: an 'unknown' comparator outcome (no manifest-recorded
+      // hash for this skill) reports no update — reporting may degrade,
+      // but this tool never claims an update is available when it can't
+      // actually verify one.
+      updateAvailable: comparison.outcome === 'outdated',
     })
   }
 

--- a/packages/mcp-server/src/tools/skill-updates.ts
+++ b/packages/mcp-server/src/tools/skill-updates.ts
@@ -26,7 +26,11 @@
  */
 
 import { z } from 'zod'
-import { SkillVersionRepository, compareSkillContentHashes, firstNonBlankHash } from '@skillsmith/core'
+import {
+  SkillVersionRepository,
+  compareSkillContentHashes,
+  firstNonBlankHash,
+} from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { loadManifest } from './install.helpers.js'
 import { getManifestInstalledSkillIds } from './manifest-skill-ids.helpers.js'


### PR DESCRIPTION
## Business Summary

**What shipped:** `skill_outdated`, `skill_updates`, and `sklx list --outdated` now correctly detect whether an installed skill's content matches the registry — previously all three compared against a hash that was never a real content hash, so none of them could reliably tell "current" from "outdated." `skill_outdated` also gains a live registry check (with offline/network/quota fallbacks) and a fix for a display bug where an unchecked skill's hash looked identical to a checked one. A migration clears out the old, incomparable hash history so it doesn't produce false "update available" signals once the new comparison goes live.

**Quality bar:** Implementation, a governance review, and a full adversarial review pass (Codex/gpt-5.6-sol) — 5 findings (2 High, 2 Medium, 1 Low), all fixed with dedicated regression tests. The two High findings were real: an unchanged skill would never regain its hash record after the migration, and a failed live check could fall back to stale cached data and report a wrong verdict instead of an honest "unknown."

**Found along the way:** a pre-existing bug in the CLI's `hasUpdates` check — it was reading a field that never existed on the object it checked, so it always fell back to a broken comparison. Fixed in the same pass since it was on this code path.

**Net result:** Fully shipped. Local verification is limited by this worktree's Docker container (a Docker-level failure, tracked under SMI-6373, not caused by this change) — typecheck and the full test suite could not run locally; lint and the standards audit are clean. CI is the gate for the rest.

---

## Technical detail

- `packages/core/src/sync/SyncEngine.ts` — records the registry's real SKILL.md content hash instead of a metadata-proxy hash; records it on every sync pass for a skill (not only when other metadata changed), skipping only when the registry supplies no hash at all.
- `packages/core/src/db/migrations/v18-skill-versions-real-content-hash.ts` — new migration, purges `skill_versions` (no FK dependents; fully rebuilds on the next sync).
- `packages/core/src/services/skill-content-comparison.ts` — new shared comparator (`compareSkillContentHashes`, `firstNonBlankHash`) consumed by all three readers below, so they can't drift apart again.
- `packages/mcp-server/src/tools/outdated.ts` — live registry arm with offline/network-error/quota-exceeded degradation handling; fixes the `latest_hash` echo bug.
- `packages/mcp-server/src/tools/skill-updates.ts` — compares the manifest's real recorded installed hash instead of `skill_versions`' oldest row; resolves a multi-client hash conflict to `unknown` rather than an arbitrary pick.
- `packages/cli/src/utils/skills-directory.ts` — `computeHasUpdates()` extracted and routed through the shared comparator, fixing the latent field-read bug noted above.
- Local verification could not exercise typecheck or the full test suite in this worktree (Docker container failure, SMI-6373); `npm run lint` and `npm run audit:standards` ran clean on host. Two reviews (governance + adversarial) documented in `docs/internal/code_review/2026-09-03-smi-6343-wave2-governance-review.md` and `2026-09-04-smi-6343-wave2-adversarial-review.md`.
- Several commits on this branch used `--no-verify` for the same container failure, with explicit authorization each time — CI is unaffected by this worktree-local issue.
