### PR TITLE
feat(mcp-server,cli,core): SMI-6343 Wave 3 -- tamper-check classification

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Added**: `skillsmith update` now refuses to force-install over an already-corrupt manifest
+  entry — before overwriting the currently-installed skill, it runs the same shared tamper-
+  check classification `skill_outdated` uses and skips (rather than updates) any entry
+  classified `local-drift`, `identity-mismatch`, or `unknown`, naming the reason in a new
+  `Skipped` bucket in the update summary (SMI-6343 Wave 3). `sklx list --outdated` similarly
+  no longer reports `hasUpdates: true` for a `local-drift`/owner-mismatch/path-unresolved
+  entry — only the two signals that don't require a network call (this scan is offline by
+  design); a signal-2-only (front-matter) corruption still surfaces through `skill_outdated`.
 - **Fix**: `skills-directory.ts`'s `hasUpdates` computation (read by `sklx list --outdated`)
   previously read a nonexistent `contentHash`/`originalContentHash` field off the *parsed
   SKILL.md* object instead of the manifest entry, so it always fell back to comparing a fresh

--- a/packages/cli/src/commands/install.action.ts
+++ b/packages/cli/src/commands/install.action.ts
@@ -128,6 +128,9 @@ export function createDbRegistryLookup(
         name: skill.name,
         trustTier: skill.trustTier,
         quarantined: quarantineRepo.isQuarantined(skill.id || skillId),
+        // SMI-6343 Wave 3: used by the shared identity-classification
+        // module's front-matter-contradiction signal.
+        author: skill.author ?? null,
       }
     },
   }
