### PR TITLE
fix(ci): SMI-6381 classify job timeout -- pin+cache minimatch install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,18 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    # SMI-6381: bumped from 2 -> 4. Not a blind bump -- measured baseline for
+    # the "Install minimatch" step below is ~55s cold-cache (see
+    # docs/internal/implementation/ci-classify-changes-timeout.md for the
+    # full root-cause writeup). That 55s baseline predates `cache: 'npm'`
+    # being added to this job (below); the cache-restore step itself adds
+    # negligible overhead -- quality-checks' own `cache: 'npm'` restore
+    # (bundled into its "Setup Node.js" step) measured ~1-2s on a hit in the
+    # same sample of runs. 4 minutes gives headroom for a genuinely degraded
+    # registry day (2x the measured cold-cache baseline) plus fixed
+    # checkout/setup-node/cache-restore overhead, while still hard-failing a
+    # step that is actually wedged rather than removing the guard.
+    timeout-minutes: 4
     outputs:
       tier: ${{ steps.classify.outputs.tier }}
       skip_docker: ${{ steps.classify.outputs.skip_docker }}
@@ -171,9 +182,39 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm install minimatch
+      - name: Install minimatch (pinned, cached)
+        # SMI-6381: `minimatch@10.2.5` is already the pinned, resolvable
+        # version in package-lock.json (packages["node_modules/minimatch"]).
+        # This step only needs it importable for
+        # scripts/ci/classify-changes.ts's `import { minimatch } from
+        # 'minimatch'`. The previous unpinned `npm install minimatch` forced
+        # a live registry packument/dist-tag lookup ("what does `latest`
+        # currently resolve to?") on every run before it could even check
+        # the tarball cache -- THAT lookup is the actual root cause of the
+        # 2026-09 timeout incident (see the implementation plan's Root Cause
+        # Analysis), not just an absence of caching. Pinning to the exact
+        # locked version removes it entirely: combined with `cache: 'npm'`
+        # above, a warm cache resolves fully offline with no network call at
+        # all. --no-save avoids rewriting package.json/lock in this
+        # ephemeral checkout; --no-audit/--no-fund drop two more registry
+        # round trips npm makes by default that this job doesn't need;
+        # --prefer-offline is a defense-in-depth fallback for the rare case
+        # the cache is warm but the exact tarball still isn't present.
+        # Version-drift note: this pin WILL go stale whenever a future
+        # dependency bump changes what version package-lock.json's top-level
+        # `minimatch` entry resolves to -- reviewed and accepted as a
+        # deliberate trade-off. It's harmless when stale
+        # (scripts/ci/classify-changes.ts's usage, `minimatch(file, pattern,
+        # { dot: true })`, is a narrow, stable API surface across
+        # minimatch's 10.x line), it's a single visible line in this file,
+        # and it's trivially bumped whenever noticed -- not worth trading
+        # away the actual fix (removing the registry round trip) to avoid.
+        # See docs/internal/implementation/ci-classify-changes-timeout.md.
+        run: |
+          echo "::notice::Installing minimatch@10.2.5 (pinned) for scripts/ci/classify-changes.ts -- if this step is slow or times out, see SMI-6381 / docs/internal/implementation/ci-classify-changes-timeout.md"
+          npm install minimatch@10.2.5 --no-save --no-audit --no-fund --prefer-offline
 
       - name: Classify changes
         id: classify


### PR DESCRIPTION
## Business Summary

**What shipped:** The `classify` CI check (a required check on every PR) had been failing at a very high rate -- including on pushes to `main` -- cancelled every time it hit its 2-minute timeout, which blocked most other required checks from running at all. The install step now pins its one dependency to the exact version already locked in `package-lock.json` and uses a warm cache instead of a fresh registry lookup on every run, and the timeout is right-sized to 4 minutes based on measured before/after timing.

**Quality bar:** Root cause investigated with live GitHub Actions timing data (not assumed), documented in a SPARC plan, and independently reviewed by VP Product/Engineering/Design (plan-review-skill) -- 10 findings, all addressed. `audit:standards` clean (0 failures), YAML syntax and Prettier formatting verified.

**Found along the way:** the same missing-cache pattern exists on 34 other CI job steps repo-wide -- filed separately as SMI-6382 rather than bundled here, to keep this fix narrow while it's actively unblocking merges.

**Net result:** Fix is up for review. Closing SMI-6381 requires 3 consecutive successful `classify` runs post-merge with no timeout cancellation (see the plan's Testing section) -- not just a one-time green run.

---

## Technical detail

**File**: `.github/workflows/ci.yml` -- `classify` job only.

- `actions/setup-node` gains `cache: 'npm'` (already used by the `quality-checks` job).
- The "Install dependencies" step (renamed "Install minimatch (pinned, cached)") changes from `npm install minimatch` to `npm install minimatch@10.2.5 --no-save --no-audit --no-fund --prefer-offline`, plus a `::notice::` log breadcrumb pointing back to SMI-6381 if this ever regresses.
- `timeout-minutes` goes from `2` to `4`.

Full root-cause analysis, the plan-review disposition (10/10 findings applied), and the exact timing data behind these numbers: `docs/internal/implementation/ci-classify-changes-timeout.md`.

No application code, database, or runtime behavior changes -- CI-workflow-only. `scripts/ci/classify-changes.ts` (the consumer of `minimatch`) is unchanged.

Linear: SMI-6381 (fix), SMI-6382 (follow-up, out of scope here).
