### PR TITLE
SMI-6385: fix missing apiClient mock in skill-outdated-resolution.test.ts

### DIFF
--- a/packages/mcp-server/src/__tests__/skill-outdated-resolution.test.ts
+++ b/packages/mcp-server/src/__tests__/skill-outdated-resolution.test.ts
@@ -67,6 +67,11 @@ function makeContext(db: Database): ToolContext {
   return {
     db,
     skillDependencyRepository: new SkillDependencyRepository(db),
+    // SMI-6343 Wave 2 added a required context.apiClient.isOffline() call in
+    // outdated.ts's live registry arm. This test predates that arm and has no
+    // live registry to mock, so `true` (offline) preserves its original
+    // behavior: only the historical/manifest resolution path is exercised.
+    apiClient: { isOffline: () => true },
   } as unknown as ToolContext
 }
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a currently-broken test on `main` — `skill-outdated-resolution.test.ts`'s mock context was missing a required method (`apiClient.isOffline()`) that a prior PR added to the real code, so it crashed instead of testing what it was supposed to test.

**Quality bar:** Root-caused with live evidence (compared against the exact commit that introduced the break, confirmed via GitHub's own CI run history) rather than assumed. Verified the fix restores this test's original, pre-existing behavior — it doesn't change what the test checks, only supplies the mock method it was always implicitly relying on before that method existed.

**Found along the way:** A more significant gap than the one broken test: this test file lives where CI's job matrix structurally never runs it — only local `git push`'s combined test config catches it. Filed separately as SMI-6385 (this fix's own issue) with the coverage-gap detail, since closing that gap for good is bigger scope than this one-line fix.

**Net result:** Fully shipped. The coverage-gap follow-up (wiring this test's location into CI properly) is tracked but not part of this PR.

---

## Technical detail

`packages/mcp-server/src/__tests__/skill-outdated-resolution.test.ts`'s `makeContext()` helper builds a bare `ToolContext` with no `apiClient`. PR #2699 (SMI-6343 Wave 2, commit `e78f37626`) added a required `context.apiClient.isOffline()` call in `outdated.ts`'s live registry arm and updated the sibling `outdated.test.ts` file's mocks, but missed this second SMI-5407 gate-test file entirely — because it's the only test file this repo's CI never actually executes (confirmed: CI's own run against `e78f37626` reports success, while this exact commit deterministically crashes here locally via the combined `vitest.config.root-tests.ts` config pre-push uses).

Fix: `apiClient: { isOffline: () => true }` — `true` because this test predates the live-registry arm entirely and has nothing to mock for it; treating it as offline skips that arm and preserves the test's original, sole concern (manifest-id-keyed historical-hash resolution).


[skip-impl-check] — test-only fix (a mock helper in an existing test file), no feature/product code change to verify.