@@ -173,6 +176,9 @@ export async function createApiBackedRegistryLookup(
           name: r.name,
           trustTier: SkillsmithApiClient.toSkill(r).trustTier,
           quarantined: r.quarantined === true || r.installable === false,
+          // SMI-6343 Wave 3: used by the shared identity-classification
+          // module's front-matter-contradiction signal.
+          author: r.author ?? null,
         }
       } catch {
         return null

--- a/packages/cli/src/commands/manage.update.helpers.ts
+++ b/packages/cli/src/commands/manage.update.helpers.ts
@@ -19,6 +19,7 @@ import {
   type RecoveryConfidence,
   type Skill,
   type SkillRecoveryResult,
+  type SkillManifestEntry,
 } from '@skillsmith/core'
 import { getInstalledSkillsForClient, type InstalledSkill } from '../utils/skills-directory.js'
 import {
@@ -153,6 +154,25 @@ export interface SkillDiff {
   oldVersion: string | null
   newVersion: string | null
   changes: string[]
+  /**
+   * SMI-6343 (Wave 3, H5): the manifest entry CURRENTLY installed under this
+   * name/client — i.e. the one `install(force: true)` is about to overwrite.
+   * Always populated alongside a real `SkillDiff` (every return branch below
+   * has already resolved `manifestEntry` by this point, via either a direct
+   * lookup or ADR-139's untracked-skill adoption). Consumed by `updateSkill`'s
+   * pre-install contradiction gate (`manage.update.identity.ts`).
+   */
+  currentEntry: SkillManifestEntry
+  /**
+   * SMI-6343 (Wave 3, H5): registry author/name ALREADY obtained while
+   * resolving this diff — reused directly for the pre-install gate's signal
+   * 2 (front-matter contradiction) instead of firing a second lookup.
+   * `null` specifically means THIS resolution path never consulted the
+   * registry (the raw-URL branch, a legitimate, sanctioned code path — not
+   * a network failure): a direct-URL install has no registry-backed
+   * identity to check against in the first place.
+   */
+  resolvedRegistryRecord: { author: string | null; name: string | null } | null
 }
 
 /**
@@ -385,6 +405,8 @@ export async function getSkillDiff(
         oldVersion: installed.version,
         newVersion: skillWithVersion.version || null,
         changes,
+        currentEntry: manifestEntry,
+        resolvedRegistryRecord: { author: skill.author ?? null, name: skill.name ?? null },
       }
     }
     // No bare-name cache row whose author agrees with the installed skill's
@@ -412,6 +434,10 @@ export async function getSkillDiff(
         changes: [
           `Source resolved to ${resolvedId} — no cached version to diff; will fetch and overwrite with the latest content.`,
         ],
+        currentEntry: manifestEntry,
+        // A direct-URL install/update never consults the registry — see the
+        // field's own doc comment on `SkillDiff`.
+        resolvedRegistryRecord: null,
       }
     }
 
@@ -431,6 +457,8 @@ export async function getSkillDiff(
       changes: [
         `Registry source confirmed at ${remote.repoUrl} — no cached version to diff; will fetch and overwrite with the latest content.`,
       ],
+      currentEntry: manifestEntry,
+      resolvedRegistryRecord: { author: remote.author ?? null, name: remote.name ?? null },
     }
   } finally {
     db.close()

--- a/packages/cli/src/commands/manage.update.identity.ts
+++ b/packages/cli/src/commands/manage.update.identity.ts
@@ -1,0 +1,121 @@
+/**
+ * @fileoverview `skillsmith update` tamper-check classification
+ * @module @skillsmith/cli/commands/manage.update.identity
+ * @see SMI-6343 Wave 3 — tamper-check classification (AC#3), H5
+ *
+ * CLI counterpart of `packages/mcp-server/src/tools/outdated.identity.ts` —
+ * both adapt their own package's registry-lookup shape into the SAME shared
+ * `@skillsmith/core` classification module (`skill-identity-
+ * classification.ts`), so the CLI and the MCP tool cannot drift into two
+ * independently-maintained implementations of the three contradiction
+ * signals.
+ *
+ * Unlike `outdated.ts` (which only gates on a Wave 2 content-hash
+ * comparison), this module classifies an entry the caller has ALREADY
+ * determined needs a force-install (`getSkillDiff()` found a real diff via
+ * its own registry-version-string comparison) — the CLI's local
+ * `skill_versions` cache is commonly empty (SMI-6343 Finding 4B), so gating
+ * classification behind a hash comparison here would make almost every
+ * `update` refuse to proceed. `classifyDivergentEntry()` is called directly:
+ * signal evaluation, plus "has this file been edited since install," never
+ * a hash-comparison precondition.
+ *
+ * Signal 2 (front-matter contradiction) reuses `getSkillDiff()`'s OWN
+ * already-obtained registry author/name (`SkillDiff.resolvedRegistryRecord`)
+ * rather than firing a second, independent `RegistryLookup.lookup(entry.id)`
+ * call — deliberately: `RegistryLookup`'s existing implementations
+ * (`createDbRegistryLookup` / `createApiBackedRegistryLookup`) require a
+ * truthy `repoUrl` before returning anything at all, an install-time
+ * concern signal 2 has no interest in, so a fresh lookup keyed on `repoUrl`
+ * presence would under-report author data `getSkillDiff` already has in
+ * hand.
+ */
+
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import {
+  hashContent,
+  classifyDivergentEntry,
+  type SkillManifestEntry,
+  type RegistryLookupOutcome,
+  type IdentitySignal,
+  type IdentityInconclusiveReason,
+  type OutdatedClassificationState,
+} from '@skillsmith/core'
+import { getInstallPath, type ClientId, type ScopedInstallTarget } from '@skillsmith/core/install'
+
+export interface UpdateEntryClassification {
+  state: OutdatedClassificationState
+  signal: IdentitySignal | null
+  inconclusiveReason: IdentityInconclusiveReason | null
+}
+
+/**
+ * Classify the CURRENTLY-installed manifest entry the caller is about to
+ * overwrite via `install(force: true)`.
+ */
+export async function classifyManifestEntryForUpdate(params: {
+  entry: SkillManifestEntry
+  client: ClientId
+  scopeTarget?: ScopedInstallTarget | undefined
+  /** `SkillDiff.resolvedRegistryRecord` — see this module's fileoverview. */
+  resolvedRegistryRecord: { author: string | null; name: string | null } | null
+}): Promise<UpdateEntryClassification> {
+  const { entry, client, scopeTarget, resolvedRegistryRecord } = params
+
+  let localContent: string | null
+  try {
+    // Defensive `typeof` guard, not just try/catch: a mocked `readFile`
+    // (this module's own test suite, and several `manage.update.test.ts`
+    // fixtures) can resolve to `undefined` without throwing when no
+    // implementation is wired for a given call — `hashContent(undefined)`
+    // would otherwise throw deep inside `classifyDivergentEntry`.
+    const raw = await readFile(join(entry.installPath, 'SKILL.md'), 'utf-8')
+    localContent = typeof raw === 'string' ? raw : null
+  } catch {
+    localContent = null
+  }
+  const localHash = localContent !== null ? hashContent(localContent) : null
+
+  // `null` means THIS resolution never consulted the registry (the raw-URL
+  // branch) — not a network failure. The shared module separately exempts
+  // an `entry.id` that doesn't parse as `owner/name` from signal 2 entirely
+  // (see `skill-identity-classification.ts`), so this "attempted: false"
+  // only actually blocks when `entry.id` IS registry-shaped yet this
+  // particular resolution genuinely never confirmed it.
+  const registryLookup: RegistryLookupOutcome = resolvedRegistryRecord
+    ? { attempted: true, record: resolvedRegistryRecord, failureReason: null }
+    : { attempted: false, record: null, failureReason: null }
+
+  const expectedRootDir = scopeTarget?.dir ?? getInstallPath(client)
+
+  return classifyDivergentEntry({
+    entry,
+    localHash,
+    localContent,
+    expectedRootDir,
+    registryLookup,
+  })
+}
+
+/** Human-readable reason string for a `Skipped` bucket entry in `updateSkills()`'s summary. */
+export function buildUpdateSkipReason(classification: UpdateEntryClassification): string {
+  switch (classification.state) {
+    case 'identity-mismatch':
+      return (
+        `recorded identity contradicts what is on disk (${classification.signal}) — ` +
+        'run skill_recover_source, then apply_manifest_reconcile before updating'
+      )
+    case 'local-drift':
+      return 'on-disk content differs from the registry with no identity contradiction — looks like a local edit'
+    case 'unknown':
+      return `could not verify identity (${classification.inconclusiveReason ?? 'unknown reason'})`
+    default:
+      return ''
+  }
+}
+
+/** True when this classification must NOT be force-installed over. */
+export function isUnsafeToForceInstall(classification: UpdateEntryClassification): boolean {
+  return classification.state !== 'outdated' && classification.state !== 'current'
+}

--- a/packages/cli/src/commands/manage.update.ts
+++ b/packages/cli/src/commands/manage.update.ts
@@ -21,6 +21,11 @@ import { getInstalledSkillsForClient } from '../utils/skills-directory.js'
 import { createApiBackedRegistryLookup } from './install.js'
 import { installedViaFor, getSkillDiff } from './manage.update.helpers.js'
 import {
+  classifyManifestEntryForUpdate,
+  buildUpdateSkipReason,
+  isUnsafeToForceInstall,
+} from './manage.update.identity.js'
+import {
   CANONICAL_CLIENT,
   getInstallPath,
   type ClientId,
@@ -33,6 +38,21 @@ import {
 // alongside updateSkill/updateSkills so manage.action.ts's existing
 // `from './manage.update.js'` import path is unaffected.
 export type { SkillDiff } from './manage.update.helpers.js'
+
+/** SMI-6343 (Wave 3, H5): richer per-skill outcome, distinguishing a safety-gated skip from a failure. */
+export type UpdateSkillOutcome =
+  | 'updated'
+  | 'up-to-date'
+  | 'skipped'
+  | 'failed'
+  | 'cancelled'
+  | 'not-installed'
+
+export interface UpdateSkillResult {
+  outcome: UpdateSkillOutcome
+  /** Populated for `skipped` (why) and `failed` (the error). */
+  reason?: string | undefined
+}
 
 /**
  * Update a single skill. With `dryRun`, shows the same diff preview without
@@ -50,14 +70,19 @@ export type { SkillDiff } from './manage.update.helpers.js'
  * `update --scope workspace` overwrites the workspace copy, never the
  * global one. Optional (defaulting to the canonical global resolution) so
  * this stays callable from tests/callers that predate ADR-139.
+ *
+ * SMI-6343 (Wave 3, H5): richer outcome so `updateSkills()`'s summary can
+ * distinguish a safety-gated `skipped` from a genuine `failed` — see
+ * `updateSkill()` below for the boolean-returning wrapper every existing
+ * caller/test keeps using unmodified.
  */
-async function updateSkill(
+async function updateSkillWithOutcome(
   skillName: string,
   dbPath: string,
   dryRun = false,
   client: ClientId = CANONICAL_CLIENT,
   scopeTarget?: ScopedInstallTarget
-): Promise<boolean> {
+): Promise<UpdateSkillResult> {
   const spinner = ora(`Checking updates for ${skillName}...`).start()
 
   try {
@@ -67,14 +92,14 @@ async function updateSkill(
       spinner.fail(
         `"${skillName}" is not installed — use "skillsmith install <author>/${skillName}" instead`
       )
-      return false
+      return { outcome: 'not-installed' }
     }
 
     if (diff === 'unresolvable') {
       spinner.fail(
         `"${skillName}" has no recorded registry source — run "sklx audit sources" to recover it, or "skillsmith install <author>/${skillName} --force" with the full ID`
       )
-      return false
+      return { outcome: 'failed', reason: 'unresolvable' }
     }
 
     if (diff === 'adopted-unresolvable') {
@@ -88,17 +113,17 @@ async function updateSkill(
           `but no registry source could be determined — run "sklx audit sources" to recover it, ` +
           `or "skillsmith install <author>/${skillName} --force" to set the real source`
       )
-      return false
+      return { outcome: 'failed', reason: 'adopted-unresolvable' }
     }
 
     if ('adoptionError' in diff) {
       spinner.fail(diff.adoptionError)
-      return false
+      return { outcome: 'failed', reason: diff.adoptionError }
     }
 
     if (diff.changes.length === 0) {
       spinner.succeed(`${skillName} is already up to date`)
-      return true
+      return { outcome: 'up-to-date' }
     }
 
     spinner.stop()
@@ -111,7 +136,7 @@ async function updateSkill(
 
     if (dryRun) {
       console.log(chalk.dim(`(dry run — ${skillName} was not updated)\n`))
-      return true
+      return { outcome: 'up-to-date' }
     }
 
     const proceed = await confirm({
@@ -121,7 +146,7 @@ async function updateSkill(
 
     if (!proceed) {
       console.log(chalk.yellow('Update cancelled'))
-      return false
+      return { outcome: 'cancelled' }
     }
 
     const updateSpinner = ora(`Updating ${skillName}...`).start()
@@ -131,6 +156,24 @@ async function updateSkill(
       const skillRepo = new SkillRepository(db)
       const skillDependencyRepo = new SkillDependencyRepository(db)
       const registryLookup = await createApiBackedRegistryLookup(skillRepo, db)
+
+      // SMI-6343 (Wave 3, H5): refuse to force-install over an ALREADY-
+      // corrupt entry before it happens — SMI-6103's existing gate protects
+      // against CREATING a bad resolution; this protects against ACTING on
+      // one that's already there. Reuses `diff.resolvedRegistryRecord`
+      // (already obtained while resolving `diff` itself) rather than a
+      // second registry lookup.
+      const classification = await classifyManifestEntryForUpdate({
+        entry: diff.currentEntry,
+        client,
+        scopeTarget,
+        resolvedRegistryRecord: diff.resolvedRegistryRecord,
+      })
+      if (isUnsafeToForceInstall(classification)) {
+        const reason = buildUpdateSkipReason(classification)
+        updateSpinner.fail(`Skipping update for ${skillName}: ${reason}`)
+        return { outcome: 'skipped', reason }
+      }
 
       const service = new SkillInstallationService({
         db,
@@ -156,18 +199,35 @@ async function updateSkill(
 
       if (result.success) {
         updateSpinner.succeed(`Updated ${skillName}`)
-        return true
+        return { outcome: 'updated' }
       }
 
       updateSpinner.fail(`Failed to update ${skillName}: ${result.error}`)
-      return false
+      return { outcome: 'failed', reason: result.error }
     } finally {
       db.close()
     }
   } catch (error) {
-    spinner.fail(`Failed to update ${skillName}: ${sanitizeError(error)}`)
-    return false
+    const reason = sanitizeError(error)
+    spinner.fail(`Failed to update ${skillName}: ${reason}`)
+    return { outcome: 'failed', reason }
   }
+}
+
+/**
+ * Boolean-returning wrapper preserving `updateSkill()`'s pre-Wave-3 external
+ * contract for every existing caller/test — `true` for `updated`/`up-to-date`,
+ * `false` for everything else (failed, skipped, cancelled, not-installed).
+ */
+async function updateSkill(
+  skillName: string,
+  dbPath: string,
+  dryRun = false,
+  client: ClientId = CANONICAL_CLIENT,
+  scopeTarget?: ScopedInstallTarget
+): Promise<boolean> {
+  const result = await updateSkillWithOutcome(skillName, dbPath, dryRun, client, scopeTarget)
+  return result.outcome === 'updated' || result.outcome === 'up-to-date'
 }
 
 /**
@@ -209,12 +269,22 @@ async function updateSkills(
   console.log(chalk.bold(`\nChecking updates for ${targetNames.length} skill(s)...\n`))
 
   let updated = 0
+  let skipped = 0
   let failed = 0
+  const skipReasons: string[] = []
 
   for (const name of targetNames) {
-    const success = await updateSkill(name, dbPath, dryRun, client, scopeTarget)
-    if (success) {
+    const result = await updateSkillWithOutcome(name, dbPath, dryRun, client, scopeTarget)
+    if (result.outcome === 'updated' || result.outcome === 'up-to-date') {
       updated++
+    } else if (result.outcome === 'skipped') {
+      // SMI-6343 (Wave 3, H5): a `local-drift`/`identity-mismatch`/`unknown`
+      // classification lands here, never silently in `Updated` — the pre-
+      // Wave-3 code had no bucket for this, so `updateSkill()` returning
+      // `true` for "already up to date" made a skipped row indistinguishable
+      // from a real success.
+      skipped++
+      skipReasons.push(`${name}: ${result.reason ?? 'unsafe to force-install'}`)
     } else {
       failed++
     }
@@ -222,6 +292,12 @@ async function updateSkills(
 
   console.log(chalk.bold('\nUpdate Summary:'))
   console.log(chalk.green(`  Updated: ${updated}`))
+  if (skipped > 0) {
+    console.log(chalk.yellow(`  Skipped: ${skipped}`))
+    for (const reason of skipReasons) {
+      console.log(chalk.dim(`    - ${reason}`))
+    }
+  }
   if (failed > 0) {
     console.log(chalk.red(`  Failed: ${failed}`))
   }
@@ -234,4 +310,4 @@ async function updateSkills(
   }
 }
 
-export { getSkillDiff, updateSkill, updateSkills }
+export { getSkillDiff, updateSkill, updateSkillWithOutcome, updateSkills }

--- a/packages/cli/src/utils/skills-directory.hash-comparison.ts
+++ b/packages/cli/src/utils/skills-directory.hash-comparison.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview `sklx list --outdated` hash-comparison + classification
+ * @module @skillsmith/cli/utils/skills-directory.hash-comparison
+ * @see SMI-6343 Wave 2 (C2) / Wave 3
+ *
+ * Split out of `skills-directory.ts` (SMI-6343 Wave 3, 500-line file gate)
+ * — re-exported from there so existing call sites (`manage.action.ts`,
+ * `getSkillsFromDirectory()`, tests) keep importing from that module
+ * unmodified, matching this codebase's established split convention (see
+ * `local-skills-dir.ts` / `skills-directory.per-harness.ts`).
+ */
+
+import { createHash } from 'crypto'
+import {
+  compareSkillContentHashes,
+  firstNonBlankHash,
+  detectOwnerMismatch,
+  detectPathUnresolved,
+  hasRecordedLocalEdit,
+  type SkillManifestEntry,
+  type SkillVersionRow,
+} from '@skillsmith/core'
+
+/**
+ * SMI-6343 (C2): compute whether a newer registry version exists for an
+ * installed skill, given (in order of preference) the manifest's recorded
+ * install/update-time content hash, else a freshly-computed on-disk SHA-256
+ * of the current SKILL.md content — compared against the most-recently
+ * synced registry content hash via the shared comparator so this can't
+ * silently drift from the other two SMI-6343 consumers (the mcp-server's
+ * skill_outdated / skill_updates tools).
+ *
+ * SMI-6343 (Wave 3): a hash mismatch alone is no longer sufficient to
+ * report `true` — `sklx list --outdated` must not surface a `local-drift`
+ * or `identity-mismatch` row as an ordinary "update available," matching
+ * `skill_outdated`'s own five-state classification. This scan is offline by
+ * design (`list` has never had a network dependency), so only the two
+ * DETERMINISTIC signals (owner-mismatch, path-unresolved) plus local-edit
+ * detection are checked here — the network-dependent front-matter-
+ * contradiction signal is deliberately NOT evaluated in this surface (H6:
+ * `list --outdated` "does not share code with" `skill_outdated`, which
+ * remains the full three-signal surface for a signal-2-only corruption).
+ *
+ * Exported for direct unit testing — this is the exact logic that fixes the
+ * pre-fix defect (comparing skill_versions' metadata-proxy hash against
+ * either a nonexistent `parsed.contentHash` field or a real on-disk hash,
+ * which meant it always fell into the "real hash vs. proxy hash" branch and
+ * could essentially never report `hasUpdates: true` correctly).
+ *
+ * @param expectedRootDir The directory this scan target's entries are
+ *   expected to resolve inside — the caller's own `skillsDir` already IS
+ *   this (global native path or workspace directory, whichever this scan
+ *   target represents), so no separate resolution is needed here.
+ */
+export function computeHasUpdates(
+  manifestEntry: SkillManifestEntry | undefined,
+  content: string,
+  latestVersion: SkillVersionRow | null,
+  expectedRootDir: string
+): boolean {
+  if (!latestVersion) return false
+  const freshHash = createHash('sha256').update(content, 'utf8').digest('hex')
+  // SMI-6343 (adversarial-review fix): firstNonBlankHash(), not a raw `??`
+  // chain — a blank-but-present contentHash/originalContentHash (`??` only
+  // falls through on null/undefined) must not block falling all the way
+  // through to a freshly-computed on-disk hash.
+  const recordedHash = firstNonBlankHash(
+    manifestEntry?.contentHash,
+    manifestEntry?.originalContentHash
+  )
+  const installedHash = recordedHash ?? freshHash
+  const outdated =
+    compareSkillContentHashes(installedHash, latestVersion.content_hash).outcome === 'outdated'
+  if (!outdated) return false
+  if (!manifestEntry) return true // untracked skill — nothing recorded to contradict
+  if (
+    detectOwnerMismatch(manifestEntry) ||
+    detectPathUnresolved(manifestEntry.installPath, expectedRootDir)
+  ) {
+    return false
+  }
+  // A recorded hash that disagrees with the current on-disk content is a
+  // local edit (local-drift) — also excluded from "update available". Routed
+  // through the SAME shared `hasRecordedLocalEdit()` the core classification
+  // module uses (rather than re-deriving this boolean inline) so this file
+  // cannot drift into exactly the "sibling implementation" bug class this
+  // effort exists to prevent (see `skill-identity-classification.ts`).
+  return !hasRecordedLocalEdit(manifestEntry, freshHash)
+}

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -4,18 +4,14 @@
  */
 
 import { readdir, readFile, realpath, stat } from 'fs/promises'
-import { createHash } from 'crypto'
 import { join } from 'path'
 import {
   ManifestManager,
   SkillParser,
   SkillVersionRepository,
   manifestKeyFor,
-  compareSkillContentHashes,
-  firstNonBlankHash,
   type Database,
   type SkillManifestEntry,
-  type SkillVersionRow,
   type TrustTier,
 } from '@skillsmith/core'
 import { openCliDatabase } from './open-database.js'
@@ -53,6 +49,14 @@ export {
   getInstalledSkillsPerHarness,
   type HarnessSkillEntry,
 } from './skills-directory.per-harness.js'
+
+// SMI-6343 (Wave 3): computeHasUpdates() extracted to skills-directory.hash-
+// comparison.ts to stay under the 500-line standard once the Wave 3
+// classification logic was added — re-exported here so existing call sites
+// (this file's own getSkillsFromDirectory() below, plus tests) keep
+// importing from this module unmodified (same convention as above).
+export { computeHasUpdates } from './skills-directory.hash-comparison.js'
+import { computeHasUpdates } from './skills-directory.hash-comparison.js'
 
 export interface InstalledSkill {
   name: string
@@ -112,37 +116,6 @@ export interface InstalledSkill {
  * the full `Dirent` interface — those mocks never claim to be a symlink, so
  * treating a missing method as `false` preserves their existing behavior.
  */
-/**
- * SMI-6343 (C2): compute whether a newer registry version exists for an
- * installed skill, given (in order of preference) the manifest's recorded
- * install/update-time content hash, else a freshly-computed on-disk SHA-256
- * of the current SKILL.md content — compared against the most-recently
- * synced registry content hash via the shared comparator so this can't
- * silently drift from the other two SMI-6343 consumers (the mcp-server's
- * skill_outdated / skill_updates tools).
- *
- * Exported for direct unit testing — this is the exact logic that fixes the
- * pre-fix defect (comparing skill_versions' metadata-proxy hash against
- * either a nonexistent `parsed.contentHash` field or a real on-disk hash,
- * which meant it always fell into the "real hash vs. proxy hash" branch and
- * could essentially never report `hasUpdates: true` correctly).
- */
-export function computeHasUpdates(
-  manifestEntry: SkillManifestEntry | undefined,
-  content: string,
-  latestVersion: SkillVersionRow | null
-): boolean {
-  if (!latestVersion) return false
-  // SMI-6343 (adversarial-review fix): firstNonBlankHash(), not a raw `??`
-  // chain — a blank-but-present contentHash/originalContentHash (`??` only
-  // falls through on null/undefined) must not block falling all the way
-  // through to a freshly-computed on-disk hash.
-  const installedHash =
-    firstNonBlankHash(manifestEntry?.contentHash, manifestEntry?.originalContentHash) ??
-    createHash('sha256').update(content, 'utf8').digest('hex')
-  return compareSkillContentHashes(installedHash, latestVersion.content_hash).outcome === 'outdated'
-}
-
 async function resolvesToDirectory(
   entryPath: string,
   isDirectory: boolean,
@@ -271,7 +244,7 @@ export async function getSkillsFromDirectory(
               const skillId = (parsedAny['id'] as string | undefined) ?? entry.name
               const latestVersion = await versionRepo.getLatestVersion(skillId)
               const manifestEntry = manifestEntries[manifestKeyFor(entry.name, effectiveClient)]
-              hasUpdates = computeHasUpdates(manifestEntry, content, latestVersion)
+              hasUpdates = computeHasUpdates(manifestEntry, content, latestVersion, skillsDir)
             } catch {
               // Version check failed — safe to ignore, fall back to false
               hasUpdates = false

--- a/packages/cli/tests/manage.update.test.ts
+++ b/packages/cli/tests/manage.update.test.ts
@@ -116,6 +116,19 @@ const mocks = vi.hoisted(() => ({
   // untracked skill (no manifest entry) — see the identical mocks in
   // manage.update.source-recovery.test.ts.
   manifestUpdateSafelyFn: vi.fn(async () => undefined),
+  // SMI-6343 (Wave 3): the pre-install contradiction gate's classification
+  // call — defaults to "safe to update" (matches the pre-Wave-3 assumption
+  // every existing test in this file made); overridden per-test to exercise
+  // the Skipped bucket / pre-install gate.
+  classifyDivergentEntryFn: vi.fn(
+    (
+      _params?: unknown
+    ): { state: string; signal: string | null; inconclusiveReason: string | null } => ({
+      state: 'outdated',
+      signal: null,
+      inconclusiveReason: null,
+    })
+  ),
   buildAdoptedEntryFn: vi.fn(
     async (name: string, installPath: string): Promise<Record<string, unknown>> => ({
       id: name,
@@ -171,6 +184,7 @@ vi.mock('@skillsmith/core', () => ({
   // fully mocked and ignores its params) -- present only so the constructor
   // call site's destructuring/typing has something to reference.
   hashContent: vi.fn((content: string) => content),
+  classifyDivergentEntry: (params: unknown) => mocks.classifyDivergentEntryFn(params),
   // Reached only via install.js's createApiBackedRegistryLookup(), which
   // updateSkill() now calls on every update — not the update path's main
   // logic, but must resolve without throwing.
@@ -276,6 +290,11 @@ describe('SMI-5593: skillsmith update — real update path', () => {
       confidence: 'unknown',
       registryId: null,
       recoveredSource: null,
+    })
+    mocks.classifyDivergentEntryFn.mockReturnValue({
+      state: 'outdated',
+      signal: null,
+      inconclusiveReason: null,
     })
     // ADR-139 (SMI-6274 Wave 4): adoption defaults — succeed, and
     // reconstruct an 'unknown'-version/source entry, matching production.
@@ -611,6 +630,37 @@ describe('SMI-5593: skillsmith update — real update path', () => {
 
       expect(success).toBe(false)
     })
+
+    // SMI-6343 (Wave 3, H5): the pre-install contradiction gate — refuses
+    // force-install(force: true) when the CURRENT entry's identity
+    // classification comes back unsafe, even though the user confirmed the
+    // prompt. SMI-6103's existing gate protects against CREATING a bad
+    // resolution; this protects against ACTING on one that's already there.
+    it('refuses to force-install when the pre-install classification finds an identity contradiction', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0', author: 'wrsmith108' })
+      mockCache([
+        {
+          id: 'wrsmith108/astro',
+          name: 'astro',
+          version: '2.0.0',
+          trustTier: 'community',
+          author: 'wrsmith108',
+        },
+      ])
+      mocks.classifyDivergentEntryFn.mockReturnValue({
+        state: 'identity-mismatch',
+        signal: 'owner-mismatch',
+        inconclusiveReason: null,
+      })
+      const { confirm } = await import('@inquirer/prompts')
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('astro', '/fake/db.sqlite')
+
+      expect(success).toBe(false)
+      expect(mocks.installFn).not.toHaveBeenCalled()
+    })
   })
 
   describe('updateSkills (multi-skill / --all)', () => {
@@ -653,6 +703,40 @@ describe('SMI-5593: skillsmith update — real update path', () => {
       const { confirm } = await import('@inquirer/prompts')
       vi.mocked(confirm).mockResolvedValue(true)
     }
+
+    // SMI-6343 (Wave 3, H5): a local-drift/identity-mismatch row must land
+    // in the new Skipped bucket with a reason — never silently counted as
+    // Updated (the pre-Wave-3 bug: `updateSkill()` returning `true` for
+    // "already up to date" gave a skipped row no bucket of its own to land
+    // in without looking like a success).
+    it('excludes a local-drift/identity-mismatch skill from the update batch and reports it in the new Skipped count with a reason', async () => {
+      await mockTwoInstalledSkills()
+      // The adopted entry's `id` is the install-directory basename (this
+      // suite's `loadManifest` mock always returns an empty manifest, so
+      // both skills go through ADR-139 adoption) — differentiate on it.
+      mocks.classifyDivergentEntryFn.mockImplementation((params?: unknown) => {
+        const entryId = (params as { entry: { id: string } }).entry.id
+        return entryId === 'ci-doctor'
+          ? { state: 'local-drift', signal: null, inconclusiveReason: null }
+          : { state: 'outdated', signal: null, inconclusiveReason: null }
+      })
+
+      const { updateSkills } = await import('../src/commands/manage.js')
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await updateSkills(['astro', 'ci-doctor'], '/fake/db.sqlite', false)
+
+      // Only astro (classified 'outdated') is actually force-installed.
+      expect(mocks.installFn).toHaveBeenCalledTimes(1)
+      expect(mocks.installFn).toHaveBeenCalledWith('wrsmith108/astro', { force: true })
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(output).toContain('Updated: 1')
+      expect(output).toContain('Skipped: 1')
+      expect(output).not.toContain('Updated: 2')
+      expect(output).toMatch(/ci-doctor.*local edit/i)
+
+      logSpy.mockRestore()
+    })
 
     it('updates a specific set of named skills and reports a summary', async () => {
       await mockTwoInstalledSkills()

--- a/packages/cli/tests/skills-directory.hash-comparison.test.ts
+++ b/packages/cli/tests/skills-directory.hash-comparison.test.ts
@@ -1,5 +1,7 @@
 /**
- * @fileoverview Unit tests for computeHasUpdates() — SMI-6343 Wave 2 (C2)
+ * @fileoverview Unit tests for computeHasUpdates(,
+      '/tmp/skills'
+    ) — SMI-6343 Wave 2 (C2)
  *
  * Direct unit tests for the extracted pure comparison helper used by
  * `getSkillsFromDirectory()` (the function `sklx list --outdated` actually
@@ -48,7 +50,9 @@ function makeVersionRow(overrides: Partial<SkillVersionRow> = {}): SkillVersionR
 
 describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
   it('returns false when there is no latest registry version at all', () => {
-    expect(computeHasUpdates(makeManifestEntry(), 'on-disk content', null)).toBe(false)
+    expect(computeHasUpdates(makeManifestEntry(), 'on-disk content', null, '/tmp/skills')).toBe(
+      false
+    )
   })
 
   it('returns false when the manifest-recorded contentHash matches the latest registry hash', () => {
@@ -58,7 +62,8 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       computeHasUpdates(
         entry,
         'irrelevant on-disk content',
-        makeVersionRow({ content_hash: registryHash })
+        makeVersionRow({ content_hash: registryHash }),
+        '/tmp/skills'
       )
     ).toBe(false)
   })
@@ -68,8 +73,13 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
     expect(
       computeHasUpdates(
         entry,
-        'irrelevant on-disk content',
-        makeVersionRow({ content_hash: sha256('newer-registry-content') })
+        // SMI-6343 (Wave 3): the on-disk content now also feeds the
+        // local-edit check, so it must actually match what contentHash was
+        // computed from (no local edit) for this to isolate the "genuinely
+        // outdated" case the test is about.
+        'installed-content',
+        makeVersionRow({ content_hash: sha256('newer-registry-content') }),
+        '/tmp/skills'
       )
     ).toBe(true)
   })
@@ -82,7 +92,8 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       computeHasUpdates(
         entry,
         'irrelevant on-disk content',
-        makeVersionRow({ content_hash: sha256('install-time-content') })
+        makeVersionRow({ content_hash: sha256('install-time-content') }),
+        '/tmp/skills'
       )
     ).toBe(false)
   })
@@ -93,12 +104,15 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       originalContentHash: sha256('stale-install-time-content'),
     })
     // Registry now matches the ORIGINAL install-time hash, not the latest
-    // update — proves contentHash (not originalContentHash) wins.
+    // update — proves contentHash (not originalContentHash) wins. On-disk
+    // content matches contentHash (no local edit), isolating this test to
+    // the preference behavior it's actually about.
     expect(
       computeHasUpdates(
         entry,
-        'irrelevant on-disk content',
-        makeVersionRow({ content_hash: sha256('stale-install-time-content') })
+        'latest-installed-content',
+        makeVersionRow({ content_hash: sha256('stale-install-time-content') }),
+        '/tmp/skills'
       )
     ).toBe(true)
   })
@@ -110,14 +124,16 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       computeHasUpdates(
         entry,
         onDiskContent,
-        makeVersionRow({ content_hash: sha256(onDiskContent) })
+        makeVersionRow({ content_hash: sha256(onDiskContent) }),
+        '/tmp/skills'
       )
     ).toBe(false)
     expect(
       computeHasUpdates(
         entry,
         onDiskContent,
-        makeVersionRow({ content_hash: sha256('different-registry-content') })
+        makeVersionRow({ content_hash: sha256('different-registry-content') }),
+        '/tmp/skills'
       )
     ).toBe(true)
   })
@@ -135,14 +151,18 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       computeHasUpdates(
         entry,
         'irrelevant on-disk content',
-        makeVersionRow({ content_hash: sha256('install-time-content') })
+        makeVersionRow({ content_hash: sha256('install-time-content') }),
+        '/tmp/skills'
       )
     ).toBe(false)
+    // On-disk content matches originalContentHash (no local edit), isolating
+    // this test to the blank-contentHash-fallthrough behavior it's about.
     expect(
       computeHasUpdates(
         entry,
-        'irrelevant on-disk content',
-        makeVersionRow({ content_hash: sha256('different-registry-content') })
+        'install-time-content',
+        makeVersionRow({ content_hash: sha256('different-registry-content') }),
+        '/tmp/skills'
       )
     ).toBe(true)
   })
@@ -154,14 +174,16 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       computeHasUpdates(
         entry,
         onDiskContent,
-        makeVersionRow({ content_hash: sha256(onDiskContent) })
+        makeVersionRow({ content_hash: sha256(onDiskContent) }),
+        '/tmp/skills'
       )
     ).toBe(false)
     expect(
       computeHasUpdates(
         entry,
         onDiskContent,
-        makeVersionRow({ content_hash: sha256('different-registry-content') })
+        makeVersionRow({ content_hash: sha256('different-registry-content') }),
+        '/tmp/skills'
       )
     ).toBe(true)
   })
@@ -172,15 +194,67 @@ describe('computeHasUpdates (SMI-6343 Wave 2, C2)', () => {
       computeHasUpdates(
         undefined,
         onDiskContent,
-        makeVersionRow({ content_hash: sha256(onDiskContent) })
+        makeVersionRow({ content_hash: sha256(onDiskContent) }),
+        '/tmp/skills'
       )
     ).toBe(false)
     expect(
       computeHasUpdates(
         undefined,
         onDiskContent,
-        makeVersionRow({ content_hash: sha256('something-else') })
+        makeVersionRow({ content_hash: sha256('something-else') }),
+        '/tmp/skills'
       )
     ).toBe(true)
+  })
+
+  // ===========================================================================
+  // SMI-6343 Wave 3: `sklx list --outdated` must never surface a
+  // local-drift/identity-mismatch row as an ordinary "update available".
+  // ===========================================================================
+
+  it('never reports hasUpdates: true for an owner-mismatch entry (signal 1, deterministic)', () => {
+    // source: "github:lobehub/lobehub" vs id: "wrsmith108/linear" — the real
+    // `linear` incident shape.
+    const entry = makeManifestEntry({
+      id: 'wrsmith108/linear',
+      source: 'github:lobehub/lobehub',
+      contentHash: sha256('installed-content'),
+    })
+    expect(
+      computeHasUpdates(
+        entry,
+        'installed-content',
+        makeVersionRow({ content_hash: sha256('newer-registry-content') }),
+        '/tmp/skills'
+      )
+    ).toBe(false)
+  })
+
+  it('never reports hasUpdates: true for a path-unresolved entry (signal 3, deterministic)', () => {
+    const entry = makeManifestEntry({
+      installPath: '/var/folders/tmp/some-test-fixture-leak/linear',
+      contentHash: sha256('installed-content'),
+    })
+    expect(
+      computeHasUpdates(
+        entry,
+        'installed-content',
+        makeVersionRow({ content_hash: sha256('newer-registry-content') }),
+        '/tmp/skills' // expectedRootDir does NOT contain installPath above
+      )
+    ).toBe(false)
+  })
+
+  it('never reports hasUpdates: true for a local-drift entry (on-disk content diverges from the recorded hash, no identity signal)', () => {
+    const entry = makeManifestEntry({ contentHash: sha256('originally-installed-content') })
+    expect(
+      computeHasUpdates(
+        entry,
+        'user-edited-content', // differs from what contentHash was recorded against
+        makeVersionRow({ content_hash: sha256('registry-content') }),
+        '/tmp/skills'
+      )
+    ).toBe(false)
   })
 })

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Added**: `skill-identity-classification.ts` — a shared tamper-check classification module
+  consumed by both `@skillsmith/mcp-server` (`skill_outdated`) and `@skillsmith/cli`
+  (`skillsmith update`), so the two packages cannot drift into two independently-maintained
+  implementations of the same logic (SMI-6343 Wave 3). Runs three contradiction signals
+  against a manifest entry already known to differ from the registry — owner-mismatch
+  (`id` vs `source`), path-unresolved (`installPath` outside the claimed client's root), and
+  front-matter-contradiction (on-disk `author`/`name` vs the registry's record, fail-closed
+  to `unknown` per ADR-144/145 when the registry lookup can't complete) — plus a fourth
+  local-edit check (`hasRecordedLocalEdit()`) that distinguishes a benign local edit
+  (`local-drift`) from a genuine version bump (`outdated`). Exports the full five-state
+  `OutdatedClassificationState` (`current`/`outdated`/`local-drift`/`identity-mismatch`/
+  `unknown`) from `@skillsmith/core`.
 - **Fix**: `skill_versions.content_hash` (`SyncEngine.upsertSkills()`) now records the
   registry's real SKILL.md content hash instead of a hash of a JSON metadata proxy
   (`{id, name, description, updated_at}`) — the proxy meant every reader comparing against

--- a/packages/core/src/exports/services.install.ts
+++ b/packages/core/src/exports/services.install.ts
@@ -79,6 +79,33 @@ export {
 } from '../services/skill-installation.feedback.js'
 
 // ============================================================================
+// Identity Classification (SMI-6343 Wave 3)
+// ============================================================================
+
+// Shared three-signal contradiction classification, consumed by BOTH
+// mcp-server (`outdated.identity.ts`) and cli (`manage.update.helpers.ts`)
+// so the two packages cannot drift into two independently-maintained
+// implementations of the same logic.
+export {
+  parseOwnerFromSource,
+  parseOwnerFromId,
+  detectOwnerMismatch,
+  detectPathUnresolved,
+  classifyManifestEntryIdentity,
+  hasRecordedLocalEdit,
+  classifyDivergentEntry,
+  classifyOutdatedState,
+  type IdentitySignal,
+  type IdentityInconclusiveReason,
+  type OutdatedClassificationState,
+  type IdentityRegistryRecord,
+  type RegistryLookupOutcome,
+  type ManifestEntryForIdentity,
+  type IdentityClassificationResult,
+  type DivergentEntryClassification,
+} from '../services/skill-identity-classification.js'
+
+// ============================================================================
 // Discovery-Tool Consistency (SMI-5896: Wave 3)
 // ============================================================================
 

--- a/packages/core/src/services/skill-identity-classification.test.ts
+++ b/packages/core/src/services/skill-identity-classification.test.ts
@@ -115,6 +115,15 @@ describe('detectPathUnresolved (signal 3)', () => {
   it('does not fire when installPath equals the root itself', () => {
     expect(detectPathUnresolved(root, root)).toBe(false)
   })
+  it('does NOT fire for a contained child whose name merely starts with two dots (adversarial-review regression)', () => {
+    // path.relative('/root', '/root/..cache') === '..cache' — a literal,
+    // legitimate directory name, not a parent-directory escape. A bare
+    // `rel.startsWith('..')` check would misclassify this as outside.
+    expect(detectPathUnresolved(`${root}/..cache`, root)).toBe(false)
+  })
+  it('fires for an actual parent-directory escape one level up', () => {
+    expect(detectPathUnresolved('/home/user/.claude/other', root)).toBe(true)
+  })
 })
 
 describe('hasRecordedLocalEdit', () => {

--- a/packages/core/src/services/skill-identity-classification.test.ts
+++ b/packages/core/src/services/skill-identity-classification.test.ts
@@ -1,0 +1,348 @@
+/**
+ * @fileoverview Unit tests for the shared skill-identity classification module
+ * @see SMI-6343 Wave 3 — tamper-check classification (AC#3)
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseOwnerFromSource,
+  parseOwnerFromId,
+  detectOwnerMismatch,
+  detectPathUnresolved,
+  hasRecordedLocalEdit,
+  classifyManifestEntryIdentity,
+  classifyDivergentEntry,
+  classifyOutdatedState,
+  type ManifestEntryForIdentity,
+  type RegistryLookupOutcome,
+} from './skill-identity-classification.js'
+
+function entry(overrides: Partial<ManifestEntryForIdentity> = {}): ManifestEntryForIdentity {
+  return {
+    id: 'wrsmith108/linear',
+    source: 'github:wrsmith108/linear',
+    installPath: '/home/user/.claude/skills/linear',
+    ...overrides,
+  }
+}
+
+const notAttempted: RegistryLookupOutcome = { attempted: false, record: null, failureReason: null }
+
+describe('parseOwnerFromSource', () => {
+  it('parses the owner out of a github: prefixed source', () => {
+    expect(parseOwnerFromSource('github:lobehub/lobehub')).toBe('lobehub')
+  })
+  it('parses a bare owner/repo without the prefix', () => {
+    expect(parseOwnerFromSource('acme/widget')).toBe('acme')
+  })
+  it('returns null for the "unknown" distrust sentinel', () => {
+    expect(parseOwnerFromSource('unknown')).toBeNull()
+  })
+  it('returns null for a source with no parseable owner segment', () => {
+    expect(parseOwnerFromSource('registry')).toBeNull()
+    expect(parseOwnerFromSource('')).toBeNull()
+    expect(parseOwnerFromSource(null)).toBeNull()
+    expect(parseOwnerFromSource(undefined)).toBeNull()
+  })
+  it('returns null for a raw URL source with no github: prefix', () => {
+    expect(parseOwnerFromSource('https://github.com/owner/repo')).toBeNull()
+  })
+})
+
+describe('parseOwnerFromId', () => {
+  it('parses the owner out of an owner/name id', () => {
+    expect(parseOwnerFromId('wrsmith108/linear')).toBe('wrsmith108')
+  })
+  it('returns null for a bare name with no slash', () => {
+    expect(parseOwnerFromId('linear')).toBeNull()
+  })
+  it('returns null for null/undefined', () => {
+    expect(parseOwnerFromId(null)).toBeNull()
+    expect(parseOwnerFromId(undefined)).toBeNull()
+  })
+  it('returns null for a raw GitHub URL id (direct-URL install) — regression: must not parse "https:" as the owner', () => {
+    expect(parseOwnerFromId('https://github.com/owner-b/test-repo')).toBeNull()
+  })
+  it('returns null for a 3+-segment owner/repo/path shape', () => {
+    expect(parseOwnerFromId('owner/repo/path')).toBeNull()
+  })
+})
+
+describe('detectOwnerMismatch (signal 1)', () => {
+  it('fires when id and source name different owners — the real `linear` incident shape', () => {
+    expect(detectOwnerMismatch({ id: 'wrsmith108/linear', source: 'github:lobehub/lobehub' })).toBe(
+      true
+    )
+  })
+  it('does not fire when owners agree', () => {
+    expect(
+      detectOwnerMismatch({ id: 'wrsmith108/linear', source: 'github:wrsmith108/linear' })
+    ).toBe(false)
+  })
+  it('does not fire (case-insensitive) when owners agree only up to case', () => {
+    expect(
+      detectOwnerMismatch({ id: 'WrSmith108/linear', source: 'github:wrsmith108/linear' })
+    ).toBe(false)
+  })
+  it('does not fire when source is the "unknown" sentinel', () => {
+    expect(detectOwnerMismatch({ id: 'wrsmith108/linear', source: 'unknown' })).toBe(false)
+  })
+  it('does not fire when id has no owner segment', () => {
+    expect(detectOwnerMismatch({ id: 'linear', source: 'github:lobehub/lobehub' })).toBe(false)
+  })
+  it('does not fire for a direct-URL install (id is the raw URL itself) — regression found against a real CLI multi-client fixture', () => {
+    expect(
+      detectOwnerMismatch({
+        id: 'https://github.com/owner-b/test-repo',
+        source: 'github:owner-b/test-repo',
+      })
+    ).toBe(false)
+  })
+})
+
+describe('detectPathUnresolved (signal 3)', () => {
+  const root = '/home/user/.claude/skills'
+  it('does not fire for a path inside the expected root', () => {
+    expect(detectPathUnresolved(`${root}/astro`, root)).toBe(false)
+  })
+  it('fires for a path outside the expected root — the fixture-leak shape', () => {
+    expect(detectPathUnresolved('/tmp/skillsmith-test-abc123/fixture', root)).toBe(true)
+  })
+  it('fires for a missing installPath', () => {
+    expect(detectPathUnresolved(undefined, root)).toBe(true)
+    expect(detectPathUnresolved('', root)).toBe(true)
+  })
+  it('does not fire when installPath equals the root itself', () => {
+    expect(detectPathUnresolved(root, root)).toBe(false)
+  })
+})
+
+describe('hasRecordedLocalEdit', () => {
+  it('returns true when the on-disk hash differs from the recorded hash', () => {
+    expect(hasRecordedLocalEdit({ contentHash: 'aaa' }, 'bbb')).toBe(true)
+  })
+  it('returns false when the on-disk hash matches the recorded hash', () => {
+    expect(hasRecordedLocalEdit({ contentHash: 'aaa' }, 'aaa')).toBe(false)
+  })
+  it('falls back to originalContentHash when contentHash is absent', () => {
+    expect(hasRecordedLocalEdit({ originalContentHash: 'aaa' }, 'bbb')).toBe(true)
+  })
+  it('defaults to false (no evidence of edit) when neither hash was ever recorded', () => {
+    expect(hasRecordedLocalEdit({}, 'bbb')).toBe(false)
+  })
+  it('defaults to false when the local hash itself is unavailable', () => {
+    expect(hasRecordedLocalEdit({ contentHash: 'aaa' }, null)).toBe(false)
+  })
+})
+
+describe('classifyManifestEntryIdentity — signal 2 (frontmatter contradiction)', () => {
+  const frontmatterContent = [
+    '---',
+    'name: commit',
+    'author: some-unrelated-author',
+    '---',
+    '# Commit skill',
+    'Sentry commit-message conventions.',
+  ].join('\n')
+
+  it('fires when on-disk author contradicts the registry record for the claimed id', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry({ id: 'acme/commit', source: 'github:acme/commit' }),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: { author: 'acme', name: 'commit' } },
+    })
+    expect(result.signal).toBe('frontmatter-contradiction')
+    expect(result.inconclusive).toBe(false)
+  })
+
+  it('does not fire when on-disk author agrees with the registry record', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry({
+        id: 'some-unrelated-author/commit',
+        source: 'github:some-unrelated-author/commit',
+      }),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: {
+        attempted: true,
+        record: { author: 'some-unrelated-author', name: 'commit' },
+      },
+    })
+    expect(result.signal).toBeNull()
+    expect(result.inconclusive).toBe(false)
+  })
+
+  it('is inconclusive (never "no contradiction") when the lookup was not attempted — offline', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry(),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: false, record: null, failureReason: 'offline' },
+    })
+    expect(result.signal).toBeNull()
+    expect(result.inconclusive).toBe(true)
+    expect(result.inconclusiveReason).toBe('offline')
+  })
+
+  it('is inconclusive when quota-exhausted', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry(),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: false, record: null, failureReason: 'quota-exhausted' },
+    })
+    expect(result.inconclusive).toBe(true)
+    expect(result.inconclusiveReason).toBe('quota-exhausted')
+  })
+
+  it('is inconclusive when the lookup was attempted but failed (network error)', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry(),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: null, failureReason: 'network-error' },
+    })
+    expect(result.inconclusive).toBe(true)
+    expect(result.inconclusiveReason).toBe('network-error')
+  })
+
+  it('is inconclusive when the lookup completed but found no registry record', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry(),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: null },
+    })
+    expect(result.inconclusive).toBe(true)
+    expect(result.inconclusiveReason).toBe('no-registry-record')
+  })
+
+  it('does not fire (and is not inconclusive) when local content has no parseable frontmatter', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry(),
+      localContent: 'plain content with no frontmatter',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: { author: 'wrsmith108', name: 'linear' } },
+    })
+    expect(result.signal).toBeNull()
+    expect(result.inconclusive).toBe(false)
+  })
+
+  it('is a clean non-fire (not inconclusive) when id does not parse as owner/name — a raw-URL direct install has no registry key to check', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry({
+        id: 'https://github.com/owner-b/test-repo',
+        source: 'github:owner-b/test-repo',
+      }),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: notAttempted,
+    })
+    expect(result.signal).toBeNull()
+    expect(result.inconclusive).toBe(false)
+  })
+
+  it('signal 1 takes precedence over an inconclusive signal 2', () => {
+    const result = classifyManifestEntryIdentity({
+      entry: entry({ id: 'wrsmith108/linear', source: 'github:lobehub/lobehub' }),
+      localContent: frontmatterContent,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: notAttempted,
+    })
+    expect(result.signal).toBe('owner-mismatch')
+    expect(result.inconclusive).toBe(false)
+  })
+})
+
+describe('classifyDivergentEntry', () => {
+  it('classifies as identity-mismatch when a signal fires', () => {
+    const result = classifyDivergentEntry({
+      entry: entry({ id: 'wrsmith108/linear', source: 'github:lobehub/lobehub' }),
+      localHash: 'abc',
+      localContent: 'content',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: notAttempted,
+    })
+    expect(result.state).toBe('identity-mismatch')
+    expect(result.signal).toBe('owner-mismatch')
+  })
+
+  it('classifies as unknown when signal 2 is inconclusive', () => {
+    const result = classifyDivergentEntry({
+      entry: entry(),
+      localHash: 'abc',
+      localContent: 'content',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: false, record: null, failureReason: 'offline' },
+    })
+    expect(result.state).toBe('unknown')
+    expect(result.inconclusiveReason).toBe('offline')
+  })
+
+  it('classifies as local-drift when no signal fires but on-disk content diverges from the recorded hash', () => {
+    const result = classifyDivergentEntry({
+      entry: entry({ contentHash: 'recorded-hash' }),
+      localHash: 'edited-hash',
+      localContent: 'content',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: { author: 'wrsmith108', name: 'linear' } },
+    })
+    expect(result.state).toBe('local-drift')
+    expect(result.signal).toBeNull()
+  })
+
+  it('classifies as outdated when no signal fires and no local edit is evidenced', () => {
+    const result = classifyDivergentEntry({
+      entry: entry(),
+      localHash: 'installed-hash',
+      localContent: 'content',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: { author: 'wrsmith108', name: 'linear' } },
+    })
+    expect(result.state).toBe('outdated')
+  })
+})
+
+describe('classifyOutdatedState', () => {
+  it('returns current without evaluating signals', () => {
+    const result = classifyOutdatedState({
+      comparisonOutcome: 'current',
+      unknownReasonWhenComparisonUnknown: 'no-history',
+      entry: entry({ id: 'wrsmith108/linear', source: 'github:lobehub/lobehub' }), // would fire if evaluated
+      localHash: 'x',
+      localContent: 'content',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: notAttempted,
+    })
+    expect(result.state).toBe('current')
+    expect(result.signal).toBeNull()
+  })
+
+  it('returns unknown with the caller-supplied reason when the comparison itself is unknown', () => {
+    const result = classifyOutdatedState({
+      comparisonOutcome: 'unknown',
+      unknownReasonWhenComparisonUnknown: 'no-history',
+      entry: entry(),
+      localHash: null,
+      localContent: null,
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: notAttempted,
+    })
+    expect(result.state).toBe('unknown')
+    expect(result.inconclusiveReason).toBe('no-history')
+  })
+
+  it('delegates to classifyDivergentEntry for an outdated comparison outcome', () => {
+    const result = classifyOutdatedState({
+      comparisonOutcome: 'outdated',
+      unknownReasonWhenComparisonUnknown: 'no-history',
+      entry: entry(),
+      localHash: 'installed-hash',
+      localContent: 'content',
+      expectedRootDir: '/home/user/.claude/skills',
+      registryLookup: { attempted: true, record: { author: 'wrsmith108', name: 'linear' } },
+    })
+    expect(result.state).toBe('outdated')
+  })
+})

--- a/packages/core/src/services/skill-identity-classification.ts
+++ b/packages/core/src/services/skill-identity-classification.ts
@@ -1,0 +1,413 @@
+/**
+ * @fileoverview Shared skill-identity contradiction-signal classification
+ * @module @skillsmith/core/services/skill-identity-classification
+ * @see SMI-6343 Wave 3 — tamper-check classification (AC#3)
+ *
+ * Three deterministic-or-best-effort "does this manifest entry's recorded
+ * identity contradict what's actually installed" signals, plus a
+ * "has this on-disk content been locally edited since install" check —
+ * consumed by BOTH `packages/mcp-server/src/tools/outdated.ts` (via
+ * `outdated.identity.ts`) and `packages/cli/src/commands/manage.update.ts`,
+ * so the two packages cannot drift into two independently-maintained
+ * implementations of the same contradiction logic (exactly the "sibling
+ * implementation" bug class both Wave 1 and Wave 2 of SMI-6343 already hit).
+ *
+ * Deliberately decoupled from either caller's own `RegistrySkillInfo` shape
+ * (mcp-server's `install.types.ts` and core's own `skill-installation.types.ts`
+ * both have independently-evolved versions) — callers adapt their own
+ * registry-lookup result into the minimal {@link RegistryLookupOutcome} shape
+ * this module needs.
+ *
+ * Every function here is synchronous and filesystem-free by design: signal 3
+ * (path containment) is a pure string check against an already-resolved
+ * expected root directory, not a `fs.realpath` call — the callers of this
+ * module (`outdated.ts`, `manage.update.ts`) only ever reach the "outdated"
+ * classification branch after already having successfully read the
+ * installed skill's SKILL.md this same iteration, so "does installPath
+ * exist" is already established by the time these signals run.
+ */
+
+import { relative, isAbsolute } from 'node:path'
+import { SkillParser } from '../indexer/SkillParser.js'
+import { firstNonBlankHash } from './skill-content-comparison.js'
+import type { ContentComparisonOutcome } from './skill-content-comparison.js'
+import type { ClientId } from '../install/paths.js'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Which of the three contradiction signals fired. */
+export type IdentitySignal = 'owner-mismatch' | 'frontmatter-contradiction' | 'path-unresolved'
+
+/** Why a classification could not be conclusively determined. */
+export type IdentityInconclusiveReason =
+  | 'offline'
+  | 'quota-exhausted'
+  | 'network-error'
+  | 'no-registry-record'
+  | 'no-history'
+
+/** The five-state classification `outdated.ts`/`manage.update.ts` report against a divergent entry. */
+export type OutdatedClassificationState =
+  | 'current'
+  | 'outdated'
+  | 'local-drift'
+  | 'identity-mismatch'
+  | 'unknown'
+
+/** Minimal registry-record shape signal 2 needs. */
+export interface IdentityRegistryRecord {
+  author?: string | null
+  name?: string | null
+}
+
+/**
+ * The outcome of a caller's OWN registry lookup for the entry's claimed
+ * `id`, adapted into this module's minimal shape.
+ *
+ * `attempted: false` means the caller never even tried this run (offline,
+ * or an earlier skill in the same batch already exhausted quota) —
+ * `failureReason` in that case names WHY it wasn't attempted. `attempted:
+ * true` with `record: null` means the lookup completed but found nothing
+ * for this id (a distinct case from a failed lookup — see
+ * `no-registry-record` below).
+ */
+export interface RegistryLookupOutcome {
+  attempted: boolean
+  record: IdentityRegistryRecord | null
+  /** Populated when the lookup either wasn't attempted or didn't complete. */
+  failureReason?: 'offline' | 'quota-exhausted' | 'network-error' | null
+}
+
+/** The subset of a manifest entry every signal needs. */
+export interface ManifestEntryForIdentity {
+  id: string
+  source: string
+  installPath: string
+  client?: ClientId
+  contentHash?: string
+  originalContentHash?: string
+}
+
+/** Result of {@link classifyManifestEntryIdentity}. */
+export interface IdentityClassificationResult {
+  /** Which signal fired. Null when no signal fired (regardless of `inconclusive`). */
+  signal: IdentitySignal | null
+  /** True when signal 2 (frontmatter) could not be checked at all. */
+  inconclusive: boolean
+  /** Populated only when `inconclusive` is true. */
+  inconclusiveReason: IdentityInconclusiveReason | null
+}
+
+/** Result of {@link classifyDivergentEntry}. */
+export interface DivergentEntryClassification {
+  state: Exclude<OutdatedClassificationState, 'current'>
+  signal: IdentitySignal | null
+  inconclusiveReason: IdentityInconclusiveReason | null
+}
+
+// ============================================================================
+// Signal 1 — owner mismatch
+// ============================================================================
+
+/**
+ * Parse a clean `owner/name` pair (exactly one slash, no URL scheme) into
+ * its owner segment. Returns `null` for anything that isn't that exact
+ * shape — critically, a raw URL (`https://github.com/owner/repo`, a
+ * direct-URL install's `id`/`source`) is NOT an `owner/name` pair and must
+ * return `null` here rather than a garbage "owner" parsed from before the
+ * URL's first slash (e.g. `'https:'`). Mirrors the same 2-segment
+ * distinction `install.helpers.ts`'s `parseSkillId()` already draws between
+ * a registry id and a direct GitHub reference.
+ */
+function parseOwnerFromOwnerNamePair(value: string): string | null {
+  if (value.includes('://')) return null
+  const parts = value.split('/')
+  if (parts.length !== 2) return null
+  const [owner, name] = parts
+  return owner.length > 0 && name.length > 0 ? owner : null
+}
+
+/**
+ * Parse the owner segment out of a manifest `source` string. Real installs
+ * write `source` as `'github:' + owner + '/' + repo` (`skill-installation.
+ * service.ts`) — the `'github:'` prefix is optional here so a bare
+ * `owner/repo` (or a future non-GitHub source shape) still parses. Returns
+ * `null` for the `'unknown'` distrust sentinel, a raw URL, or anything else
+ * with no parseable `owner/name` shape.
+ */
+export function parseOwnerFromSource(source: string | undefined | null): string | null {
+  if (!source || source === 'unknown') return null
+  const withoutPrefix = source.startsWith('github:') ? source.slice('github:'.length) : source
+  return parseOwnerFromOwnerNamePair(withoutPrefix)
+}
+
+/**
+ * Parse the owner segment out of a manifest entry's `id`. Returns `null`
+ * for anything that isn't a clean `owner/name` pair — most importantly a
+ * raw GitHub URL, which a direct-URL install records as `id` verbatim (see
+ * {@link parseOwnerFromOwnerNamePair}).
+ */
+export function parseOwnerFromId(id: string | undefined | null): string | null {
+  if (!id) return null
+  return parseOwnerFromOwnerNamePair(id)
+}
+
+/**
+ * Signal 1: `id` parses as `owner/name` and `source` names a DIFFERENT
+ * owner. Deterministic, offline, zero network dependency. Catches the real
+ * `linear` skill corruption (`source: "github:lobehub/lobehub"` vs
+ * `id: "wrsmith108/linear"`).
+ */
+export function detectOwnerMismatch(
+  entry: Pick<ManifestEntryForIdentity, 'id' | 'source'>
+): boolean {
+  const idOwner = parseOwnerFromId(entry.id)
+  const sourceOwner = parseOwnerFromSource(entry.source)
+  if (!idOwner || !sourceOwner) return false
+  return idOwner.toLowerCase() !== sourceOwner.toLowerCase()
+}
+
+// ============================================================================
+// Signal 3 — path unresolved
+// ============================================================================
+
+/**
+ * Signal 3: `installPath` is absent, or resolves OUTSIDE `expectedRootDir`
+ * (the claimed client's native install root, or a workspace-scoped
+ * equivalent the caller resolves — see each caller's own scope handling).
+ *
+ * Deliberately a pure string containment check (`path.relative`), not a
+ * filesystem call: both callers of this module only reach this signal after
+ * already having successfully read the entry's SKILL.md this same
+ * iteration, so filesystem existence is already established. This also
+ * catches the exact shape of the SMI-6343 Wave 1 test-fixture leak (an
+ * OS-temp-dir `installPath` written into the real manifest) via simple
+ * string comparison, with no need to resolve symlinks.
+ */
+export function detectPathUnresolved(
+  installPath: string | undefined | null,
+  expectedRootDir: string
+): boolean {
+  if (!installPath) return true
+  const rel = relative(expectedRootDir, installPath)
+  if (rel === '') return false
+  return rel.startsWith('..') || isAbsolute(rel)
+}
+
+// ============================================================================
+// Signal 2 — front-matter contradiction
+// ============================================================================
+
+interface Signal2Result {
+  fired: boolean
+  inconclusive: boolean
+  inconclusiveReason: IdentityInconclusiveReason | null
+}
+
+function normalize(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Signal 2: on-disk front-matter `author`/`name` contradicts the registry's
+ * record for the claimed `id`. Catches the real `commit` skill corruption
+ * (internally-consistent id/source, but content that belongs to an
+ * unrelated skill) — signal 1 alone does not catch this shape.
+ *
+ * H2 (fail-closed): when the registry lookup could not complete (offline,
+ * network error, quota-exhausted) OR completed but found no record for the
+ * claimed id, this returns `inconclusive: true` — NEVER "no contradiction."
+ * An inconclusive signal 2 still forces the overall classification to
+ * `unknown`, not `local-drift`/`current` — see {@link classifyDivergentEntry}.
+ *
+ * Exception, not a weakening of H2: when `id` itself doesn't parse as a
+ * well-formed `owner/name` registry key (a raw GitHub URL from a direct-URL
+ * install, an unresolved UUID) there is structurally no registry record to
+ * look up in the first place — a caller cannot "fail to check" something
+ * that was never a registry-backed identity to begin with. This is a clean
+ * non-fire, not an inconclusive one, exactly mirroring how an unparseable
+ * on-disk front-matter is treated below.
+ */
+function evaluateFrontmatterContradiction(
+  entryId: string,
+  localContent: string | null,
+  registryLookup: RegistryLookupOutcome
+): Signal2Result {
+  if (parseOwnerFromId(entryId) === null) {
+    return { fired: false, inconclusive: false, inconclusiveReason: null }
+  }
+  if (!registryLookup.attempted) {
+    return {
+      fired: false,
+      inconclusive: true,
+      inconclusiveReason: registryLookup.failureReason ?? 'network-error',
+    }
+  }
+  if (registryLookup.failureReason) {
+    return { fired: false, inconclusive: true, inconclusiveReason: registryLookup.failureReason }
+  }
+  if (!registryLookup.record) {
+    return { fired: false, inconclusive: true, inconclusiveReason: 'no-registry-record' }
+  }
+
+  const parsed = localContent !== null ? new SkillParser().parse(localContent) : null
+  if (!parsed) {
+    // Nothing to contradict with — a local parse failure is a data-quality
+    // fact, not a network-dependent uncertainty, so this is a clean
+    // non-fire, not `inconclusive` (see this module's fileoverview).
+    return { fired: false, inconclusive: false, inconclusiveReason: null }
+  }
+
+  const localAuthor = normalize(parsed.author)
+  const localName = normalize(parsed.name)
+  const registryAuthor = normalize(registryLookup.record.author)
+  const registryName = normalize(registryLookup.record.name)
+
+  const authorContradiction =
+    localAuthor !== null &&
+    registryAuthor !== null &&
+    localAuthor.toLowerCase() !== registryAuthor.toLowerCase()
+  const nameContradiction =
+    localName !== null &&
+    registryName !== null &&
+    localName.toLowerCase() !== registryName.toLowerCase()
+
+  return {
+    fired: authorContradiction || nameContradiction,
+    inconclusive: false,
+    inconclusiveReason: null,
+  }
+}
+
+// ============================================================================
+// Combined signal classification
+// ============================================================================
+
+/**
+ * Run all three contradiction signals against a manifest entry. Any one
+ * conclusively firing means `signal` is non-null — order (1, 3, 2) checks
+ * the two deterministic/offline signals first, only falling to the
+ * network-dependent signal 2 when neither of those already answered the
+ * question.
+ */
+export function classifyManifestEntryIdentity(params: {
+  entry: ManifestEntryForIdentity
+  localContent: string | null
+  expectedRootDir: string
+  registryLookup: RegistryLookupOutcome
+}): IdentityClassificationResult {
+  const { entry, localContent, expectedRootDir, registryLookup } = params
+
+  if (detectOwnerMismatch(entry)) {
+    return { signal: 'owner-mismatch', inconclusive: false, inconclusiveReason: null }
+  }
+  if (detectPathUnresolved(entry.installPath, expectedRootDir)) {
+    return { signal: 'path-unresolved', inconclusive: false, inconclusiveReason: null }
+  }
+
+  const signal2 = evaluateFrontmatterContradiction(entry.id, localContent, registryLookup)
+  if (signal2.inconclusive) {
+    return { signal: null, inconclusive: true, inconclusiveReason: signal2.inconclusiveReason }
+  }
+  if (signal2.fired) {
+    return { signal: 'frontmatter-contradiction', inconclusive: false, inconclusiveReason: null }
+  }
+  return { signal: null, inconclusive: false, inconclusiveReason: null }
+}
+
+// ============================================================================
+// Local-edit detection (local-drift vs outdated)
+// ============================================================================
+
+/**
+ * Has the on-disk content changed since the manifest's own recorded
+ * install/update-time hash? This is what distinguishes a benign local edit
+ * (`local-drift`) from a genuine registry version bump (`outdated`) once
+ * no identity signal has fired.
+ *
+ * When the manifest never recorded a comparable hash at all (a legacy or
+ * adopted entry, `contentHash`/`originalContentHash` both absent), this
+ * deliberately defaults to `false` (no edit evidence) rather than `true`
+ * (conservative) — absence of a recorded hash is a data-quality gap, not
+ * positive evidence of tampering, and defaulting to `true` here would
+ * misclassify the large population of legacy/adopted entries that never had
+ * a hash recorded as `local-drift` even when they are genuinely just
+ * outdated (SMI-6343 Wave 3 review finding).
+ */
+export function hasRecordedLocalEdit(
+  entry: Pick<ManifestEntryForIdentity, 'contentHash' | 'originalContentHash'>,
+  localHash: string | null
+): boolean {
+  const recordedHash = firstNonBlankHash(entry.contentHash, entry.originalContentHash)
+  if (recordedHash === null || localHash === null) return false
+  return recordedHash !== localHash
+}
+
+// ============================================================================
+// Full divergent-entry classification
+// ============================================================================
+
+/**
+ * Classify an entry the caller has ALREADY determined is divergent from the
+ * registry (mcp-server: `compareSkillContentHashes(...).outcome ===
+ * 'outdated'`; CLI: `getSkillDiff()` found a version/content difference).
+ * Never returns `'current'` — callers own that trivial case themselves,
+ * since it never needs signal evaluation at all.
+ */
+export function classifyDivergentEntry(params: {
+  entry: ManifestEntryForIdentity
+  localHash: string | null
+  localContent: string | null
+  expectedRootDir: string
+  registryLookup: RegistryLookupOutcome
+}): DivergentEntryClassification {
+  const identity = classifyManifestEntryIdentity(params)
+  if (identity.signal) {
+    return { state: 'identity-mismatch', signal: identity.signal, inconclusiveReason: null }
+  }
+  if (identity.inconclusive) {
+    return { state: 'unknown', signal: null, inconclusiveReason: identity.inconclusiveReason }
+  }
+
+  const hasLocalEdit = hasRecordedLocalEdit(params.entry, params.localHash)
+  return hasLocalEdit
+    ? { state: 'local-drift', signal: null, inconclusiveReason: null }
+    : { state: 'outdated', signal: null, inconclusiveReason: null }
+}
+
+/**
+ * Full 5-state classification given an already-computed content-comparison
+ * outcome (from `compareSkillContentHashes`) plus the caller-derived reason
+ * a plain `'unknown'` comparison outcome couldn't be resolved (offline,
+ * quota-exhausted, network-error, or no-history — the caller already tracks
+ * which applies; see `outdated.ts`'s `deriveUnknownReason`).
+ */
+export function classifyOutdatedState(params: {
+  comparisonOutcome: ContentComparisonOutcome
+  unknownReasonWhenComparisonUnknown: IdentityInconclusiveReason
+  entry: ManifestEntryForIdentity
+  localHash: string | null
+  localContent: string | null
+  expectedRootDir: string
+  registryLookup: RegistryLookupOutcome
+}): {
+  state: OutdatedClassificationState
+  signal: IdentitySignal | null
+  inconclusiveReason: IdentityInconclusiveReason | null
+} {
+  if (params.comparisonOutcome === 'current') {
+    return { state: 'current', signal: null, inconclusiveReason: null }
+  }
+  if (params.comparisonOutcome === 'unknown') {
+    return {
+      state: 'unknown',
+      signal: null,
+      inconclusiveReason: params.unknownReasonWhenComparisonUnknown,
+    }
+  }
+  return classifyDivergentEntry(params)
+}

--- a/packages/core/src/services/skill-identity-classification.ts
+++ b/packages/core/src/services/skill-identity-classification.ts
@@ -27,7 +27,7 @@
  * exist" is already established by the time these signals run.
  */
 
-import { relative, isAbsolute } from 'node:path'
+import { relative, isAbsolute, sep } from 'node:path'
 import { SkillParser } from '../indexer/SkillParser.js'
 import { firstNonBlankHash } from './skill-content-comparison.js'
 import type { ContentComparisonOutcome } from './skill-content-comparison.js'
@@ -185,6 +185,25 @@ export function detectOwnerMismatch(
  * catches the exact shape of the SMI-6343 Wave 1 test-fixture leak (an
  * OS-temp-dir `installPath` written into the real manifest) via simple
  * string comparison, with no need to resolve symlinks.
+ *
+ * NOT a symlink-escape check (Wave 3 adversarial review, considered and
+ * scoped out): a real `installPath` inside `expectedRootDir` that is
+ * ITSELF a symlink pointing elsewhere is a local-filesystem-tampering
+ * threat distinct from this signal's actual purpose (catching a manifest
+ * entry whose *recorded* path doesn't match a legitimate install
+ * location — a software-bug/registry-tamper shape, not local attacker
+ * capability); an attacker with write access to plant such a symlink
+ * inside the client root already has equivalent-or-greater capability to
+ * edit SKILL.md content directly, making a `fs.realpath` upgrade here
+ * (which would also force this whole synchronous, filesystem-free module
+ * to become async) address a threat this signal was never meant to cover.
+ *
+ * The parent-segment check below (`rel === '..' || rel.startsWith('..' +
+ * sep)`) is deliberately NOT a bare `rel.startsWith('..')`: a literal
+ * directory name that happens to start with two dots (e.g. `..cache`) is a
+ * legitimate contained child — `path.relative('/r', '/r/..cache')` returns
+ * `'..cache'`, which a bare `startsWith('..')` would misclassify as an
+ * escape (Wave 3 adversarial review finding).
  */
 export function detectPathUnresolved(
   installPath: string | undefined | null,
@@ -193,7 +212,7 @@ export function detectPathUnresolved(
   if (!installPath) return true
   const rel = relative(expectedRootDir, installPath)
   if (rel === '') return false
-  return rel.startsWith('..') || isAbsolute(rel)
+  return rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)
 }
 
 // ============================================================================

--- a/packages/core/src/services/skill-installation.types.ts
+++ b/packages/core/src/services/skill-installation.types.ts
@@ -247,6 +247,12 @@ export interface RegistrySkillInfo {
   quarantined?: boolean
   /** SHA-256 hash of SKILL.md at index time for tamper detection */
   contentHash?: string
+  /**
+   * SMI-6343 Wave 3: the registry's recorded author for this skill id, used
+   * by the shared identity-classification module's front-matter-contradiction
+   * signal. `null`/absent when the registry has no author on record.
+   */
+  author?: string | null
 }
 
 /**

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Added**: `skill_outdated` now runs a three-signal tamper-check classification on every
+  entry that differs from the registry, widening `status` from `current`/`outdated`/`unknown`
+  to a five-state result: `local-drift` (a benign local edit, excluded from bulk update) and
+  `identity-mismatch` (the recorded id/source/content contradicts what's on disk — e.g. a
+  corrupted manifest entry pointing at an unrelated skill) alongside the existing three states
+  (SMI-6343 Wave 3). Adds a structured `diagnosis` field (`state`, `signal`,
+  `inconclusiveReason`, `summary`, `remediation`, `safeToBulkUpdate`) as the tool's full
+  user-facing surface — `skill_outdated` has no renderer anywhere in this repo, so this JSON
+  response IS the UX. `OutdatedSummary` gains `local_drift`/`identity_mismatch` counts.
 - **Fix**: `skill_outdated` and `skill_updates` now compare real content hashes instead of a
   structurally meaningless proxy comparison (SMI-6343 Wave 2). `skill_outdated` gains a live
   registry lookup arm (via `lookupSkillFromRegistry()`) with full offline/network-error/

--- a/packages/mcp-server/src/__tests__/skill-outdated-resolution.test.ts
+++ b/packages/mcp-server/src/__tests__/skill-outdated-resolution.test.ts
@@ -22,10 +22,15 @@
  * git tier's owner/skill-name, is what skill_outdated keys on.
  *
  * $HOME is set BEFORE the dynamic import of outdated.js (its install.helpers
- * module-level MANIFEST_PATH freezes at import).
+ * module-level MANIFEST_PATH freezes at import — and, as of SMI-6343 Wave 3,
+ * so does `@skillsmith/core/install`'s CLIENT_NATIVE_PATHS, which the new
+ * path-unresolved identity signal reads). `vi.resetModules()` runs between
+ * the env-var write and the dynamic import so both frozen constants are
+ * re-evaluated against the redirected $HOME (same technique as
+ * `manage-update-multi-client.test.ts` / `manage-multi-client.test.ts`).
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -70,7 +75,8 @@ function makeContext(db: Database): ToolContext {
     // SMI-6343 Wave 2 added a required context.apiClient.isOffline() call in
     // outdated.ts's live registry arm. This test predates that arm and has no
     // live registry to mock, so `true` (offline) preserves its original
-    // behavior: only the historical/manifest resolution path is exercised.
+    // behavior: only the historical/manifest resolution path is exercised
+    // (SMI-6385 fixed this same gap independently on main; identical here).
     apiClient: { isOffline: () => true },
   } as unknown as ToolContext
 }
@@ -84,7 +90,14 @@ beforeAll(async () => {
   originalHome = process.env['HOME']
   tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'smi5407-out-home-'))
   process.env['HOME'] = tempHome
-  skillsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'smi5407-out-skills-'))
+  // SMI-6343 (Wave 3): nested under the redirected $HOME's canonical
+  // `.claude/skills` — matching what a REAL install's installPath looks
+  // like — rather than a sibling temp dir. Signal 3 (path-unresolved)
+  // treats an installPath outside the claimed client's native root as an
+  // identity contradiction; a sibling temp dir with no relation to $HOME
+  // would misfire that signal for every fixture entry here.
+  skillsRoot = path.join(tempHome, '.claude', 'skills')
+  fs.mkdirSync(skillsRoot, { recursive: true })
   writeSourceFixture(skillsRoot) // gives each entry a real SKILL.md to hash
 
   // Manifest mirrors exactly what the CLI backfill writes (see the write half).
@@ -124,6 +137,12 @@ beforeAll(async () => {
   const manifestPath = path.join(tempHome, '.skillsmith', 'manifest.json')
   fs.mkdirSync(path.dirname(manifestPath), { recursive: true })
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+  // SMI-6343 (Wave 3): forces a fresh evaluation of every module the dynamic
+  // import below transitively pulls in — including @skillsmith/core/install's
+  // CLIENT_NATIVE_PATHS — against the $HOME set above, rather than whatever
+  // value was frozen in when this file's static top-level imports first
+  // loaded @skillsmith/core.
+  vi.resetModules()
   ;({ executeOutdated } = (await import('../tools/outdated.js')) as unknown as {
     executeOutdated: OutdatedFn
   })

--- a/packages/mcp-server/src/tools/install.helpers.ts
+++ b/packages/mcp-server/src/tools/install.helpers.ts
@@ -169,6 +169,9 @@ export async function lookupSkillFromRegistry(
           quarantined: response.data.quarantined === true,
           // SMI-3510: Content hash for tamper detection
           contentHash: response.data.content_hash ?? undefined,
+          // SMI-6343 Wave 3: used by the shared identity-classification
+          // module's front-matter-contradiction signal.
+          author: response.data.author ?? null,
         }
       }
       // API found skill but no repo_url - it's seed data
@@ -196,6 +199,9 @@ export async function lookupSkillFromRegistry(
       trustTier: validateTrustTier(dbSkill.trustTier),
       // SMI-2437: Pass through quarantine status from local DB
       quarantined: isQuarantined,
+      // SMI-6343 Wave 3: used by the shared identity-classification
+      // module's front-matter-contradiction signal.
+      author: dbSkill.author ?? null,
     }
   }
 

--- a/packages/mcp-server/src/tools/install.types.ts
+++ b/packages/mcp-server/src/tools/install.types.ts
@@ -363,6 +363,16 @@ export interface SkillManifestEntry {
   pinnedVersion?: string
   /** SMI-skill-version-tracking Wave 1: How updates are handled (Wave 2: enforcement) */
   updatePolicy?: 'auto' | 'manual' | 'never'
+  /**
+   * SMI-5894 (Wave 1 Step 3): which client this installation targets.
+   * Absent on manifest entries written before multi-client re-keying —
+   * treat a missing value as the canonical client (`claude-code`), matching
+   * `manifestKeyFor()`'s own default. Mirrors the equivalent field on core's
+   * own `SkillManifestEntry` (`skill-installation.types.ts`) — this
+   * mcp-server-local copy predates that one and was never widened to match
+   * until SMI-6343 Wave 3 needed it for the path-unresolved identity signal.
+   */
+  client?: ClientId
 }
 
 export interface SkillManifest {
@@ -391,4 +401,10 @@ export interface RegistrySkillInfo {
   quarantined?: boolean
   /** SHA-256 hash of SKILL.md at index time for tamper detection */
   contentHash?: string
+  /**
+   * SMI-6343 Wave 3: the registry's recorded author for this skill id, used
+   * by the shared identity-classification module's front-matter-contradiction
+   * signal. `null`/absent when the registry has no author on record.
+   */
+  author?: string | null
 }

--- a/packages/mcp-server/src/tools/outdated.helpers.ts
+++ b/packages/mcp-server/src/tools/outdated.helpers.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview skill_outdated MCP tool — execution helpers
+ * @module @skillsmith/mcp-server/tools/outdated.helpers
+ * @see SMI-3138: Wave 5 — Dependency intelligence outdated tool
+ *
+ * Split out of `outdated.ts` (SMI-6343 Wave 3, 500-line file gate) — the
+ * generic file-read and dependency-satisfaction helpers, distinct from
+ * `outdated.identity.ts`'s Wave-3-specific tamper-check classification.
+ */
+
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import type { SkillDependencyRow } from '@skillsmith/core'
+import type { DependencyStatus } from './outdated.js'
+
+/**
+ * Read the installed SKILL.md's raw content. Returns null if the file
+ * cannot be read.
+ *
+ * SMI-6343 (Wave 3): split out of the old `readInstalledHash` so the raw
+ * content is available for signal 2's front-matter parsing too, without a
+ * second file read.
+ */
+export async function readInstalledContent(installPath: string): Promise<string | null> {
+  const skillMdPath = path.join(installPath, 'SKILL.md')
+  try {
+    const raw = await fs.readFile(skillMdPath, 'utf-8')
+    // Defensive `typeof` guard: a mocked `readFile` with no implementation
+    // wired for a given call can resolve to `undefined` without throwing.
+    return typeof raw === 'string' ? raw : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check dependency satisfaction for a skill.
+ * - skill_hard / skill_soft / skill_peer: satisfied if dep_target is in installedSkillIds
+ * - mcp_server / model_minimum / other: marked satisfied (best-effort, can't verify)
+ */
+export function checkDependencies(
+  deps: SkillDependencyRow[],
+  installedSkillIds: Set<string>
+): DependencyStatus {
+  const satisfied: string[] = []
+  const missing: string[] = []
+
+  for (const dep of deps) {
+    const label = `${dep.dep_type}:${dep.dep_target}`
+
+    if (
+      dep.dep_type === 'skill_hard' ||
+      dep.dep_type === 'skill_soft' ||
+      dep.dep_type === 'skill_peer'
+    ) {
+      if (installedSkillIds.has(dep.dep_target)) {
+        satisfied.push(label)
+      } else {
+        missing.push(label)
+      }
+    } else {
+      // mcp_server, model_minimum, etc. — can't reliably verify, mark satisfied
+      satisfied.push(label)
+    }
+  }
+
+  return { total: deps.length, satisfied, missing }
+}

--- a/packages/mcp-server/src/tools/outdated.identity.ts
+++ b/packages/mcp-server/src/tools/outdated.identity.ts
@@ -1,0 +1,194 @@
+/**
+ * @fileoverview skill_outdated tamper-check classification helpers
+ * @module @skillsmith/mcp-server/tools/outdated.identity
+ * @see SMI-6343 Wave 3 — tamper-check classification (AC#3)
+ *
+ * Split out of `outdated.ts` to keep that file under the audit:standards
+ * 500-line gate. Adapts `outdated.ts`'s already-in-flight Wave 2 live/
+ * historical registry-arm state into the shared, cross-package
+ * `@skillsmith/core` identity-classification module (`skill-identity-
+ * classification.ts`), and builds the per-state `OutdatedDiagnosis` copy
+ * (H6 — this is the tool's entire user-facing surface, since `skill_outdated`
+ * has zero renderers).
+ */
+
+import {
+  classifyOutdatedState,
+  type IdentityInconclusiveReason,
+  type IdentitySignal,
+  type OutdatedClassificationState,
+  type RegistryLookupOutcome,
+  type ManifestEntryForIdentity,
+} from '@skillsmith/core'
+import { CANONICAL_CLIENT, CLIENT_NATIVE_PATHS } from '@skillsmith/core/install'
+import type { ContentComparisonOutcome } from '@skillsmith/core'
+import type { OutdatedDiagnosis } from './outdated.js'
+import type { RegistrySkillInfo } from './install.types.js'
+
+/**
+ * Reconstruct signal 2's registry-lookup outcome from the state `outdated.
+ * ts`'s live registry arm already tracks — no second network call. See that
+ * file's own doc comments (`liveArmOffline`/`quotaExhausted`/`liveArmFailed`)
+ * for what each flag means; this function is deliberately the single place
+ * that translates those Wave 2 flags into the shape Wave 3's shared
+ * classification module expects.
+ */
+export function buildRegistryLookupOutcome(params: {
+  liveArmAttempted: boolean
+  liveArmOffline: boolean
+  quotaExhausted: boolean
+  liveArmFailed: boolean
+  registryInfo: RegistrySkillInfo | null
+}): RegistryLookupOutcome {
+  if (!params.liveArmAttempted) {
+    return {
+      attempted: false,
+      record: null,
+      failureReason: params.liveArmOffline
+        ? 'offline'
+        : params.quotaExhausted
+          ? 'quota-exhausted'
+          : null,
+    }
+  }
+  if (params.liveArmFailed) {
+    return { attempted: true, record: null, failureReason: 'network-error' }
+  }
+  return {
+    attempted: true,
+    record: params.registryInfo
+      ? { author: params.registryInfo.author ?? null, name: params.registryInfo.name ?? null }
+      : null,
+    failureReason: null,
+  }
+}
+
+/**
+ * Why a plain `compareSkillContentHashes(...).outcome === 'unknown'` row
+ * (i.e. one that never even reached signal evaluation) couldn't be
+ * resolved. Distinct from signal 2's own inconclusive reason — this covers
+ * the Wave 2 hash-comparison layer, not the Wave 3 identity layer.
+ */
+export function deriveUnknownReason(params: {
+  liveArmOffline: boolean
+  quotaExhausted: boolean
+  liveArmFailed: boolean
+}): IdentityInconclusiveReason {
+  if (params.liveArmOffline) return 'offline'
+  if (params.quotaExhausted) return 'quota-exhausted'
+  if (params.liveArmFailed) return 'network-error'
+  return 'no-history'
+}
+
+/**
+ * Classify one manifest entry given its already-computed content-comparison
+ * outcome. Resolves `expectedRootDir` (signal 3) from the entry's claimed
+ * client, defaulting to the canonical client per `manifestKeyFor()`'s own
+ * SMI-5894 default — `skill_outdated` only ever reads the GLOBAL manifest
+ * (`loadManifest()` with no override), so every entry it processes is a
+ * global-scope install and `CLIENT_NATIVE_PATHS` is the correct root for
+ * every one of them (unlike the CLI's `manage.update.ts`, which must also
+ * account for workspace-scoped installs — see that file's own resolution).
+ */
+export function classifyOutdatedEntry(params: {
+  entry: ManifestEntryForIdentity
+  comparisonOutcome: ContentComparisonOutcome
+  localHash: string | null
+  localContent: string | null
+  registryLookup: RegistryLookupOutcome
+  unknownReason: IdentityInconclusiveReason
+}): {
+  state: OutdatedClassificationState
+  signal: IdentitySignal | null
+  inconclusiveReason: IdentityInconclusiveReason | null
+} {
+  const expectedRootDir = CLIENT_NATIVE_PATHS[params.entry.client ?? CANONICAL_CLIENT]
+  return classifyOutdatedState({
+    comparisonOutcome: params.comparisonOutcome,
+    unknownReasonWhenComparisonUnknown: params.unknownReason,
+    entry: params.entry,
+    localHash: params.localHash,
+    localContent: params.localContent,
+    expectedRootDir,
+    registryLookup: params.registryLookup,
+  })
+}
+
+/**
+ * H6 — the literal per-state diagnosis copy table. `skill_outdated` has zero
+ * renderers (verified: grep of `skill_outdated`/`OutdatedSkillInfo` across
+ * `packages/cli/src`, `packages/vscode-extension/src`, `packages/website/src`
+ * returns zero functional hits), so this MCP JSON response IS the v1
+ * surface — the exact text here matters.
+ */
+export function buildOutdatedDiagnosis(params: {
+  state: OutdatedClassificationState
+  signal: IdentitySignal | null
+  inconclusiveReason: IdentityInconclusiveReason | null
+}): OutdatedDiagnosis {
+  const { state, signal, inconclusiveReason } = params
+
+  switch (state) {
+    case 'current':
+      return {
+        state,
+        signal: null,
+        inconclusiveReason: null,
+        summary: "On-disk content matches the registry's current content for this id.",
+        remediation: null,
+        safeToBulkUpdate: true,
+      }
+    case 'outdated':
+      return {
+        state,
+        signal: null,
+        inconclusiveReason: null,
+        summary: 'The registry has newer content for this id than what is installed.',
+        remediation: 'Run `skillsmith update <name>` to install the newer version.',
+        safeToBulkUpdate: true,
+      }
+    case 'local-drift':
+      return {
+        state,
+        signal: null,
+        inconclusiveReason: null,
+        summary:
+          'On-disk content differs from the registry, and nothing contradicts the recorded ' +
+          'identity — this looks like a local edit.',
+        remediation:
+          'Excluded from bulk update to protect the local edit. Update this one explicitly if ' +
+          "you want to discard it, or run `apply_manifest_reconcile({ action: 'mark_local', … })` " +
+          'to stop tracking it against the registry.',
+        safeToBulkUpdate: false,
+      }
+    case 'identity-mismatch':
+      return {
+        state,
+        signal,
+        inconclusiveReason: null,
+        summary:
+          "This entry's recorded identity contradicts what is on disk — the recorded id/source " +
+          'may name an unrelated skill.',
+        remediation:
+          'Run `skill_recover_source` for evidence, then `apply_manifest_reconcile` with ' +
+          '`mark_local`, `relink`, or `drop_entry`. Do **not** update this entry — doing so would ' +
+          'overwrite the installed skill with unrelated content.',
+        safeToBulkUpdate: false,
+      }
+    case 'unknown': {
+      const reason = inconclusiveReason ?? 'no-history'
+      const remediation =
+        reason === 'no-registry-record'
+          ? 'Run `skill_recover_source` to identify the source.'
+          : 'Re-run when back online / after quota resets.'
+      return {
+        state,
+        signal: null,
+        inconclusiveReason: reason,
+        summary: `Could not determine whether this entry is current (${reason}).`,
+        remediation,
+        safeToBulkUpdate: false,
+      }
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -5,8 +5,10 @@
  */
 
 import { createHash } from 'crypto'
+import { basename, join } from 'path'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { SkillVersionRepository, SkillDependencyRepository } from '@skillsmith/core'
+import { getCanonicalInstallPath } from '@skillsmith/core/install'
 import { createTestDatabase, closeDatabase } from '@skillsmith/core/testkit'
 import { executeOutdated } from './outdated.js'
 import type { ToolContext } from '../context.js'
@@ -73,6 +75,15 @@ function emptyManifest(): SkillManifest {
   return { version: '1', installedSkills: {} }
 }
 
+/**
+ * SMI-6343 (Wave 3): every real installPath is rebased under the canonical
+ * native root — signal 3 (path-unresolved) treats a path OUTSIDE the
+ * claimed client's native root as a contradiction, and every pre-Wave-3
+ * test in this file uses fictional `/tmp/skills/<name>`-shaped paths that
+ * would otherwise misfire as `identity-mismatch`. The caller-supplied
+ * `installPath`'s basename is preserved (only the directory prefix
+ * changes) so every existing call site keeps compiling unmodified.
+ */
 function manifestWithSkills(
   skills: Array<{ id: string; name: string; installPath: string }>
 ): SkillManifest {
@@ -83,7 +94,7 @@ function manifestWithSkills(
       name: s.name,
       version: '1.0.0',
       source: 'registry',
-      installPath: s.installPath,
+      installPath: join(getCanonicalInstallPath(), basename(s.installPath)),
       installedAt: '2026-01-01T00:00:00Z',
       lastUpdated: '2026-01-01T00:00:00Z',
     }
@@ -147,7 +158,7 @@ describe('executeOutdated', () => {
     expect(result.summary.outdated).toBe(0)
   })
 
-  it('reports skill as outdated when hashes differ', async () => {
+  it('reports skill as unknown (not outdated) when a hash mismatch is found ONLY via stale offline history — SMI-6343 Wave 3: an "outdated" verdict now requires a fresh, successful identity check, which offline cannot provide', async () => {
     const skillId = 'community/outdated-skill'
     mockedLoadManifest.mockResolvedValue(
       manifestWithSkills([
@@ -158,18 +169,21 @@ describe('executeOutdated', () => {
     // Local content is old.
     mockedReadFile.mockResolvedValue('old-content')
 
-    // Registry has a different (real) hash.
+    // Registry has a different (real) hash — but only via stale historical
+    // data (offline, default `makeContext(db)`), so signal 2 can never be
+    // checked this run — H2 fail-closed: this must resolve to `unknown`,
+    // never a confidently-wrong `outdated`.
     await versionRepo.recordVersion(skillId, sha256('latest-content'), '2.0.0')
 
     const result = await executeOutdated({ include_deps: true }, makeContext(db))
 
     expect(result.skills).toHaveLength(1)
-    expect(result.skills[0].status).toBe('outdated')
+    expect(result.skills[0].status).toBe('unknown')
+    expect(result.skills[0].diagnosis.inconclusiveReason).toBe('offline')
+    expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(false)
     expect(result.skills[0].installed_hash).toBe(sha256('old-content').slice(0, 8))
-    expect(result.skills[0].latest_hash).toBe(sha256('latest-content').slice(0, 8))
-    expect(result.skills[0].semver).toBe('2.0.0')
-    expect(result.summary.outdated).toBe(1)
-    expect(result.summary.up_to_date).toBe(0)
+    expect(result.summary.unknown).toBe(1)
+    expect(result.summary.outdated).toBe(0)
   })
 
   it('reports unknown when no version history exists, and never echoes installed_hash as latest_hash', async () => {
@@ -710,6 +724,198 @@ describe('executeOutdated', () => {
       await expect(
         executeOutdated({ include_deps: false }, makeContext(db, { online: true }))
       ).resolves.toBeDefined()
+    })
+  })
+
+  // ===========================================================================
+  // SMI-6343 Wave 3: tamper-check classification (AC#3) — five state fixtures
+  // ===========================================================================
+
+  describe('tamper-check classification', () => {
+    it('classifies a genuine version bump as outdated (safe to bulk-update) when no signal fires', async () => {
+      const skillId = 'wrsmith108/astro'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([{ id: skillId, name: 'astro', installPath: '/tmp/skills/astro' }])
+      )
+      mockedReadFile.mockResolvedValue('old-content') // no frontmatter — signal 2 has nothing to contradict
+      mockedLookupSkillFromRegistry.mockResolvedValue({
+        repoUrl: 'https://github.com/wrsmith108/astro',
+        name: 'astro',
+        trustTier: 'community',
+        contentHash: sha256('new-content'),
+        author: 'wrsmith108',
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(result.skills[0].status).toBe('outdated')
+      expect(result.skills[0].diagnosis.state).toBe('outdated')
+      expect(result.skills[0].diagnosis.signal).toBeNull()
+      expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(true)
+      expect(result.skills[0].diagnosis.remediation).toMatch(/skillsmith update/)
+      expect(result.summary.outdated).toBe(1)
+      expect(result.summary.local_drift).toBe(0)
+      expect(result.summary.identity_mismatch).toBe(0)
+    })
+
+    it('classifies a benign local edit as local-drift (excluded from bulk update) when no identity signal fires', async () => {
+      const skillId = 'wrsmith108/notes'
+      const manifest: SkillManifest = {
+        version: '1',
+        installedSkills: {
+          notes: {
+            id: skillId,
+            name: 'notes',
+            version: '1.0.0',
+            source: 'github:wrsmith108/notes',
+            installPath: join(getCanonicalInstallPath(), 'notes'),
+            installedAt: '2026-01-01T00:00:00Z',
+            lastUpdated: '2026-01-01T00:00:00Z',
+            // Recorded at install time — differs from the on-disk content
+            // mocked below, which is what makes this a local edit.
+            contentHash: sha256('originally-installed-content'),
+          },
+        },
+      }
+      mockedLoadManifest.mockResolvedValue(manifest)
+      mockedReadFile.mockResolvedValue('user-edited-content') // no frontmatter
+      mockedLookupSkillFromRegistry.mockResolvedValue({
+        repoUrl: 'https://github.com/wrsmith108/notes',
+        name: 'notes',
+        trustTier: 'community',
+        contentHash: sha256('registry-content'),
+        author: 'wrsmith108',
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(result.skills[0].status).toBe('local-drift')
+      expect(result.skills[0].diagnosis.state).toBe('local-drift')
+      expect(result.skills[0].diagnosis.signal).toBeNull()
+      expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(false)
+      expect(result.skills[0].diagnosis.summary).toMatch(/local edit/i)
+      expect(result.summary.local_drift).toBe(1)
+      expect(result.summary.outdated).toBe(0)
+      expect(result.summary.identity_mismatch).toBe(0)
+    })
+
+    it('classifies an owner-mismatch entry as identity-mismatch (signal 1) — the real `linear` incident shape', async () => {
+      // source: "github:lobehub/lobehub" vs id: "wrsmith108/linear" — the
+      // exact real-world corruption this signal was built to catch.
+      const skillId = 'wrsmith108/linear'
+      const manifest: SkillManifest = {
+        version: '1',
+        installedSkills: {
+          linear: {
+            id: skillId,
+            name: 'linear',
+            version: '1.0.0',
+            source: 'github:lobehub/lobehub',
+            installPath: join(getCanonicalInstallPath(), 'linear'),
+            installedAt: '2026-01-01T00:00:00Z',
+            lastUpdated: '2026-01-01T00:00:00Z',
+          },
+        },
+      }
+      mockedLoadManifest.mockResolvedValue(manifest)
+      mockedReadFile.mockResolvedValue('linear-content')
+      // Offline — signal 1 is deterministic/offline, so this is exercised
+      // via the historical arm alone, with no live registry call at all.
+      await versionRepo.recordVersion(skillId, sha256('different-content'), '1.0.0')
+
+      const result = await executeOutdated({ include_deps: false }, makeContext(db))
+
+      expect(mockedLookupSkillFromRegistry).not.toHaveBeenCalled()
+      expect(result.skills[0].status).toBe('identity-mismatch')
+      expect(result.skills[0].diagnosis.state).toBe('identity-mismatch')
+      expect(result.skills[0].diagnosis.signal).toBe('owner-mismatch')
+      expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(false)
+      expect(result.skills[0].diagnosis.remediation).toMatch(/skill_recover_source/)
+      expect(result.summary.identity_mismatch).toBe(1)
+    })
+
+    it('classifies a front-matter contradiction as identity-mismatch (signal 2) despite id/source agreement — the real `commit` incident shape', async () => {
+      // Internally-consistent id/source (signal 1 passes clean) but the
+      // on-disk front-matter's claimed author contradicts the registry's
+      // record for this id — the harder case, since it requires content
+      // inspection rather than a simple id/source string comparison.
+      const skillId = 'acme/commit'
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([{ id: skillId, name: 'commit', installPath: '/tmp/skills/commit' }])
+      )
+      const frontmatterContent = [
+        '---',
+        'name: commit',
+        'author: unrelated-author',
+        '---',
+        '# Commit skill',
+        'Sentry commit-message conventions.',
+      ].join('\n')
+      mockedReadFile.mockResolvedValue(frontmatterContent)
+      mockedLookupSkillFromRegistry.mockResolvedValue({
+        repoUrl: 'https://github.com/acme/commit',
+        name: 'commit',
+        trustTier: 'community',
+        contentHash: sha256('unrelated-registry-content'),
+        author: 'acme',
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      expect(result.skills[0].status).toBe('identity-mismatch')
+      expect(result.skills[0].diagnosis.signal).toBe('frontmatter-contradiction')
+      expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(false)
+      expect(result.summary.identity_mismatch).toBe(1)
+    })
+
+    it('H2 fail-closed: an inconclusive signal 2 (quota-exhausted mid-batch) classifies as unknown, never local-drift or outdated', async () => {
+      // Two skills: the first triggers quota exhaustion, so the SECOND
+      // skill's live arm is skipped entirely THIS run — signal 2 can never
+      // be checked for it. If the fail-open bug were reintroduced (treating
+      // "could not check" as "no contradiction"), this would silently
+      // resolve to `outdated` (no recorded contentHash -> no local-edit
+      // evidence either) instead of the required `unknown`.
+      mockedLoadManifest.mockResolvedValue(
+        manifestWithSkills([
+          { id: 'community/quota-trigger', name: 'quota-trigger', installPath: '/tmp/skills/a' },
+          { id: 'community/quota-victim', name: 'quota-victim', installPath: '/tmp/skills/b' },
+        ])
+      )
+      mockedReadFile.mockResolvedValue('mismatched-content')
+      // Stale history for the second skill so its comparison outcome is
+      // 'outdated' via the historical fallback, reaching classification.
+      await versionRepo.recordVersion(
+        'community/quota-victim',
+        sha256('stale-registry-content'),
+        '1.0.0'
+      )
+      const quotaError = new Error('Monthly quota reached (100/100 community tier).')
+      mockedLookupSkillFromRegistry.mockImplementationOnce(async (_id, _ctx, opts) => {
+        opts?.onQuotaExceeded?.(quotaError)
+        opts?.onLiveLookupFailed?.(quotaError)
+        return null
+      })
+
+      const result = await executeOutdated(
+        { include_deps: false },
+        makeContext(db, { online: true })
+      )
+
+      const victim = result.skills.find((s) => s.id === 'community/quota-victim')
+      expect(victim?.status).toBe('unknown')
+      expect(victim?.status).not.toBe('local-drift')
+      expect(victim?.status).not.toBe('outdated')
+      expect(victim?.diagnosis.inconclusiveReason).toBe('quota-exhausted')
+      expect(victim?.diagnosis.safeToBulkUpdate).toBe(false)
     })
   })
 })

--- a/packages/mcp-server/src/tools/outdated.ts
+++ b/packages/mcp-server/src/tools/outdated.ts
@@ -13,16 +13,21 @@
  */
 
 import { z } from 'zod'
-import { promises as fs } from 'fs'
-import * as path from 'path'
 import { SkillVersionRepository, compareSkillContentHashes } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
-import type { SkillDependencyRow } from '@skillsmith/core'
+import type { IdentitySignal, IdentityInconclusiveReason } from '@skillsmith/core'
 import type { ToolContext } from '../context.js'
 import { hashContent } from './install.conflict-helpers.js'
 import { loadManifest, lookupSkillFromRegistry } from './install.helpers.js'
 import { getManifestInstalledSkillIds } from './manifest-skill-ids.helpers.js'
-import type { SkillManifestEntry } from './install.types.js'
+import type { SkillManifestEntry, RegistrySkillInfo } from './install.types.js'
+import { readInstalledContent, checkDependencies } from './outdated.helpers.js'
+import {
+  classifyOutdatedEntry,
+  buildRegistryLookupOutcome,
+  deriveUnknownReason,
+  buildOutdatedDiagnosis,
+} from './outdated.identity.js'
 
 // ============================================================================
 // Input / Output types
@@ -52,6 +57,33 @@ export interface DependencyStatus {
 }
 
 /**
+ * SMI-6343 (Wave 3, H6): structured, machine-readable companion to the
+ * free-text `hint`. `skill_outdated` has zero renderers anywhere in this
+ * repo (verified — see `outdated.identity.ts`'s doc comment), so this MCP
+ * JSON response is the tool's entire v1 user-facing surface; the field
+ * names and copy ARE the UX.
+ */
+export interface OutdatedDiagnosis {
+  state: 'current' | 'outdated' | 'local-drift' | 'identity-mismatch' | 'unknown'
+  /** Which contradiction signal fired. Null for non-identity-mismatch states. */
+  signal: 'owner-mismatch' | 'frontmatter-contradiction' | 'path-unresolved' | null
+  /** Why the state could not be determined. Null unless state is 'unknown'. */
+  inconclusiveReason:
+    | 'offline'
+    | 'quota-exhausted'
+    | 'network-error'
+    | 'no-registry-record'
+    | 'no-history'
+    | null
+  /** One sentence, addressed to the caller. */
+  summary: string
+  /** The exact next action, naming a real tool call. Null when none is needed. */
+  remediation: string | null
+  /** Whether a bulk/--all update may include this entry. */
+  safeToBulkUpdate: boolean
+}
+
+/**
  * Per-skill outdated information returned by the tool
  */
 export interface OutdatedSkillInfo {
@@ -61,21 +93,26 @@ export interface OutdatedSkillInfo {
   installed_hash: string
   /** 8-char prefix of the latest registry hash */
   latest_hash: string
-  /** Status of the skill: current, outdated, or unknown (no registry data) */
-  status: 'current' | 'outdated' | 'unknown'
+  /**
+   * SMI-6343 (Wave 3): widened from `current | outdated | unknown` to a
+   * five-state classification separating a genuine version bump
+   * (`outdated`, safe to bulk-update) from a benign local edit
+   * (`local-drift`) and a corrupted recorded identity (`identity-mismatch`)
+   * — see `diagnosis` for the structured explanation.
+   */
+  status: 'current' | 'outdated' | 'local-drift' | 'identity-mismatch' | 'unknown'
   /** Semver from the latest version record, if available */
   semver: string | null
   /** Dependency satisfaction details (omitted when include_deps is false) */
   dependencies?: DependencyStatus
+  /** SMI-6343 (Wave 3): structured classification, additive alongside `hint`. */
+  diagnosis: OutdatedDiagnosis
   /**
-   * SMI-5407: present when manifest entry lacks a `source` URL — directs
-   * the user to `sklx audit sources` / `skill_recover_source` to recover.
-   * SMI-6343 (H1): also present, taking precedence over the source-missing
-   * case, when `status === 'unknown'` because the live registry check was
-   * skipped (offline) or stopped (monthly quota exhausted, reset time
-   * included) — the plan's required "diagnosis naming" text for those two
-   * degradation states. A future wave may promote this into a fuller
-   * structured `diagnosis` field; `hint` is the interim carrier.
+   * SMI-5407: present when manifest entry lacks a `source` URL. SMI-6343
+   * (H1): also present, taking precedence, when `status === 'unknown'`
+   * because the live registry check was skipped (offline) or stopped
+   * (quota exhausted). `diagnosis` (above) is the spec'd structured carrier
+   * of this same information as of Wave 3; `hint` is unchanged, not removed.
    */
   hint?: string
 }
@@ -89,6 +126,10 @@ export interface OutdatedSummary {
   up_to_date: number
   unknown: number
   missing_deps: number
+  /** SMI-6343 (Wave 3): entries with a benign local edit, excluded from bulk update. */
+  local_drift: number
+  /** SMI-6343 (Wave 3): entries whose recorded identity contradicts what's on disk. */
+  identity_mismatch: number
 }
 
 /**
@@ -125,58 +166,6 @@ export const outdatedToolSchema = {
 }
 
 // ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Read and hash the installed SKILL.md content.
- * Returns null if the file cannot be read.
- */
-async function readInstalledHash(installPath: string): Promise<string | null> {
-  const skillMdPath = path.join(installPath, 'SKILL.md')
-  try {
-    const content = await fs.readFile(skillMdPath, 'utf-8')
-    return hashContent(content)
-  } catch {
-    return null
-  }
-}
-
-/**
- * Check dependency satisfaction for a skill.
- * - skill_hard / skill_soft / skill_peer: satisfied if dep_target is in installedSkillIds
- * - mcp_server / model_minimum / other: marked satisfied (best-effort, can't verify)
- */
-function checkDependencies(
-  deps: SkillDependencyRow[],
-  installedSkillIds: Set<string>
-): DependencyStatus {
-  const satisfied: string[] = []
-  const missing: string[] = []
-
-  for (const dep of deps) {
-    const label = `${dep.dep_type}:${dep.dep_target}`
-
-    if (
-      dep.dep_type === 'skill_hard' ||
-      dep.dep_type === 'skill_soft' ||
-      dep.dep_type === 'skill_peer'
-    ) {
-      if (installedSkillIds.has(dep.dep_target)) {
-        satisfied.push(label)
-      } else {
-        missing.push(label)
-      }
-    } else {
-      // mcp_server, model_minimum, etc. — can't reliably verify, mark satisfied
-      satisfied.push(label)
-    }
-  }
-
-  return { total: deps.length, satisfied, missing }
-}
-
-// ============================================================================
 // Execution
 // ============================================================================
 
@@ -209,6 +198,8 @@ async function executeOutdatedImpl(
         up_to_date: 0,
         unknown: 0,
         missing_deps: 0,
+        local_drift: 0,
+        identity_mismatch: 0,
       },
     }
   }
@@ -226,6 +217,8 @@ async function executeOutdatedImpl(
   let upToDateCount = 0
   let unknownCount = 0
   let missingDepsCount = 0
+  let localDriftCount = 0
+  let identityMismatchCount = 0
 
   // SMI-6343 (H1): the live registry arm is skipped entirely, for every
   // skill, when offline — never a per-skill error in that case. Monthly
@@ -257,14 +250,20 @@ async function executeOutdatedImpl(
         latest_hash: '--------',
         status: 'unknown',
         semver: null,
+        diagnosis: buildOutdatedDiagnosis({
+          state: 'unknown',
+          signal: null,
+          inconclusiveReason: 'no-history',
+        }),
         ...(input.include_deps ? { dependencies: { total: 0, satisfied: [], missing: [] } } : {}),
       })
       unknownCount++
       continue
     }
 
-    // Hash the currently installed SKILL.md
-    const localHash = await readInstalledHash(entry.installPath)
+    // Read + hash the currently installed SKILL.md
+    const localContent = await readInstalledContent(entry.installPath)
+    const localHash = localContent !== null ? hashContent(localContent) : null
 
     // Historical arm: the most-recently-synced skill_versions row. Valid as
     // an "ever matched" signal now that SyncEngine records a real SKILL.md
@@ -297,9 +296,12 @@ async function executeOutdatedImpl(
     // network-error case silently falling back to historicalHash, exactly
     // the bug this whole block exists to prevent.
     let liveArmFailed = false
+    // SMI-6343 (Wave 3): hoisted so signal 2 can reuse this SAME lookup
+    // instead of firing a second registry call for the same skill.
+    let registryInfo: RegistrySkillInfo | null = null
     if (!liveArmOffline && !quotaExhausted && localHash !== null) {
       try {
-        const registryInfo = await lookupSkillFromRegistry(entry.id, context, {
+        registryInfo = await lookupSkillFromRegistry(entry.id, context, {
           onQuotaExceeded: (error) => {
             quotaExhausted = true
             if (!quotaDiagnosis) {
@@ -338,17 +340,72 @@ async function executeOutdatedImpl(
     const registryHash = liveArmFailed ? null : (liveHash ?? historicalHash)
     const comparison = compareSkillContentHashes(localHash, registryHash)
 
-    let status: 'current' | 'outdated' | 'unknown'
+    // SMI-6343 (Wave 3): mirrors the gate guarding the `try` block above —
+    // was the live arm actually attempted for THIS skill (vs. skipped for
+    // offline/quota/no-local-hash)? Feeds signal 2 below.
+    const liveArmAttempted = !liveArmOffline && !quotaExhausted && localHash !== null
+    const unknownReasonIfAny = deriveUnknownReason({
+      liveArmOffline,
+      quotaExhausted,
+      liveArmFailed,
+    })
+
+    let status: 'current' | 'outdated' | 'local-drift' | 'identity-mismatch' | 'unknown'
+    let identitySignal: IdentitySignal | null = null
+    let inconclusiveReason: IdentityInconclusiveReason | null = null
+
     if (comparison.outcome === 'current') {
       status = 'current'
-      upToDateCount++
-    } else if (comparison.outcome === 'outdated') {
-      status = 'outdated'
-      outdatedCount++
-    } else {
+    } else if (comparison.outcome === 'unknown') {
       status = 'unknown'
-      unknownCount++
+      inconclusiveReason = unknownReasonIfAny
+    } else {
+      // comparison.outcome === 'outdated' — run the three contradiction
+      // signals (SMI-6343 Wave 3, AC#3) before trusting this as a genuine,
+      // safe-to-bulk-update version bump.
+      const registryLookup = buildRegistryLookupOutcome({
+        liveArmAttempted,
+        liveArmOffline,
+        quotaExhausted,
+        liveArmFailed,
+        registryInfo,
+      })
+      const classification = classifyOutdatedEntry({
+        entry,
+        comparisonOutcome: comparison.outcome,
+        localHash,
+        localContent,
+        registryLookup,
+        unknownReason: unknownReasonIfAny,
+      })
+      status = classification.state
+      identitySignal = classification.signal
+      inconclusiveReason = classification.inconclusiveReason
     }
+
+    switch (status) {
+      case 'current':
+        upToDateCount++
+        break
+      case 'outdated':
+        outdatedCount++
+        break
+      case 'local-drift':
+        localDriftCount++
+        break
+      case 'identity-mismatch':
+        identityMismatchCount++
+        break
+      case 'unknown':
+        unknownCount++
+        break
+    }
+
+    const diagnosis = buildOutdatedDiagnosis({
+      state: status,
+      signal: identitySignal,
+      inconclusiveReason,
+    })
 
     // SMI-6343 (H1): the plan's degradation contract requires a diagnosis
     // naming the reason for an offline- or quota-caused `unknown` row.
@@ -376,6 +433,7 @@ async function executeOutdatedImpl(
       latest_hash: registryHash ? registryHash.slice(0, 8) : '--------',
       status,
       semver: historicalSemver,
+      diagnosis,
       // SMI-5407: surface a recovery hint when the manifest entry has no source.
       // The source is needed by skill_diff / View-Changes to fetch the latest
       // SKILL.md content. Recovering it requires `sklx audit sources`. The
@@ -418,6 +476,8 @@ async function executeOutdatedImpl(
       up_to_date: upToDateCount,
       unknown: unknownCount,
       missing_deps: missingDepsCount,
+      local_drift: localDriftCount,
+      identity_mismatch: identityMismatchCount,
     },
   }
 }

--- a/packages/mcp-server/tests/unit/install-helpers.registry.test.ts
+++ b/packages/mcp-server/tests/unit/install-helpers.registry.test.ts
@@ -42,6 +42,10 @@ describe('install.helpers (registry + fetch)', () => {
         name: 'test-skill',
         trustTier: 'community',
         quarantined: false,
+        // SMI-6343 (Wave 3): author now always populated (null when the
+        // API response carries none) for the shared identity-classification
+        // module's front-matter-contradiction signal.
+        author: null,
       })
       expect(mockContext.apiClient.getSkill).toHaveBeenCalledWith('test/skill')
     })
@@ -76,6 +80,7 @@ describe('install.helpers (registry + fetch)', () => {
         name: 'local-skill',
         trustTier: 'experimental',
         quarantined: false,
+        author: null,
       })
     })
 
@@ -110,6 +115,7 @@ describe('install.helpers (registry + fetch)', () => {
         name: 'fallback-skill',
         trustTier: 'community',
         quarantined: false,
+        author: null,
       })
     })
 


### PR DESCRIPTION
## Business Summary

**What shipped:** `skill_outdated` now tells you WHY a skill differs from the registry, not just THAT it does — a benign local edit, a genuinely-corrupted manifest entry, or a real update available are three different things, and only the last one is safe to bulk-update. `skillsmith update` now refuses to overwrite an already-corrupted entry instead of silently trusting it. `sklx list --outdated` no longer flags a local edit or a corrupted entry as "update available."

**Quality bar:** Governance review, Codex (GPT-5.6-Sol) adversarial review, and the pr-reviewer 14-check gate all complete — two rounds each found one real bug, both fixed. Full three-package test suite green, including the src-colocated tests CI actually runs (`vitest.config.colocated.ts`: 325 files, 5087 tests).

**Found along the way:** SMI-6383 (a worktree host-typecheck resolution gap, filed in Wave 2) is unrelated to this PR. No new issues filed this wave.

**Net result:** Fully shipped, pending final go/no-go.

---

## Technical detail

Adds `packages/core/src/services/skill-identity-classification.ts` — a shared module running three contradiction signals (owner-mismatch, path-unresolved, front-matter-contradiction) plus local-edit detection, consumed by both `packages/mcp-server/src/tools/outdated.ts` (via `outdated.identity.ts`) and `packages/cli/src/commands/manage.update.ts` (via `manage.update.identity.ts`), so mcp-server and cli cannot drift into two independently-maintained implementations of the same logic.

`skill_outdated`'s `status` widens from `current`/`outdated`/`unknown` to a five-state result adding `local-drift` and `identity-mismatch`, with a structured `diagnosis` field (this tool has no renderer anywhere in the repo, so the JSON response is the entire user-facing surface). `skillsmith update` gains a pre-install gate that refuses to force-install over a `local-drift`/`identity-mismatch`/`unknown` entry, reporting a new `Skipped` bucket with a reason. `sklx list --outdated` runs the two offline-only signals directly.

Fail-closed per ADR-144/145: an incomplete registry lookup (offline, network error, quota-exhausted) never resolves to "safe," only to `unknown`.

Review rounds fixed two real bugs beyond the initial implementation: a sibling-implementation risk in the CLI's `computeHasUpdates()` (re-derived `hasRecordedLocalEdit()`'s logic inline instead of calling it), and a path-containment boundary bug (`detectPathUnresolved()` misclassified a legitimate directory name starting with `..` as a parent-directory escape). Reports: `docs/internal/code_review/2026-09-04-smi-6343-wave3-governance-review.md`, `2026-09-04-smi-6343-wave3-adversarial-review.md`, and the pr-reviewer gate report.

CHANGELOG entries added for `@skillsmith/core`, `@skillsmith/mcp-server`, `@skillsmith/cli`.
