### PR TITLE
feat(mcp-server,core,vscode-extension): SMI-6343 Wave 4 -- apply_manifest_reconcile tool

### DIFF
--- a/.claude/development/mcp-tools-guide.md
+++ b/.claude/development/mcp-tools-guide.md
@@ -25,9 +25,10 @@ Reference for Skillsmith MCP server tools, authentication, and CLI.
 | `skill_pack_audit` | Audit all skills in a directory (Individual+) |
 | `skill_audit` | Audit skill for security advisories (Team+) |
 | `skill_inventory_audit` | Audit every installed AI coding client's skill inventory for local namespace collisions; returns rename + edit suggestions (Team+) |
-| `apply_namespace_rename` | Apply a rename suggestion from a local namespace-collision audit (`apply` / `custom` / `skip`) (Team+) |
+| `apply_namespace_rename` | Apply a rename suggestion from a local namespace-collision audit (`apply` / `custom` / `skip` / `revert`) (Team+) |
 | `apply_recommended_edit` | Apply a recommended prose edit; gated on `APPLY_TEMPLATE_REGISTRY` (Team+) |
 | `undo_apply` | Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s) (Team+) |
+| `apply_manifest_reconcile` | Repair a corrupted or ambiguous `~/.skillsmith/manifest.json` entry — `mark_local` / `relink` / `drop_entry` / `verify` / `revert` (Community; SMI-6343 Wave 4) |
 | `team_workspace` | Manage team workspaces: create, list, get, delete (Team+) |
 | `share_skill` | Add, remove, or list skills in a team workspace (Team+) |
 | `publish_private` | Mark a skill private on this device, hidden from your own search results (Team+) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,10 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `skill_pack_audit` | Audit all skills in a directory (Individual+) |
 | `skill_audit` | Audit skill for security advisories (Team+) |
 | `skill_inventory_audit` | Audit every installed AI coding client's skill inventory (plus Claude Code's own commands/agents/CLAUDE.md rules) for local namespace collisions; returns rename + edit suggestions (SMI-4590; multi-client SMI-6077) |
-| `apply_namespace_rename` | Apply a rename suggestion from a local namespace-collision audit (`apply` / `custom` / `skip`) (SMI-4590) |
+| `apply_namespace_rename` | Apply a rename suggestion from a local namespace-collision audit (`apply` / `custom` / `skip` / `revert`) (SMI-4590; `revert` SMI-5671) |
 | `apply_recommended_edit` | Apply a recommended prose edit; gated on `APPLY_TEMPLATE_REGISTRY` (SMI-4590) |
 | `undo_apply` | Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s), restored from the apply tool's own backup (SMI-5456/SMI-5470) |
+| `apply_manifest_reconcile` | Repair a corrupted or ambiguous `~/.skillsmith/manifest.json` entry through a supported path — `mark_local` / `relink` / `drop_entry` / `verify` / `revert` (SMI-6343 Wave 4, ADR-144 §6 / ADR-145) |
 | `team_workspace` | Manage team workspaces: create, list, get, delete (Team+) |
 | `share_skill` | Add, remove, or list skills in a team workspace (Team+) |
 | `publish_private` | Mark a skill private on this device, hidden from your own search results (Team+) |

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Added**: `SkillManifestEntry` (`services/skill-installation.types.ts`) gains two optional
+  fields per ADR-145 (manifest provenance as a second trust axis, orthogonal to `source`):
+  `provenance?: 'local' | 'registry'` (who asserts this entry's identity — absent means a legacy
+  entry with no assertion ever recorded, never defaulting to `'registry'`) and
+  `verifiedAt?: string` (ISO-8601 UTC timestamp of the last successful re-verification of the
+  entry's on-disk content hash against the registry's current content hash for the claimed `id`).
+  Written by `@skillsmith/mcp-server`'s new `apply_manifest_reconcile` tool (SMI-6343 Wave 4); read
+  by SMI-6345 Wave 2's E1 identity-evidence gate. `AGENT_TOOL_PROFILE_NAMES`
+  (`services/agent-tool-profile.ts`) gains `apply_manifest_reconcile` (17 entries).
 - **Added**: `emitToolCallEvent()` and a pluggable `TelemetryIdentityProvider` in
   `audit/remote-audit.ts` — posts a `tool_call` telemetry event carrying the
   server-verified `team_id`/actor identity (never a client-supplied credential,

--- a/packages/core/src/services/agent-pack/agent-pack.test.ts
+++ b/packages/core/src/services/agent-pack/agent-pack.test.ts
@@ -64,6 +64,7 @@ const TEST_PROFILE: readonly string[] = [
   'apply_recommended_edit',
   'skill_audit',
   'undo_apply',
+  'apply_manifest_reconcile',
 ]
 
 function pack() {

--- a/packages/core/src/services/agent-pack/prompt-source.ts
+++ b/packages/core/src/services/agent-pack/prompt-source.ts
@@ -86,9 +86,16 @@ export const JOBS: readonly JobDefinition[] = [
       '1. Run skill_outdated to list installed skills that are behind the registry. This is a free diagnosis; always show the whole list.',
       '2. For anything outdated, use skill_updates to see what a bump would bring and skill_diff to show what actually changed between the installed and latest versions, calling out breaking upstream changes explicitly.',
       '3. Use skill_pack_audit when the user wants the state of a whole bundle at once rather than skill by skill.',
-      '4. Group the findings: breaking changes first, then routine bumps. Propose the update plan; apply nothing until the user approves the specific set.',
+      "4. When skill_outdated reports 'local-drift' or 'identity-mismatch' instead of a plain version bump, do not update that entry. Its diagnosis names the next step: apply_manifest_reconcile with mark_local (stop tracking a local edit against the registry), relink (assert a corrected, registry-validated id/source), or drop_entry (remove a stale entry whose install path no longer resolves). Show the diagnosis before proposing a reconcile action.",
+      '5. Group the remaining findings: breaking changes first, then routine bumps. Propose the update plan; apply nothing until the user approves the specific set.',
     ].join('\n'),
-    tools: ['skill_outdated', 'skill_updates', 'skill_diff', 'skill_pack_audit'],
+    tools: [
+      'skill_outdated',
+      'skill_updates',
+      'skill_diff',
+      'skill_pack_audit',
+      'apply_manifest_reconcile',
+    ],
   },
   {
     id: 'audit-fix',
@@ -221,7 +228,7 @@ export const CLI_FALLBACK_COMMANDS: readonly string[] = [
 
 /** Closing note naming the MCP-only tools that have no CLI equivalent yet. */
 export const CLI_FALLBACK_NOTE =
-  'The CLI has no equivalent for skill_pack_audit, the apply_namespace_rename/apply_recommended_edit guided diff-and-approve flow, or undo_apply - those stay MCP-only until the server is back.'
+  'The CLI has no equivalent for skill_pack_audit, the apply_namespace_rename/apply_recommended_edit guided diff-and-approve flow, undo_apply, or apply_manifest_reconcile - those stay MCP-only until the server is back.'
 
 /** One-line SKILL.md frontmatter description (agentskills.io core field). */
 export const PACK_DESCRIPTION =

--- a/packages/core/src/services/agent-tool-profile.test.ts
+++ b/packages/core/src/services/agent-tool-profile.test.ts
@@ -12,8 +12,8 @@ import {
 } from './agent-tool-profile.js'
 
 describe('AGENT_TOOL_PROFILE_NAMES (core, QD-1 relocation)', () => {
-  it('has 16 entries', () => {
-    expect(AGENT_TOOL_PROFILE_NAMES).toHaveLength(16)
+  it('has 17 entries', () => {
+    expect(AGENT_TOOL_PROFILE_NAMES).toHaveLength(17)
   })
 
   it('contains undo_apply', () => {

--- a/packages/core/src/services/agent-tool-profile.ts
+++ b/packages/core/src/services/agent-tool-profile.ts
@@ -75,4 +75,11 @@ export const AGENT_TOOL_PROFILE_NAMES: readonly string[] = [
   'apply_recommended_edit',
   'skill_audit',
   'undo_apply',
+  // SMI-6343 Wave 4: manifest identity repair. Included because
+  // `skill_outdated` (already in this profile)'s `diagnosis.remediation`
+  // copy for `identity-mismatch`/`local-drift` names this tool by name as
+  // the next step — an agent following that documented workflow needs it
+  // in its curated profile, same as `apply_namespace_rename` sits alongside
+  // `skill_inventory_audit`.
+  'apply_manifest_reconcile',
 ]

--- a/packages/core/src/services/skill-installation.types.ts
+++ b/packages/core/src/services/skill-installation.types.ts
@@ -226,6 +226,33 @@ export interface SkillManifestEntry {
    * `manifestKeyFor()`'s own default.
    */
   client?: ClientId
+  /**
+   * ADR-145 §1: who asserts this entry's identity, independent of `source`.
+   * `'registry'` — Skillsmith itself resolved this identity and performed
+   * the install (an install record). `'local'` — the user has positively
+   * asserted this skill is their own / not registry-tracked; this is an
+   * assertion, not an absence of information. Absent = legacy entry, no
+   * assertion was ever recorded — NEVER defaults to `'registry'`. The only
+   * writer of `provenance: 'local'` is `apply_manifest_reconcile`'s
+   * `mark_local` action, which must clear `source` to `'unknown'` in the
+   * SAME locked update (ADR-145 §2 — the two fields are never written
+   * independently, since `'local'` + a registry-ref `source` is an illegal
+   * combination that fails closed on read).
+   */
+  provenance?: 'local' | 'registry'
+  /**
+   * ADR-145 §3 / ADR-144 §6: ISO-8601 UTC timestamp of the last successful
+   * re-verification of this entry's on-disk content hash against the
+   * registry's content hash for the claimed `id`. Absent = never
+   * re-verified. Written only by `apply_manifest_reconcile`'s `verify`
+   * action, only on a hash MATCH — a failed verification leaves this field
+   * untouched rather than clearing it (a stale verification is not the
+   * same claim as "never verified"). Gates exactly one transition: E1
+   * eligibility in SMI-6345 Wave 2's identity-evidence gate (the cross-ADR
+   * contract ADR-145 §4 documents). Not part of the `provenance`/`source`
+   * combination matrix — it is a freshness signal, not a trust axis.
+   */
+  verifiedAt?: string
 }
 
 /** Manifest tracking all installed skills */

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Added**: `apply_manifest_reconcile` — a new Community-tier MCP tool that repairs a corrupted or
+  ambiguous `~/.skillsmith/manifest.json` entry through a supported path instead of a hand-edit
+  (SMI-6343 Wave 4, ADR-144 §6 / ADR-145). Five actions: `mark_local` (clears registry tracking —
+  writes `source: 'unknown'` + `provenance: 'local'` atomically, per ADR-145 §2), `relink` (sets an
+  explicit, registry-validated `id`/`source` pair, never inferring an identity), `drop_entry`
+  (hard-removes an entry whose `installPath` no longer resolves), `verify` (re-checks one entry or,
+  by default, every entry against the registry's current content hash, writing `verifiedAt` only on
+  a match — the writer ADR-144 §6's blanket trust-downgrade needs to promote an entry back to E1
+  eligibility), and `revert` (a durable, cross-session undo of a prior reconcile action on ONE
+  entry, backed by a new `~/.skillsmith/manifest-reconcile-ledger.json` ledger and
+  `ManifestManager.updateSafely()`'s locked, single-key merge — survives an unrelated skill install
+  happening in between, unlike `undo_apply`, which was evaluated and rejected as the undo mechanism
+  here: session-scoped/in-process, a whole-file hash guard hostile to the manifest's seven
+  independent writers, and an unlocked restore path). The backup step uses `createProseBackup`
+  (single-file copy), never `createSkillBackup` (recursive directory copy that could otherwise leak
+  `~/.skillsmith/config.json`'s live API key into the backups tree if ever pointed at the wrong
+  path) — guarded by a `stat().isFile()` precondition before every backup. New
+  `packages/mcp-server/src/tools/apply-manifest-reconcile.ts` (+`.types.ts`, `.helpers.ts`,
+  `.actions.ts`, `.errors.ts`) and `manifest-reconcile-ledger.ts` (+`.types.ts`).
 - **Added**: `team_analytics_dashboard`, `team_usage_report`, `analytics_dashboard`, and
   `usage_report` now read from cloud-aggregated MCP tool-call data (`search_metrics`) instead of
   the stub/local-only implementation (SMI-6362 Wave 1). `analytics.supabase.service.ts` gained

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -285,9 +285,10 @@ All tiers include:
 | `skill_pack_audit` | Audit all skills in a directory | Individual+ |
 | `skill_audit` | Check skills for security advisories | Team+ |
 | `skill_inventory_audit` | Audit every installed AI coding client's skill inventory for local namespace collisions; returns rename + edit suggestions | Team+ |
-| `apply_namespace_rename` | Apply a rename suggestion from an inventory audit (`apply`/`custom`/`skip`) | Team+ |
+| `apply_namespace_rename` | Apply a rename suggestion from an inventory audit (`apply`/`custom`/`skip`/`revert`) | Team+ |
 | `apply_recommended_edit` | Apply a recommended prose edit from an inventory audit (gated on APPLY_TEMPLATE_REGISTRY) | Team+ |
 | `undo_apply` | Session-scoped undo for the most recent apply_namespace_rename / apply_recommended_edit changeset(s), restored from the apply tool's own backup | Team+ |
+| `apply_manifest_reconcile` | Repair a corrupted or ambiguous manifest entry (`mark_local`/`relink`/`drop_entry`/`verify`/`revert`) — see `skill_outdated`'s `identity-mismatch`/`local-drift` diagnosis | Community |
 | `team_workspace` | Manage team workspaces (create, list, get, delete) | Team+ |
 | `share_skill` | Add, remove, or list skills in a team workspace | Team+ |
 | `publish_private` | Mark a skill as private to your team | Team+ |

--- a/packages/mcp-server/src/assets/agent-pack/SKILL.md
+++ b/packages/mcp-server/src/assets/agent-pack/SKILL.md
@@ -58,9 +58,10 @@ When the user wants to know what has fallen behind or wants to be brought up to 
 1. Run skill_outdated to list installed skills that are behind the registry. This is a free diagnosis; always show the whole list.
 2. For anything outdated, use skill_updates to see what a bump would bring and skill_diff to show what actually changed between the installed and latest versions, calling out breaking upstream changes explicitly.
 3. Use skill_pack_audit when the user wants the state of a whole bundle at once rather than skill by skill.
-4. Group the findings: breaking changes first, then routine bumps. Propose the update plan; apply nothing until the user approves the specific set.
+4. When skill_outdated reports 'local-drift' or 'identity-mismatch' instead of a plain version bump, do not update that entry. Its diagnosis names the next step: apply_manifest_reconcile with mark_local (stop tracking a local edit against the registry), relink (assert a corrected, registry-validated id/source), or drop_entry (remove a stale entry whose install path no longer resolves). Show the diagnosis before proposing a reconcile action.
+5. Group the remaining findings: breaking changes first, then routine bumps. Propose the update plan; apply nothing until the user approves the specific set.
 
-Tools: skill_outdated, skill_updates, skill_diff, skill_pack_audit.
+Tools: skill_outdated, skill_updates, skill_diff, skill_pack_audit, apply_manifest_reconcile.
 
 ### Audit and clean up my inventory
 
@@ -136,7 +137,7 @@ skillsmith validate ./candidate-skill
 skillsmith install community/jest-helper
 ```
 
-The CLI has no equivalent for skill_pack_audit, the apply_namespace_rename/apply_recommended_edit guided diff-and-approve flow, or undo_apply - those stay MCP-only until the server is back.
+The CLI has no equivalent for skill_pack_audit, the apply_namespace_rename/apply_recommended_edit guided diff-and-approve flow, undo_apply, or apply_manifest_reconcile - those stay MCP-only until the server is back.
 
 ## Undo and recovery
 

--- a/packages/mcp-server/src/assets/agent-pack/shims/claude/skillsmith-agent.md
+++ b/packages/mcp-server/src/assets/agent-pack/shims/claude/skillsmith-agent.md
@@ -1,7 +1,7 @@
 ---
 name: skillsmith-agent
 description: "Named entry point for the Skillsmith Agent: delegate keeping your agent skills current, auditing your inventory, and vetting skills before install. Operating instructions live in the Skillsmith Agent skill pack."
-tools: search, get_skill, install_skill, uninstall_skill, skill_recommend, skill_validate, skill_compare, skill_outdated, skill_updates, skill_diff, skill_pack_audit, skill_inventory_audit, apply_namespace_rename, apply_recommended_edit, skill_audit, undo_apply
+tools: search, get_skill, install_skill, uninstall_skill, skill_recommend, skill_validate, skill_compare, skill_outdated, skill_updates, skill_diff, skill_pack_audit, skill_inventory_audit, apply_namespace_rename, apply_recommended_edit, skill_audit, undo_apply, apply_manifest_reconcile
 ---
 
 This file is the Claude-format named-agent shim for the Skillsmith Agent.

--- a/packages/mcp-server/src/assets/agent-pack/shims/codex/agents.toml
+++ b/packages/mcp-server/src/assets/agent-pack/shims/codex/agents.toml
@@ -2,4 +2,4 @@
 [agents.skillsmith-agent]
 description = "Named entry point for the Skillsmith Agent: delegate keeping your agent skills current, auditing your inventory, and vetting skills before install. Operating instructions live in the Skillsmith Agent skill pack."
 instructions = "See the Skillsmith Agent skill pack (SKILL.md installed as skillsmith-agent) for operating instructions. This entry carries no behavior of its own."
-tools = ["search", "get_skill", "install_skill", "uninstall_skill", "skill_recommend", "skill_validate", "skill_compare", "skill_outdated", "skill_updates", "skill_diff", "skill_pack_audit", "skill_inventory_audit", "apply_namespace_rename", "apply_recommended_edit", "skill_audit", "undo_apply"]
+tools = ["search", "get_skill", "install_skill", "uninstall_skill", "skill_recommend", "skill_validate", "skill_compare", "skill_outdated", "skill_updates", "skill_diff", "skill_pack_audit", "skill_inventory_audit", "apply_namespace_rename", "apply_recommended_edit", "skill_audit", "undo_apply", "apply_manifest_reconcile"]

--- a/packages/mcp-server/src/assets/agent-pack/shims/copilot/skillsmith-agent.agent.md
+++ b/packages/mcp-server/src/assets/agent-pack/shims/copilot/skillsmith-agent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: skillsmith-agent
 description: "Named entry point for the Skillsmith Agent: delegate keeping your agent skills current, auditing your inventory, and vetting skills before install. Operating instructions live in the Skillsmith Agent skill pack."
-tools: search, get_skill, install_skill, uninstall_skill, skill_recommend, skill_validate, skill_compare, skill_outdated, skill_updates, skill_diff, skill_pack_audit, skill_inventory_audit, apply_namespace_rename, apply_recommended_edit, skill_audit, undo_apply
+tools: search, get_skill, install_skill, uninstall_skill, skill_recommend, skill_validate, skill_compare, skill_outdated, skill_updates, skill_diff, skill_pack_audit, skill_inventory_audit, apply_namespace_rename, apply_recommended_edit, skill_audit, undo_apply, apply_manifest_reconcile
 ---
 
 This file is the Copilot named-agent shim for the Skillsmith Agent.

--- a/packages/mcp-server/src/assets/agent-pack/shims/opencode/skillsmith-agent.md
+++ b/packages/mcp-server/src/assets/agent-pack/shims/opencode/skillsmith-agent.md
@@ -9,4 +9,4 @@ It carries no behavior of its own. The agent's operating instructions are the Sk
 
 All capability, tier gating, and the safety split between diagnosing and changing files live in the Skillsmith MCP server, so they hold regardless of which runtime loaded this shim.
 
-Curated tools: search, get_skill, install_skill, uninstall_skill, skill_recommend, skill_validate, skill_compare, skill_outdated, skill_updates, skill_diff, skill_pack_audit, skill_inventory_audit, apply_namespace_rename, apply_recommended_edit, skill_audit, undo_apply.
+Curated tools: search, get_skill, install_skill, uninstall_skill, skill_recommend, skill_validate, skill_compare, skill_outdated, skill_updates, skill_diff, skill_pack_audit, skill_inventory_audit, apply_namespace_rename, apply_recommended_edit, skill_audit, undo_apply, apply_manifest_reconcile.

--- a/packages/mcp-server/src/audit-tool-dispatch.ts
+++ b/packages/mcp-server/src/audit-tool-dispatch.ts
@@ -43,6 +43,10 @@ import {
   applyRecommendedEditToolSchema,
 } from './tools/apply-recommended-edit.js'
 import { undoApply, undoApplyToolSchema } from './tools/undo-apply.js'
+import {
+  applyManifestReconcile,
+  applyManifestReconcileToolSchema,
+} from './tools/apply-manifest-reconcile.js'
 import { APPLY_TEMPLATE_REGISTRY } from './audit/edit-applier.js'
 import { withLicenseAndQuota } from './middleware/license.js'
 import type { LicenseMiddleware } from './middleware/license.js'
@@ -76,6 +80,9 @@ function buildAuditToolNames(): string[] {
     // Always registered (like apply_namespace_rename) — not gated on any
     // registry, since undo has no per-template surface to gate.
     'undo_apply',
+    // SMI-6343 Wave 4: manifest identity repair. Always registered — no
+    // per-template gate applies to it.
+    'apply_manifest_reconcile',
   ]
   if (APPLY_TEMPLATE_REGISTRY.size > 0) {
     names.push('apply_recommended_edit')
@@ -122,6 +129,7 @@ export function newAuditToolDefinitions(): NewAuditToolDefinition[] {
     skillInventoryAuditToolSchema,
     applyNamespaceRenameToolSchema,
     undoApplyToolSchema,
+    applyManifestReconcileToolSchema,
   ]
   if (APPLY_TEMPLATE_REGISTRY.size > 0) {
     defs.push(applyRecommendedEditToolSchema)
@@ -189,6 +197,13 @@ export async function dispatchAuditTool(
 
     case 'undo_apply':
       return okBody(await undoApply(args))
+
+    case 'apply_manifest_reconcile':
+      // SMI-6343 Wave 4: unlike the other audit-family tools above, this
+      // one needs `toolContext` (relink's registry validation + verify's
+      // live registry comparison both call `lookupSkillFromRegistry`,
+      // which requires `context.apiClient`/`context.db`).
+      return okBody(await applyManifestReconcile(args, toolContext))
 
     case 'apply_recommended_edit':
       // Defense-in-depth: even if the parent dispatcher routes this name

--- a/packages/mcp-server/src/middleware/toolProfile.test.ts
+++ b/packages/mcp-server/src/middleware/toolProfile.test.ts
@@ -76,6 +76,7 @@ const TODAY_REGISTERED_TOOLS: readonly FixtureTool[] = [
   tool('apply_namespace_rename'),
   tool('apply_recommended_edit'),
   tool('skill_recover_source'),
+  tool('apply_manifest_reconcile'),
 ]
 
 const EXPECTED_PROFILE_MEMBER_NAMES = [
@@ -94,11 +95,12 @@ const EXPECTED_PROFILE_MEMBER_NAMES = [
   'apply_namespace_rename',
   'apply_recommended_edit',
   'skill_audit',
+  'apply_manifest_reconcile',
 ]
 
 describe('AGENT_TOOL_PROFILE_NAMES', () => {
-  it('has exactly 16 entries (15 pre-SMI-5470 + undo_apply)', () => {
-    expect(AGENT_TOOL_PROFILE_NAMES).toHaveLength(16)
+  it('has exactly 17 entries (15 pre-SMI-5470 + undo_apply + SMI-6343 apply_manifest_reconcile)', () => {
+    expect(AGENT_TOOL_PROFILE_NAMES).toHaveLength(17)
   })
 
   it('includes undo_apply (registered as of SMI-5470; kept out of this fixture on purpose, see TODAY_REGISTERED_TOOLS)', () => {

--- a/packages/mcp-server/src/tool-dispatch.ts
+++ b/packages/mcp-server/src/tool-dispatch.ts
@@ -213,6 +213,7 @@ export async function dispatchToolCall(
     case 'apply_namespace_rename':
     case 'apply_recommended_edit':
     case 'undo_apply':
+    case 'apply_manifest_reconcile':
       // SMI-4590 Step 0b: audit-family tools live in `audit-tool-dispatch.ts`
       // to keep this file under the 500-LOC gate. SMI-5456 §7 / SMI-5470:
       // added the explicit cases for `skill_inventory_audit` /
@@ -220,7 +221,9 @@ export async function dispatchToolCall(
       // they were previously routed nowhere (fell through to `default`'s
       // "Unknown tool" throw despite being ListTools-discoverable and
       // dispatch-implemented in `audit-tool-dispatch.ts`); a call to any of
-      // them from a real MCP client would have failed.
+      // them from a real MCP client would have failed. SMI-6343 Wave 4 adds
+      // `apply_manifest_reconcile` to this same explicit list for the same
+      // reason — omitting it here would make it discoverable-but-uncallable.
       return dispatchAuditTool(name, args, toolContext, licenseMiddleware, quotaMiddleware)
 
     case 'skill_rescan': {

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.actions.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.actions.ts
@@ -25,36 +25,22 @@ import type { ManifestReconcileLedgerEntry } from './manifest-reconcile-ledger.t
 import type {
   ApplyManifestReconcileInput,
   ApplyManifestReconcileResponse,
-  ManifestReconcileVerifyResult,
 } from './apply-manifest-reconcile.types.js'
 import {
   ReconcileGuardError,
+  assertDropTargetNoLongerResolves,
   reconcileKeyForLedgerEntry,
   resolveReconcileEntry,
   takeManifestBackup,
   validateRelinkIdentity,
-  verifyEntryAgainstRegistry,
   type ReconcileScopeTarget,
 } from './apply-manifest-reconcile.helpers.js'
+import { withLockTimeoutMapping } from './apply-manifest-reconcile.lock-helpers.js'
 
-/** `ManifestManager.acquireLock()`'s 30s-timeout error has no typed shape — match its message. */
-function isLockTimeoutError(err: unknown): boolean {
-  return err instanceof Error && err.message.includes('Failed to acquire manifest lock')
-}
-
-async function withLockTimeoutMapping<T>(manifestPath: string, run: () => Promise<T>): Promise<T> {
-  try {
-    return await run()
-  } catch (err) {
-    if (err instanceof ReconcileGuardError) throw err
-    if (isLockTimeoutError(err)) {
-      throw new ReconcileGuardError('manifest.reconcile.lock_timeout', {
-        path: `${manifestPath}.lock`,
-      })
-    }
-    throw err
-  }
-}
+// `verify` lives in its own sibling file (500-line gate) — re-exported here
+// so existing `from './apply-manifest-reconcile.actions.js'` imports (the
+// dispatcher, tests) keep working unmodified.
+export { runVerify } from './apply-manifest-reconcile.verify.js'
 
 function requireName(input: ApplyManifestReconcileInput): string {
   if (!input.name || input.name.trim().length === 0) {
@@ -218,7 +204,14 @@ export async function runDropEntry(
 ): Promise<ApplyManifestReconcileResponse> {
   const name = requireName(input)
   const manager = new ManifestManager(scopeTarget.manifestPath)
-  resolveReconcileEntry(await manager.load(), name, scopeTarget.client)
+  const { entry: preCheckEntry } = resolveReconcileEntry(
+    await manager.load(),
+    name,
+    scopeTarget.client
+  )
+  // Adversarial-review finding: the tool's own contract for this action is
+  // "installPath no longer resolves" — enforce it, don't just narrate it.
+  await assertDropTargetNoLongerResolves(name, preCheckEntry)
   const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
 
   let resolvedKey = ''
@@ -253,112 +246,6 @@ export async function runDropEntry(
     manifestKey: resolvedKey,
     ledgerEntryId: ledgerEntry.id,
     backupPath,
-  }
-}
-
-// ============================================================================
-// verify (C3)
-// ============================================================================
-
-export async function runVerify(
-  input: ApplyManifestReconcileInput,
-  scopeTarget: ReconcileScopeTarget,
-  context: ToolContext
-): Promise<ApplyManifestReconcileResponse> {
-  const manager = new ManifestManager(scopeTarget.manifestPath)
-  const manifest = await manager.load()
-
-  let targets: Array<{ key: string; entry: SkillManifestEntry }>
-  if (input.name) {
-    // Single-entry verify: total unavailability is a hard failure — the
-    // caller asked about ONE entry and there is nothing partial to report.
-    if (context.apiClient.isOffline()) {
-      throw new ReconcileGuardError('manifest.reconcile.verify_unavailable', {
-        name: input.name,
-        detail: 'registry is offline',
-      })
-    }
-    const { key, entry } = resolveReconcileEntry(manifest, input.name, scopeTarget.client)
-    targets = [{ key, entry }]
-  } else {
-    // Batch (C3: "Batch by default"). Never hard-fails on offline/quota —
-    // each entry degrades to an honest unverified result (H1 philosophy).
-    targets = Object.entries(manifest.installedSkills).map(([key, entry]) => ({
-      key,
-      entry: entry as SkillManifestEntry,
-    }))
-  }
-
-  let quotaExhausted = false
-  const results: ManifestReconcileVerifyResult[] = []
-  const writes: Array<{ key: string; verifiedAt: string }> = []
-
-  for (const { key, entry } of targets) {
-    const outcome = await verifyEntryAgainstRegistry(
-      entry,
-      context,
-      () => {
-        quotaExhausted = true
-      },
-      quotaExhausted
-    )
-    results.push({ name: entry.name ?? key, manifestKey: key, ...outcome })
-    if (outcome.verified && outcome.verifiedAt) {
-      writes.push({ key, verifiedAt: outcome.verifiedAt })
-    }
-  }
-
-  if (writes.length === 0) {
-    // C3: "Writes nothing on a mismatch" — no backup/ledger churn for a
-    // pass that changed nothing.
-    return { success: true, action: 'verify', verifyResults: results }
-  }
-
-  const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
-  const ledgerEntries: ManifestReconcileLedgerEntry[] = []
-
-  await withLockTimeoutMapping(scopeTarget.manifestPath, () =>
-    manager.updateSafely((m: SkillManifest) => {
-      const updatedSkills = { ...m.installedSkills }
-      for (const { key, verifiedAt } of writes) {
-        const current = updatedSkills[key] as SkillManifestEntry | undefined
-        // Defense-in-depth: an entry that vanished between the async verify
-        // pass and this lock (dropped by a concurrent writer) is skipped —
-        // there is nothing left to stamp verifiedAt onto.
-        if (!current) continue
-        updatedSkills[key] = { ...current, verifiedAt }
-      }
-      return { ...m, installedSkills: updatedSkills }
-    })
-  )
-
-  // Ledger entries recorded AFTER the write (their before/after snapshots
-  // come from what we observed, which is accurate for the common case of
-  // no concurrent writer; skipped entries above simply get no ledger row).
-  for (const { key, verifiedAt } of writes) {
-    const entry = targets.find((t) => t.key === key)?.entry
-    if (!entry) continue
-    const ledgerEntry = await appendReconcileLedgerEntry({
-      manifestPath: scopeTarget.manifestPath,
-      manifestKey: key,
-      name: entry.name ?? key,
-      client: scopeTarget.client,
-      action: 'verify',
-      beforeState: entry as unknown as Record<string, unknown>,
-      afterState: { ...entry, verifiedAt } as unknown as Record<string, unknown>,
-      reason: input.reason ?? 'apply_manifest_reconcile: verify',
-    })
-    ledgerEntries.push(ledgerEntry)
-  }
-
-  return {
-    success: true,
-    action: 'verify',
-    verifyResults: results,
-    backupPath,
-    // Single-entry verify: surface the one ledger entry id directly for a
-    // later precise revert, mirroring the other single-write actions.
-    ledgerEntryId: input.name ? ledgerEntries[0]?.id : undefined,
   }
 }
 

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.actions.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.actions.ts
@@ -1,0 +1,490 @@
+/**
+ * @fileoverview Per-action implementations for `apply_manifest_reconcile`
+ *               (SMI-6343 Wave 4).
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile.actions
+ *
+ * Split out of `apply-manifest-reconcile.ts` (500-line file gate). Every
+ * write goes through `ManifestManager.updateSafely()` — core's locked,
+ * single-key read-modify-write — never a whole-file writer (C7). Every
+ * write also takes a `createProseBackup` snapshot first (C8) and records a
+ * ledger entry after (C7), so both the forensic backup and the durable
+ * revert exist before the caller sees a success response.
+ */
+
+import { ManifestManager, type SkillManifest, type SkillManifestEntry } from '@skillsmith/core'
+import { resolveClientId, type ClientId } from '@skillsmith/core/install'
+
+import type { ToolContext } from '../context.js'
+import {
+  appendReconcileLedgerEntry,
+  findReconcileLedgerEntriesFor,
+  readReconcileLedgerResult,
+  removeReconcileLedgerEntry,
+} from './manifest-reconcile-ledger.js'
+import type { ManifestReconcileLedgerEntry } from './manifest-reconcile-ledger.types.js'
+import type {
+  ApplyManifestReconcileInput,
+  ApplyManifestReconcileResponse,
+  ManifestReconcileVerifyResult,
+} from './apply-manifest-reconcile.types.js'
+import {
+  ReconcileGuardError,
+  reconcileKeyForLedgerEntry,
+  resolveReconcileEntry,
+  takeManifestBackup,
+  validateRelinkIdentity,
+  verifyEntryAgainstRegistry,
+  type ReconcileScopeTarget,
+} from './apply-manifest-reconcile.helpers.js'
+
+/** `ManifestManager.acquireLock()`'s 30s-timeout error has no typed shape — match its message. */
+function isLockTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('Failed to acquire manifest lock')
+}
+
+async function withLockTimeoutMapping<T>(manifestPath: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run()
+  } catch (err) {
+    if (err instanceof ReconcileGuardError) throw err
+    if (isLockTimeoutError(err)) {
+      throw new ReconcileGuardError('manifest.reconcile.lock_timeout', {
+        path: `${manifestPath}.lock`,
+      })
+    }
+    throw err
+  }
+}
+
+function requireName(input: ApplyManifestReconcileInput): string {
+  if (!input.name || input.name.trim().length === 0) {
+    throw new ReconcileGuardError('manifest.reconcile.invalid_input', {
+      detail: `'name' is required for action '${input.action}'`,
+    })
+  }
+  return input.name
+}
+
+// ============================================================================
+// mark_local
+// ============================================================================
+
+export async function runMarkLocal(
+  input: ApplyManifestReconcileInput,
+  scopeTarget: ReconcileScopeTarget,
+  _context: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  const name = requireName(input)
+  const manager = new ManifestManager(scopeTarget.manifestPath)
+
+  // Fast-fail pre-check before spending a backup on a doomed write.
+  resolveReconcileEntry(await manager.load(), name, scopeTarget.client)
+  const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
+
+  let resolvedKey = ''
+  let beforeState: SkillManifestEntry | undefined
+  let afterState: SkillManifestEntry | undefined
+
+  await withLockTimeoutMapping(scopeTarget.manifestPath, () =>
+    manager.updateSafely((manifest: SkillManifest) => {
+      const { key, entry } = resolveReconcileEntry(manifest, name, scopeTarget.client)
+      resolvedKey = key
+      beforeState = { ...entry }
+      // ADR-145 §2: `provenance: 'local'` and `source: 'unknown'` are
+      // written in the SAME locked update — never independently. Writing
+      // `provenance` alone would produce the illegal `'local'` +
+      // registry-ref cell (ADR-145's combination matrix).
+      const updated: SkillManifestEntry = { ...entry, source: 'unknown', provenance: 'local' }
+      afterState = updated
+      return {
+        ...manifest,
+        installedSkills: { ...manifest.installedSkills, [key]: updated },
+      }
+    })
+  )
+
+  const ledgerEntry = await appendReconcileLedgerEntry({
+    manifestPath: scopeTarget.manifestPath,
+    manifestKey: resolvedKey,
+    name,
+    client: scopeTarget.client,
+    action: 'mark_local',
+    beforeState: beforeState as unknown as Record<string, unknown>,
+    afterState: afterState as unknown as Record<string, unknown>,
+    reason: input.reason ?? 'apply_manifest_reconcile: mark_local',
+  })
+
+  return {
+    success: true,
+    action: 'mark_local',
+    name,
+    manifestKey: resolvedKey,
+    entry: afterState,
+    ledgerEntryId: ledgerEntry.id,
+    backupPath,
+  }
+}
+
+// ============================================================================
+// relink
+// ============================================================================
+
+export async function runRelink(
+  input: ApplyManifestReconcileInput,
+  scopeTarget: ReconcileScopeTarget,
+  context: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  const name = requireName(input)
+  if (!input.id || !input.source) {
+    throw new ReconcileGuardError('manifest.reconcile.relink_incomplete')
+  }
+  const id = input.id
+  const source = input.source
+
+  const manager = new ManifestManager(scopeTarget.manifestPath)
+  resolveReconcileEntry(await manager.load(), name, scopeTarget.client)
+
+  // Registry-validated pair (ADR-144 §3): confirm `id` is a real registry
+  // identity BEFORE writing it. `apply_manifest_reconcile` never accepts a
+  // `skill_recover_source` candidate implicitly — the caller supplies both
+  // `id` and `source` explicitly; this only proves `id` is not fabricated.
+  const validation = await validateRelinkIdentity(id, context)
+  if (!validation.ok) {
+    throw new ReconcileGuardError('manifest.reconcile.relink_unvalidated', {
+      id,
+      detail: validation.detail,
+    })
+  }
+
+  const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
+
+  let resolvedKey = ''
+  let beforeState: SkillManifestEntry | undefined
+  let afterState: SkillManifestEntry | undefined
+
+  await withLockTimeoutMapping(scopeTarget.manifestPath, () =>
+    manager.updateSafely((manifest: SkillManifest) => {
+      const { key, entry } = resolveReconcileEntry(manifest, name, scopeTarget.client)
+      resolvedKey = key
+      beforeState = { ...entry }
+      // relink asserts an identity; it does NOT set verifiedAt — a relink
+      // is not a content verification (see the tool's Actions doc). Any
+      // PRIOR verifiedAt is explicitly cleared here: it was recorded
+      // against the entry's OLD claimed id, and carrying it forward onto a
+      // freshly-relinked (possibly different) identity would misrepresent
+      // stale evidence as current — ADR-145 §3's freshness guarantee only
+      // holds when verifiedAt and the identity it was checked against
+      // change together.
+      const updated: SkillManifestEntry = { ...entry, id, source, provenance: 'registry' }
+      delete updated.verifiedAt
+      afterState = updated
+      return {
+        ...manifest,
+        installedSkills: { ...manifest.installedSkills, [key]: updated },
+      }
+    })
+  )
+
+  const ledgerEntry = await appendReconcileLedgerEntry({
+    manifestPath: scopeTarget.manifestPath,
+    manifestKey: resolvedKey,
+    name,
+    client: scopeTarget.client,
+    action: 'relink',
+    beforeState: beforeState as unknown as Record<string, unknown>,
+    afterState: afterState as unknown as Record<string, unknown>,
+    reason: input.reason ?? 'apply_manifest_reconcile: relink',
+  })
+
+  return {
+    success: true,
+    action: 'relink',
+    name,
+    manifestKey: resolvedKey,
+    entry: afterState,
+    ledgerEntryId: ledgerEntry.id,
+    backupPath,
+  }
+}
+
+// ============================================================================
+// drop_entry
+// ============================================================================
+
+export async function runDropEntry(
+  input: ApplyManifestReconcileInput,
+  scopeTarget: ReconcileScopeTarget,
+  _context: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  const name = requireName(input)
+  const manager = new ManifestManager(scopeTarget.manifestPath)
+  resolveReconcileEntry(await manager.load(), name, scopeTarget.client)
+  const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
+
+  let resolvedKey = ''
+  let beforeState: SkillManifestEntry | undefined
+
+  await withLockTimeoutMapping(scopeTarget.manifestPath, () =>
+    manager.updateSafely((manifest: SkillManifest) => {
+      const { key, entry } = resolveReconcileEntry(manifest, name, scopeTarget.client)
+      resolvedKey = key
+      beforeState = { ...entry }
+      const remaining = { ...manifest.installedSkills }
+      delete remaining[key]
+      return { ...manifest, installedSkills: remaining }
+    })
+  )
+
+  const ledgerEntry = await appendReconcileLedgerEntry({
+    manifestPath: scopeTarget.manifestPath,
+    manifestKey: resolvedKey,
+    name,
+    client: scopeTarget.client,
+    action: 'drop_entry',
+    beforeState: beforeState as unknown as Record<string, unknown>,
+    afterState: null,
+    reason: input.reason ?? 'apply_manifest_reconcile: drop_entry',
+  })
+
+  return {
+    success: true,
+    action: 'drop_entry',
+    name,
+    manifestKey: resolvedKey,
+    ledgerEntryId: ledgerEntry.id,
+    backupPath,
+  }
+}
+
+// ============================================================================
+// verify (C3)
+// ============================================================================
+
+export async function runVerify(
+  input: ApplyManifestReconcileInput,
+  scopeTarget: ReconcileScopeTarget,
+  context: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  const manager = new ManifestManager(scopeTarget.manifestPath)
+  const manifest = await manager.load()
+
+  let targets: Array<{ key: string; entry: SkillManifestEntry }>
+  if (input.name) {
+    // Single-entry verify: total unavailability is a hard failure — the
+    // caller asked about ONE entry and there is nothing partial to report.
+    if (context.apiClient.isOffline()) {
+      throw new ReconcileGuardError('manifest.reconcile.verify_unavailable', {
+        name: input.name,
+        detail: 'registry is offline',
+      })
+    }
+    const { key, entry } = resolveReconcileEntry(manifest, input.name, scopeTarget.client)
+    targets = [{ key, entry }]
+  } else {
+    // Batch (C3: "Batch by default"). Never hard-fails on offline/quota —
+    // each entry degrades to an honest unverified result (H1 philosophy).
+    targets = Object.entries(manifest.installedSkills).map(([key, entry]) => ({
+      key,
+      entry: entry as SkillManifestEntry,
+    }))
+  }
+
+  let quotaExhausted = false
+  const results: ManifestReconcileVerifyResult[] = []
+  const writes: Array<{ key: string; verifiedAt: string }> = []
+
+  for (const { key, entry } of targets) {
+    const outcome = await verifyEntryAgainstRegistry(
+      entry,
+      context,
+      () => {
+        quotaExhausted = true
+      },
+      quotaExhausted
+    )
+    results.push({ name: entry.name ?? key, manifestKey: key, ...outcome })
+    if (outcome.verified && outcome.verifiedAt) {
+      writes.push({ key, verifiedAt: outcome.verifiedAt })
+    }
+  }
+
+  if (writes.length === 0) {
+    // C3: "Writes nothing on a mismatch" — no backup/ledger churn for a
+    // pass that changed nothing.
+    return { success: true, action: 'verify', verifyResults: results }
+  }
+
+  const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
+  const ledgerEntries: ManifestReconcileLedgerEntry[] = []
+
+  await withLockTimeoutMapping(scopeTarget.manifestPath, () =>
+    manager.updateSafely((m: SkillManifest) => {
+      const updatedSkills = { ...m.installedSkills }
+      for (const { key, verifiedAt } of writes) {
+        const current = updatedSkills[key] as SkillManifestEntry | undefined
+        // Defense-in-depth: an entry that vanished between the async verify
+        // pass and this lock (dropped by a concurrent writer) is skipped —
+        // there is nothing left to stamp verifiedAt onto.
+        if (!current) continue
+        updatedSkills[key] = { ...current, verifiedAt }
+      }
+      return { ...m, installedSkills: updatedSkills }
+    })
+  )
+
+  // Ledger entries recorded AFTER the write (their before/after snapshots
+  // come from what we observed, which is accurate for the common case of
+  // no concurrent writer; skipped entries above simply get no ledger row).
+  for (const { key, verifiedAt } of writes) {
+    const entry = targets.find((t) => t.key === key)?.entry
+    if (!entry) continue
+    const ledgerEntry = await appendReconcileLedgerEntry({
+      manifestPath: scopeTarget.manifestPath,
+      manifestKey: key,
+      name: entry.name ?? key,
+      client: scopeTarget.client,
+      action: 'verify',
+      beforeState: entry as unknown as Record<string, unknown>,
+      afterState: { ...entry, verifiedAt } as unknown as Record<string, unknown>,
+      reason: input.reason ?? 'apply_manifest_reconcile: verify',
+    })
+    ledgerEntries.push(ledgerEntry)
+  }
+
+  return {
+    success: true,
+    action: 'verify',
+    verifyResults: results,
+    backupPath,
+    // Single-entry verify: surface the one ledger entry id directly for a
+    // later precise revert, mirroring the other single-write actions.
+    ledgerEntryId: input.name ? ledgerEntries[0]?.id : undefined,
+  }
+}
+
+// ============================================================================
+// revert (C7)
+// ============================================================================
+
+export async function runRevert(
+  input: ApplyManifestReconcileInput,
+  scopeTarget: ReconcileScopeTarget,
+  _context: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  // Read the raw discriminated union (not the convenience `readReconcileLedger`
+  // wrapper, which silently degrades a malformed ledger to empty) — for
+  // `revert` specifically, a ledger the tool couldn't actually read must
+  // never be indistinguishable from "nothing to revert" (an idempotent
+  // no-op). Both failure kinds map to their own M2 error code.
+  const ledgerResult = await readReconcileLedgerResult()
+  if (ledgerResult.kind === 'manifest.reconcile.ledger_version_unsupported') {
+    throw new ReconcileGuardError('manifest.reconcile.ledger_version_unsupported', {
+      found: ledgerResult.found,
+      expected: ledgerResult.expected,
+    })
+  }
+  if (ledgerResult.kind === 'manifest.reconcile.ledger_malformed') {
+    throw new ReconcileGuardError('manifest.reconcile.ledger_malformed', {
+      detail: ledgerResult.reason,
+    })
+  }
+  const ledger = ledgerResult.ledger
+
+  let target: ManifestReconcileLedgerEntry | undefined
+  if (input.ledgerEntryId) {
+    target = ledger.entries.find((e) => e.id === input.ledgerEntryId)
+    if (!target) {
+      // Idempotent no-op (C7): the entry is gone — already reverted, or
+      // the id never existed. Reverting twice is success, not an error.
+      return { success: true, action: 'revert', noOp: true, name: input.name }
+    }
+  } else {
+    const name = requireName(input)
+    const client: ClientId = resolveClientId(input.client)
+    const matches = findReconcileLedgerEntriesFor(ledger, name, client, scopeTarget.manifestPath)
+    if (matches.length === 0) {
+      return { success: true, action: 'revert', noOp: true, name }
+    }
+    if (matches.length > 1) {
+      throw new ReconcileGuardError('manifest.reconcile.revert_ambiguous', {
+        name,
+        candidateIds: matches.map((m) => m.id),
+      })
+    }
+    target = matches[0]
+  }
+
+  // H9: re-derive the key from the LEDGER ENTRY's own recorded (name,
+  // client) — never from caller input — so a revert cannot be aimed at a
+  // different row than the action it reverses.
+  const key = reconcileKeyForLedgerEntry(target.name, target.client)
+  const manager = new ManifestManager(target.manifestPath)
+
+  await withLockTimeoutMapping(target.manifestPath, () =>
+    manager.updateSafely((manifest: SkillManifest) => {
+      const current = manifest.installedSkills[key] as unknown as
+        | Record<string, unknown>
+        | undefined
+      // Same-entry conflict detection replaces the whole-file hash guard
+      // (C7): only THIS entry's current value vs. its recorded after-state
+      // matters. An unrelated install of a DIFFERENT skill is invisible to
+      // this check, exactly the case the rejected undo_apply design failed.
+      const recordedAfter = target!.afterState // null for drop_entry (entry should be absent)
+      const currentNormalized = current ?? null
+      if (!deepEqualEntry(currentNormalized, recordedAfter)) {
+        throw new ReconcileGuardError('manifest.reconcile.entry_changed', {
+          name: target!.name,
+          manifestKey: key,
+          ledgerEntryId: target!.id,
+          recordedValue: recordedAfter,
+          currentValue: currentNormalized,
+        })
+      }
+
+      // `beforeState` is never null/absent by construction — every action
+      // requires a pre-existing entry, so reverting always has a real
+      // entry snapshot to restore (including for `drop_entry`, whose
+      // `afterState` is null but `beforeState` is the removed entry).
+      const updatedSkills = { ...manifest.installedSkills }
+      updatedSkills[key] = target!.beforeState as unknown as SkillManifestEntry
+      return { ...manifest, installedSkills: updatedSkills }
+    })
+  )
+
+  await removeReconcileLedgerEntry(target.id)
+
+  return {
+    success: true,
+    action: 'revert',
+    name: target.name,
+    manifestKey: key,
+    entry: target.beforeState as unknown as SkillManifestEntry,
+    noOp: false,
+  }
+}
+
+/**
+ * Deep equality for a manifest entry snapshot (JSON-serializable values
+ * only), independent of object key insertion order — a plain
+ * `JSON.stringify(a) === JSON.stringify(b)` would false-positive-diverge
+ * on two structurally identical objects whose keys were inserted in a
+ * different order (a real risk here: one side comes from a fresh
+ * `manifest.json` parse, the other from a `manifest-reconcile-ledger.json`
+ * parse recorded at a different point in time).
+ */
+function deepEqualEntry(
+  a: Record<string, unknown> | null,
+  b: Record<string, unknown> | null
+): boolean {
+  return canonicalJson(a) === canonicalJson(b)
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  const keys = Object.keys(value as Record<string, unknown>).sort()
+  const body = keys
+    .map((k) => `${JSON.stringify(k)}:${canonicalJson((value as Record<string, unknown>)[k])}`)
+    .join(',')
+  return `{${body}}`
+}

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.errors.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.errors.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview `describeReconcileError()` — the M2 error-taxonomy prose
+ *               generator for `apply_manifest_reconcile`.
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile.errors
+ *
+ * Modeled on `StuckLockError` (`packages/core/src/config/owned-lock.acquire.ts`):
+ * "`reason` is a stable discriminant for mechanical triage (never
+ * prose-matching); the message embeds the manual unstick procedure
+ * verbatim." Every `ManifestReconcileErrorCode` message is generated HERE,
+ * from the code plus its context, so code and prose cannot drift apart —
+ * and each message embeds the exact next remediation command inline.
+ */
+
+import type { ManifestReconcileErrorCode } from './apply-manifest-reconcile.types.js'
+
+export interface ReconcileErrorContext {
+  name?: string
+  manifestKey?: string
+  /** H9: the other key found when `key_shape_ambiguous` fires. */
+  otherKey?: string
+  id?: string
+  source?: string
+  path?: string
+  ledgerEntryId?: string
+  /** entry_changed: the value recorded at write time vs. what is on disk now. */
+  recordedValue?: unknown
+  currentValue?: unknown
+  /** revert_ambiguous: candidate ledger entry ids. */
+  candidateIds?: string[]
+  /** ledger_version_unsupported. */
+  found?: number
+  expected?: number
+  /** underlying error message, when wrapping a caught error. */
+  detail?: string
+}
+
+/**
+ * Generate the human-readable message for a `ManifestReconcileErrorCode`,
+ * embedding the exact next command a caller should run.
+ */
+export function describeReconcileError(
+  code: ManifestReconcileErrorCode,
+  ctx: ReconcileErrorContext = {}
+): string {
+  switch (code) {
+    case 'manifest.reconcile.invalid_input':
+      return `Invalid apply_manifest_reconcile input${ctx.detail ? `: ${ctx.detail}` : '.'}`
+    case 'manifest.reconcile.entry_not_found':
+      return (
+        `No manifest entry found for '${ctx.name ?? '<unknown>'}'` +
+        (ctx.manifestKey ? ` (key '${ctx.manifestKey}')` : '') +
+        `. Confirm the skill name and client — run skill_outdated to list known entries.`
+      )
+    case 'manifest.reconcile.key_shape_ambiguous':
+      return (
+        `Ambiguous manifest key for '${ctx.name ?? '<unknown>'}': found both '${ctx.manifestKey ?? '<unknown>'}' ` +
+        `and '${ctx.otherKey ?? '<unknown>'}' recorded under different clients (SMI-6358/6359). ` +
+        `Refusing to guess which entry to reconcile — pass an explicit 'client' matching the entry you intend.`
+      )
+    case 'manifest.reconcile.relink_unvalidated':
+      return (
+        `Could not confirm registry id '${ctx.id ?? '<unknown>'}' exists in the registry` +
+        (ctx.detail ? ` (${ctx.detail})` : '.') +
+        ` relink never infers or guesses an identity (ADR-144 §3) — retry when the registry is reachable, ` +
+        `or run skill_recover_source for evidence and use mark_local instead if the identity cannot be confirmed.`
+      )
+    case 'manifest.reconcile.relink_incomplete':
+      return `relink requires BOTH 'id' and 'source' — apply_manifest_reconcile never infers an identity implicitly (ADR-144 §3).`
+    case 'manifest.reconcile.backup_target_not_a_file':
+      return `Refusing to back up '${ctx.path ?? '<unknown>'}' — it is not a regular file (C8 guard rail; see createProseBackup's single-file contract).`
+    case 'manifest.reconcile.backup_failed':
+      return `Failed to create the pre-mutation manifest backup${ctx.detail ? `: ${ctx.detail}` : '.'} No write was made.`
+    case 'manifest.reconcile.lock_timeout':
+      return (
+        `Timed out waiting for the manifest lock at '${ctx.path ?? '<unknown>'}'. Manual unstick -- ` +
+        `1) confirm no skillsmith process is running: ps -ax | grep -E '[s]killsmith|[s]klx'; ` +
+        `2) inspect (read-only): cat ${ctx.path ?? '<manifest>.lock'}; ` +
+        `3) if stale, remove it: rm ${ctx.path ?? '<manifest>.lock'}.`
+      )
+    case 'manifest.reconcile.entry_changed':
+      return (
+        `Refusing to revert ledger entry '${ctx.ledgerEntryId ?? '<unknown>'}' for '${ctx.name ?? '<unknown>'}': ` +
+        `the entry changed since this action ran (recorded ${JSON.stringify(ctx.recordedValue)}, now ${JSON.stringify(ctx.currentValue)}). ` +
+        `Something else wrote this entry after the reconcile — inspect it with skill_outdated before retrying.`
+      )
+    case 'manifest.reconcile.revert_ambiguous':
+      return (
+        `revert is ambiguous for '${ctx.name ?? '<unknown>'}': ${(ctx.candidateIds ?? []).length} ledger entries match ` +
+        `and none was disambiguated. Pass 'ledgerEntryId' explicitly — candidates: ${(ctx.candidateIds ?? []).join(', ')}.`
+      )
+    case 'manifest.reconcile.ledger_version_unsupported':
+      return (
+        `manifest-reconcile-ledger.json version ${String(ctx.found)} is newer than supported version ${String(ctx.expected)}. ` +
+        `This client cannot safely read or write the ledger — upgrade @skillsmith/mcp-server, or manually inspect ` +
+        `~/.skillsmith/manifest-reconcile-ledger.json before proceeding.`
+      )
+    case 'manifest.reconcile.ledger_malformed':
+      return `manifest-reconcile-ledger.json could not be parsed${ctx.detail ? ` (${ctx.detail})` : '.'} Inspect it manually at ~/.skillsmith/manifest-reconcile-ledger.json before retrying.`
+    case 'manifest.reconcile.verify_unavailable':
+      return (
+        `Could not reach the registry to verify '${ctx.name ?? '<unknown>'}'${ctx.detail ? ` (${ctx.detail})` : '.'} ` +
+        `Retry when online, or re-run without 'name' to get a partial batch result across every entry that CAN be checked.`
+      )
+    default: {
+      const exhaustive: never = code
+      return exhaustive
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.errors.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.errors.ts
@@ -66,6 +66,14 @@ export function describeReconcileError(
       )
     case 'manifest.reconcile.relink_incomplete':
       return `relink requires BOTH 'id' and 'source' — apply_manifest_reconcile never infers an identity implicitly (ADR-144 §3).`
+    case 'manifest.reconcile.drop_target_still_resolves':
+      return (
+        `Refusing to drop '${ctx.name ?? '<unknown>'}': its installPath` +
+        (ctx.path ? ` ('${ctx.path}')` : '') +
+        ` still resolves on disk. drop_entry is for entries whose install directory no longer ` +
+        `exists — if you intend to remove a still-installed skill's manifest record anyway, use ` +
+        `mark_local instead, or uninstall the skill first.`
+      )
     case 'manifest.reconcile.backup_target_not_a_file':
       return `Refusing to back up '${ctx.path ?? '<unknown>'}' — it is not a regular file (C8 guard rail; see createProseBackup's single-file contract).`
     case 'manifest.reconcile.backup_failed':

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.helpers.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.helpers.ts
@@ -1,0 +1,278 @@
+/**
+ * @fileoverview Execution helpers for `apply_manifest_reconcile`
+ *               (SMI-6343 Wave 4).
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile.helpers
+ *
+ * Split out of `apply-manifest-reconcile.ts` (500-line file gate): H9 key
+ * resolution + scope contract, C8 backup guard rail, and the `verify`
+ * action's live registry-comparison logic (reusing Wave 2's shared
+ * comparator + `lookupSkillFromRegistry`'s offline/quota degradation
+ * contract, the SAME pattern `outdated.ts` already uses).
+ */
+
+import * as fs from 'node:fs/promises'
+import type { Stats } from 'node:fs'
+
+import {
+  compareSkillContentHashes,
+  manifestKeyFor,
+  type SkillManifest,
+  type SkillManifestEntry,
+} from '@skillsmith/core'
+import {
+  CANONICAL_CLIENT,
+  InvalidScopeValueError,
+  UnsatisfiableWorkspaceScopeError,
+  parseInstallScope,
+  resolveClientId,
+  resolveScopedSkillsDir,
+  type ClientId,
+} from '@skillsmith/core/install'
+
+import type { ToolContext } from '../context.js'
+import { createProseBackup, hashContent } from './install.conflict-helpers.js'
+import { lookupSkillFromRegistry } from './install.helpers.js'
+import { readInstalledContent } from './outdated.helpers.js'
+import { MANIFEST_PATH } from './install.types.js'
+import type {
+  ApplyManifestReconcileInput,
+  ManifestReconcileErrorCode,
+  ManifestReconcileVerifyResult,
+} from './apply-manifest-reconcile.types.js'
+import type { ReconcileErrorContext } from './apply-manifest-reconcile.errors.js'
+
+/**
+ * Thrown from inside a synchronous `ManifestManager.updateSafely()` update
+ * function (or by scope/backup preflight) to carry a typed
+ * `ManifestReconcileErrorCode` out to the tool's top-level dispatcher,
+ * which maps it to the response envelope via `describeReconcileError()`.
+ */
+export class ReconcileGuardError extends Error {
+  readonly code: ManifestReconcileErrorCode
+  readonly ctx: ReconcileErrorContext
+
+  constructor(code: ManifestReconcileErrorCode, ctx: ReconcileErrorContext = {}) {
+    super(code)
+    this.name = 'ReconcileGuardError'
+    this.code = code
+    this.ctx = ctx
+  }
+}
+
+export interface ReconcileScopeTarget {
+  manifestPath: string
+  client: ClientId
+  scope: 'global' | 'workspace'
+}
+
+/**
+ * H9: resolve the manifest path for the requested scope BEFORE any read.
+ * Mirrors `uninstall_skill`'s ADR-139 scope resolution exactly (same
+ * resolver, same three inputs) so `apply_manifest_reconcile` reconciles
+ * the SAME manifest a workspace-scoped install/uninstall would touch.
+ *
+ * `InvalidScopeValueError`/`UnsatisfiableWorkspaceScopeError` propagate to
+ * the caller, which maps them to `manifest.reconcile.invalid_input`.
+ */
+export function resolveReconcileScope(input: ApplyManifestReconcileInput): ReconcileScopeTarget {
+  const client = resolveClientId(input.client)
+  const scopeTarget = resolveScopedSkillsDir({
+    client,
+    explicitScope: parseInstallScope(input.scope),
+    ...(input.cwd !== undefined && { cwd: input.cwd }),
+    globalManifestPath: MANIFEST_PATH,
+  })
+  return { manifestPath: scopeTarget.manifestPath, client, scope: scopeTarget.scope }
+}
+
+/** Re-exported so the main tool file can catch these without importing core/install directly twice. */
+export { InvalidScopeValueError, UnsatisfiableWorkspaceScopeError, CANONICAL_CLIENT }
+
+/**
+ * H9: derive the manifest key ONLY via `manifestKeyFor(name, client)` —
+ * never by indexing `installedSkills[name]` directly — and refuse rather
+ * than guess when a bare-name key exists under a DIFFERENT client (the
+ * SMI-6358/6359 bare-key writer hazard this plan cannot fix but must not
+ * assume away).
+ *
+ * Throws `ReconcileGuardError('manifest.reconcile.entry_not_found')` or
+ * `ReconcileGuardError('manifest.reconcile.key_shape_ambiguous')`.
+ */
+export function resolveReconcileEntry(
+  manifest: SkillManifest,
+  name: string,
+  client: ClientId
+): { key: string; entry: SkillManifestEntry } {
+  const key = manifestKeyFor(name, client)
+  const entry = manifest.installedSkills[key] as SkillManifestEntry | undefined
+  if (entry) return { key, entry }
+
+  // Not found under the resolved key. Before refusing entry_not_found,
+  // check whether a bare-name key exists carrying a DIFFERENT client —
+  // that is the key-shape-ambiguous case, not a genuine absence.
+  if (client !== CANONICAL_CLIENT) {
+    const bareEntry = manifest.installedSkills[name] as SkillManifestEntry | undefined
+    if (bareEntry && bareEntry.client && bareEntry.client !== client) {
+      throw new ReconcileGuardError('manifest.reconcile.key_shape_ambiguous', {
+        name,
+        manifestKey: key,
+        otherKey: name,
+      })
+    }
+  }
+
+  throw new ReconcileGuardError('manifest.reconcile.entry_not_found', { name, manifestKey: key })
+}
+
+/**
+ * On `revert`, re-derive the manifest key from the LEDGER ENTRY's own
+ * recorded `(name, client)` pair, never from caller input (H9) — a revert
+ * cannot be aimed at a different row than the action it reverses.
+ */
+export function reconcileKeyForLedgerEntry(name: string, client: string): string {
+  return manifestKeyFor(name, client as ClientId)
+}
+
+// ============================================================================
+// C8 — backup step (security)
+// ============================================================================
+
+/**
+ * C8 guard rail: assert the backup target is a regular FILE before ever
+ * calling `createProseBackup`. Makes the "someone later passes the parent
+ * directory (~/.skillsmith/, which holds config.json's live API key)"
+ * mistake structurally impossible rather than merely unlikely — see the
+ * plan's C8 subsection and the regression test asserting `config.json`
+ * never appears in the backups tree.
+ */
+export async function assertBackupTargetIsFile(filePath: string): Promise<void> {
+  let stat: Stats
+  try {
+    stat = await fs.stat(filePath)
+  } catch (err) {
+    throw new ReconcileGuardError('manifest.reconcile.backup_target_not_a_file', {
+      path: filePath,
+      detail: (err as Error).message,
+    })
+  }
+  if (!stat.isFile()) {
+    throw new ReconcileGuardError('manifest.reconcile.backup_target_not_a_file', {
+      path: filePath,
+    })
+  }
+}
+
+/**
+ * Take a pre-mutation backup of the manifest via `createProseBackup` —
+ * NEVER `createSkillBackup` (C8: the latter does a recursive `readdir`+
+ * copy and, if ever pointed at `~/.skillsmith/` instead of the file
+ * itself, would copy `config.json`'s live API key into the backups tree).
+ * `createProseBackup` is structurally incapable of this — one `copyFile`
+ * of one caller-supplied path, no `readdir`, no recursion.
+ */
+export async function takeManifestBackup(manifestPath: string): Promise<string> {
+  await assertBackupTargetIsFile(manifestPath)
+  try {
+    const { backupPath } = await createProseBackup(manifestPath, 'manifest-reconcile')
+    return backupPath
+  } catch (err) {
+    throw new ReconcileGuardError('manifest.reconcile.backup_failed', {
+      detail: (err as Error).message,
+    })
+  }
+}
+
+// ============================================================================
+// verify — live registry comparison (mirrors outdated.ts's H1 contract)
+// ============================================================================
+
+/**
+ * Compare one manifest entry's on-disk content hash against the
+ * registry's LIVE current content hash for its claimed `id`. Unlike
+ * `skill_outdated`, `verify` deliberately does NOT fall back to the
+ * historical `skill_versions` arm — ADR-144 §6's `verifiedAt` promotion
+ * specifically requires validating against ground truth NOW, not a
+ * possibly-stale cached hash (see this tool's own doc comment on the
+ * `verify` action).
+ *
+ * Never throws — every failure mode degrades to
+ * `{ verified: false, reason }`, mirroring `lookupSkillFromRegistry`'s own
+ * fail-soft contract and `outdated.ts`'s H1 degradation table.
+ */
+export async function verifyEntryAgainstRegistry(
+  entry: SkillManifestEntry,
+  context: ToolContext,
+  onQuotaExceeded: () => void,
+  quotaAlreadyExhausted: boolean
+): Promise<Omit<ManifestReconcileVerifyResult, 'name' | 'manifestKey'>> {
+  if (!entry.installPath) {
+    return { verified: false, reason: 'no-registry-record' }
+  }
+  const localContent = await readInstalledContent(entry.installPath)
+  const localHash = localContent !== null ? hashContent(localContent) : null
+  if (localHash === null) {
+    return { verified: false, reason: 'no-registry-record' }
+  }
+
+  if (context.apiClient.isOffline()) {
+    return { verified: false, reason: 'offline' }
+  }
+  if (quotaAlreadyExhausted) {
+    return { verified: false, reason: 'quota-exhausted' }
+  }
+
+  let liveArmFailed = false
+  let registryHash: string | null = null
+  try {
+    const registryInfo = await lookupSkillFromRegistry(entry.id, context, {
+      onQuotaExceeded,
+      onLiveLookupFailed: () => {
+        liveArmFailed = true
+      },
+    })
+    registryHash = registryInfo?.contentHash ?? null
+  } catch {
+    liveArmFailed = true
+  }
+
+  if (liveArmFailed) {
+    return { verified: false, reason: 'network-error' }
+  }
+  if (registryHash === null) {
+    return { verified: false, reason: 'no-registry-record' }
+  }
+
+  const comparison = compareSkillContentHashes(localHash, registryHash)
+  if (comparison.outcome === 'current') {
+    return { verified: true, verifiedAt: new Date().toISOString() }
+  }
+  return {
+    verified: false,
+    reason: comparison.outcome === 'outdated' ? 'hash-mismatch' : 'no-registry-record',
+  }
+}
+
+/**
+ * `relink`'s registry-validation step: confirm the caller-supplied `id`
+ * resolves to a real registry skill before writing it. `apply_manifest_
+ * reconcile` never infers `source` from the lookup result (ADR-144 §3 —
+ * the caller supplies BOTH `id` and `source` explicitly); this only
+ * proves `id` is a genuine registry identity, not a hallucinated one.
+ */
+export async function validateRelinkIdentity(
+  id: string,
+  context: ToolContext
+): Promise<{ ok: true } | { ok: false; detail: string }> {
+  if (context.apiClient.isOffline()) {
+    return { ok: false, detail: 'registry is offline' }
+  }
+  try {
+    const info = await lookupSkillFromRegistry(id, context)
+    if (!info) {
+      return { ok: false, detail: `'${id}' was not found in the registry` }
+    }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, detail: (err as Error).message }
+  }
+}

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.helpers.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.helpers.ts
@@ -105,7 +105,25 @@ export function resolveReconcileEntry(
 ): { key: string; entry: SkillManifestEntry } {
   const key = manifestKeyFor(name, client)
   const entry = manifest.installedSkills[key] as SkillManifestEntry | undefined
-  if (entry) return { key, entry }
+  if (entry) {
+    // Adversarial-review finding (Wave 4): for the CANONICAL client,
+    // `manifestKeyFor` returns the bare `name` itself — the same bare key
+    // the SMI-6358/6359 bug can leave a NON-canonical entry sitting under.
+    // Finding the entry at the resolved key is not proof it belongs to the
+    // requested `client`: if the entry itself carries a recorded `client`
+    // that disagrees, silently trusting it would let mark_local/relink/
+    // drop_entry mutate a DIFFERENT client's row than the caller intended.
+    // A missing `entry.client` is the documented legacy-entry default
+    // (implicitly canonical, per SMI-5894) and is NOT a conflict.
+    if (entry.client && entry.client !== client) {
+      throw new ReconcileGuardError('manifest.reconcile.key_shape_ambiguous', {
+        name,
+        manifestKey: key,
+        otherKey: key,
+      })
+    }
+    return { key, entry }
+  }
 
   // Not found under the resolved key. Before refusing entry_not_found,
   // check whether a bare-name key exists carrying a DIFFERENT client —
@@ -131,6 +149,39 @@ export function resolveReconcileEntry(
  */
 export function reconcileKeyForLedgerEntry(name: string, client: string): string {
   return manifestKeyFor(name, client as ClientId)
+}
+
+// ============================================================================
+// drop_entry — installPath-still-resolves guard (adversarial-review finding)
+// ============================================================================
+
+/**
+ * `drop_entry`'s own tool description and the plan's Actions table both
+ * describe it as removing an entry "whose installPath no longer resolves"
+ * — the implementation must actually enforce that, not just narrate it.
+ * Without this check, `drop_entry` would silently orphan a healthy,
+ * currently-installed skill's on-disk files by deleting only its manifest
+ * record. Refuses when `installPath` still resolves to an existing
+ * directory; any stat failure (ENOENT or otherwise) is treated as
+ * "no longer resolves" — exactly the case this action exists for.
+ */
+export async function assertDropTargetNoLongerResolves(
+  name: string,
+  entry: SkillManifestEntry
+): Promise<void> {
+  if (!entry.installPath) return
+  let stat: Stats
+  try {
+    stat = await fs.stat(entry.installPath)
+  } catch {
+    return
+  }
+  if (stat.isDirectory()) {
+    throw new ReconcileGuardError('manifest.reconcile.drop_target_still_resolves', {
+      name,
+      path: entry.installPath,
+    })
+  }
 }
 
 // ============================================================================

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.lock-helpers.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.lock-helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Shared lock-timeout mapping for `apply_manifest_reconcile`'s
+ *               action implementations (SMI-6343 Wave 4).
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile.lock-helpers
+ *
+ * Split out so both `apply-manifest-reconcile.actions.ts` and
+ * `apply-manifest-reconcile.verify.ts` share one implementation rather than
+ * two copies drifting apart.
+ */
+
+import { ReconcileGuardError } from './apply-manifest-reconcile.helpers.js'
+
+/** `ManifestManager.acquireLock()`'s 30s-timeout error has no typed shape — match its message. */
+function isLockTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('Failed to acquire manifest lock')
+}
+
+export async function withLockTimeoutMapping<T>(
+  manifestPath: string,
+  run: () => Promise<T>
+): Promise<T> {
+  try {
+    return await run()
+  } catch (err) {
+    if (err instanceof ReconcileGuardError) throw err
+    if (isLockTimeoutError(err)) {
+      throw new ReconcileGuardError('manifest.reconcile.lock_timeout', {
+        path: `${manifestPath}.lock`,
+      })
+    }
+    throw err
+  }
+}

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.ts
@@ -1,0 +1,253 @@
+/**
+ * @fileoverview `apply_manifest_reconcile` MCP tool (SMI-6343 Wave 4).
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile
+ *
+ * Plan: docs/internal/implementation/smi-6343-manifest-hygiene.md
+ * ("4. Reconciliation tool (Wave 4, stacked on Wave 3 — AC#1, AC#2, and
+ * ADR-144 §6's writer)"). Trust-model philosophy: ADR-144 §3 (never
+ * convert uncertainty into a registry identity) and ADR-145
+ * (docs/internal/adr/145-manifest-provenance-as-second-trust-axis.md —
+ * `provenance` is a second trust axis, orthogonal to `source`).
+ *
+ * Community tier. Repairs a corrupted or ambiguous `~/.skillsmith/
+ * manifest.json` entry through a supported path — never a hand-edit —
+ * closing AC#1/AC#2 and writing the `verifiedAt` field ADR-144 §6's
+ * blanket trust-downgrade needs a way back out of.
+ *
+ * Actions:
+ *   - `mark_local`  — clears registry tracking: `source: 'unknown'` +
+ *     `provenance: 'local'`, written atomically in one locked update
+ *     (ADR-145 §2 — these two fields are never written independently).
+ *   - `relink`      — sets `id`/`source` to an explicitly supplied,
+ *     registry-validated pair + `provenance: 'registry'`. Never infers an
+ *     identity (ADR-144 §3) — does NOT set `verifiedAt` (asserting an
+ *     identity is not verifying content).
+ *   - `drop_entry`  — hard-removes an entry whose `installPath` no longer
+ *     resolves (M7: renamed from `forget`, which read as reversible — this
+ *     is a hard delete, recoverable only via `revert`).
+ *   - `verify`      — (C3) runs the Wave 2 comparison for one entry or
+ *     every entry (batch by default) and writes `verifiedAt` only on a
+ *     match; a mismatch leaves the entry untouched.
+ *   - `revert`      — (C7) durable, cross-session undo of a prior
+ *     reconcile action on ONE entry, via a dedicated ledger
+ *     (`~/.skillsmith/manifest-reconcile-ledger.json`) modeled on
+ *     `rename-engine.revert.ts` — NOT `undo_apply`, which is rejected as
+ *     the undo mechanism for this tool (session-scoped, whole-file hash
+ *     guard hostile to the manifest's 7 independent writers, unlocked
+ *     writer — see the plan's C7 subsection).
+ */
+
+import { z } from 'zod'
+
+import {
+  CLIENT_IDS,
+  InvalidScopeValueError,
+  UnsatisfiableWorkspaceScopeError,
+  type ClientId,
+} from '@skillsmith/core/install'
+import { withTelemetry } from '@skillsmith/core/telemetry'
+
+import type { ToolContext } from '../context.js'
+import { getToolContext } from '../context.js'
+import {
+  runDropEntry,
+  runMarkLocal,
+  runRelink,
+  runRevert,
+  runVerify,
+} from './apply-manifest-reconcile.actions.js'
+import { describeReconcileError } from './apply-manifest-reconcile.errors.js'
+import { ReconcileGuardError, resolveReconcileScope } from './apply-manifest-reconcile.helpers.js'
+import type {
+  ApplyManifestReconcileInput,
+  ApplyManifestReconcileResponse,
+} from './apply-manifest-reconcile.types.js'
+
+// SMI-5982-style enum derivation (mirrors install.types.ts / uninstall.ts) —
+// derives from the same source of truth `resolveClientId` validates
+// against, so this Zod enum cannot silently drift from the real client list.
+const CLIENT_ID_ENUM_VALUES = CLIENT_IDS as unknown as [ClientId, ...ClientId[]]
+
+export const applyManifestReconcileInputSchema = z
+  .object({
+    action: z.enum(['mark_local', 'relink', 'drop_entry', 'verify', 'revert']),
+    name: z.string().min(1).optional(),
+    client: z.enum(CLIENT_ID_ENUM_VALUES).optional(),
+    scope: z.enum(['global', 'workspace']).optional(),
+    cwd: z.string().min(1).optional(),
+    id: z.string().min(1).optional(),
+    source: z.string().min(1).optional(),
+    reason: z.string().min(1).optional(),
+    ledgerEntryId: z.string().min(1).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (['mark_local', 'relink', 'drop_entry'].includes(value.action) && !value.name) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['name'],
+        message: `'name' is required when action === '${value.action}'`,
+      })
+    }
+    if (value.action === 'relink' && (!value.id || !value.source)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['id'],
+        message: "relink requires BOTH 'id' and 'source'",
+      })
+    }
+    if (value.action !== 'relink' && (value.id !== undefined || value.source !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['id'],
+        message: "'id'/'source' are only valid when action === 'relink'",
+      })
+    }
+    if (value.action === 'revert' && !value.name && !value.ledgerEntryId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['ledgerEntryId'],
+        message: "revert requires either 'ledgerEntryId' or 'name'",
+      })
+    }
+  })
+
+/**
+ * MCP tool schema for `apply_manifest_reconcile`. Hand-written JSON Schema
+ * mirroring {@link applyManifestReconcileInputSchema} so the tool is
+ * client-discoverable via ListTools. Keep in sync with the Zod schema.
+ */
+export const applyManifestReconcileToolSchema = {
+  name: 'apply_manifest_reconcile',
+  description:
+    "[Skillsmith — Maintain stage] Repair a corrupted or ambiguous ~/.skillsmith/manifest.json entry through a supported path — MUTATES the manifest (with a pre-mutation backup and a durable, revertible ledger entry). Use after skill_outdated reports 'identity-mismatch' or 'local-drift', or after skill_recover_source found low/no confidence. Actions: 'mark_local' (stop tracking this entry against the registry — writes source:'unknown' + provenance:'local'); 'relink' (assert an explicit, registry-validated id/source pair — requires BOTH; never infers an identity); 'drop_entry' (hard-remove an entry whose installPath no longer resolves); 'verify' (re-check on-disk content against the registry's current content hash for one entry or, by default, every entry — writes verifiedAt only on a match); 'revert' (durable, cross-session undo of a prior reconcile on ONE entry, by ledgerEntryId or by name — survives an unrelated skill install happening in between).",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['mark_local', 'relink', 'drop_entry', 'verify', 'revert'],
+        description:
+          "'mark_local' | 'relink' | 'drop_entry' | 'verify' | 'revert' — see tool description for each action's effect.",
+      },
+      name: {
+        type: 'string',
+        description:
+          'Skill name (manifest entry, not a full id). Required for mark_local/relink/drop_entry. Optional for verify (omit to batch-verify every entry) and revert (omit when passing ledgerEntryId).',
+      },
+      client: {
+        type: 'string',
+        enum: CLIENT_ID_ENUM_VALUES,
+        description: 'Target client (ADR-139). Defaults to the canonical client (claude-code).',
+      },
+      scope: {
+        type: 'string',
+        enum: ['global', 'workspace'],
+        description:
+          'Explicit install scope (ADR-139). Defaults to auto-detecting an EXISTING workspace directory, else global.',
+      },
+      cwd: {
+        type: 'string',
+        description:
+          "Absolute path to the calling client's actual project root, used as the ancestor-walk starting point for workspace scope resolution.",
+      },
+      id: {
+        type: 'string',
+        description:
+          "relink only, required together with 'source': registry skill id (author/name).",
+      },
+      source: {
+        type: 'string',
+        description:
+          "relink only, required together with 'id': the source reference to record (e.g. github:owner/repo).",
+      },
+      reason: {
+        type: 'string',
+        description: 'Optional human-readable reason, recorded in the revert ledger.',
+      },
+      ledgerEntryId: {
+        type: 'string',
+        description:
+          'revert only: precise ledger entry id (mrc_...) from a prior mutating action response. Preferred over name when known.',
+      },
+    },
+    required: ['action'],
+  },
+}
+
+async function applyManifestReconcileImpl(
+  input: unknown,
+  _context?: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  const parsed = applyManifestReconcileInputSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => {
+        const issuePath = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+        return `${issuePath}: ${issue.message}`
+      })
+      .join('; ')
+    return {
+      success: false,
+      action: (input as { action?: ApplyManifestReconcileInput['action'] })?.action ?? 'mark_local',
+      errorCode: 'manifest.reconcile.invalid_input',
+      error: describeReconcileError('manifest.reconcile.invalid_input', { detail: message }),
+    }
+  }
+  const validInput: ApplyManifestReconcileInput = parsed.data
+  const context = _context ?? getToolContext()
+
+  let scopeTarget: ReturnType<typeof resolveReconcileScope>
+  try {
+    scopeTarget = resolveReconcileScope(validInput)
+  } catch (err) {
+    if (err instanceof InvalidScopeValueError || err instanceof UnsatisfiableWorkspaceScopeError) {
+      return {
+        success: false,
+        action: validInput.action,
+        errorCode: 'manifest.reconcile.invalid_input',
+        error: describeReconcileError('manifest.reconcile.invalid_input', {
+          detail: err.message,
+        }),
+      }
+    }
+    throw err
+  }
+
+  try {
+    switch (validInput.action) {
+      case 'mark_local':
+        return await runMarkLocal(validInput, scopeTarget, context)
+      case 'relink':
+        return await runRelink(validInput, scopeTarget, context)
+      case 'drop_entry':
+        return await runDropEntry(validInput, scopeTarget, context)
+      case 'verify':
+        return await runVerify(validInput, scopeTarget, context)
+      case 'revert':
+        return await runRevert(validInput, scopeTarget, context)
+      default: {
+        const exhaustive: never = validInput.action
+        throw new Error(`unreachable action: ${String(exhaustive)}`)
+      }
+    }
+  } catch (err) {
+    if (err instanceof ReconcileGuardError) {
+      return {
+        success: false,
+        action: validInput.action,
+        name: validInput.name,
+        errorCode: err.code,
+        error: describeReconcileError(err.code, err.ctx),
+      }
+    }
+    throw err
+  }
+}
+
+// SMI-5017 W2.S2: wrap at export boundary
+export const applyManifestReconcile = withTelemetry(applyManifestReconcileImpl, {
+  source: 'mcp-tool',
+  extractSkillId: () => 'apply_manifest_reconcile',
+  extractFramework: () => 'unknown',
+})

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.types.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.types.ts
@@ -27,6 +27,7 @@ export type ManifestReconcileErrorCode =
   | 'manifest.reconcile.key_shape_ambiguous' // H9: bare-key vs manifestKeyFor collision
   | 'manifest.reconcile.relink_unvalidated' // relink id/source not confirmed against the registry
   | 'manifest.reconcile.relink_incomplete' // relink without BOTH id and source
+  | 'manifest.reconcile.drop_target_still_resolves' // adversarial-review finding: drop_entry's own contract requires installPath to no longer resolve
   | 'manifest.reconcile.backup_target_not_a_file' // C8 guard rail
   | 'manifest.reconcile.backup_failed'
   | 'manifest.reconcile.lock_timeout' // ManifestManager's 30s ceiling

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.types.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.types.ts
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview Type vocabulary for the `apply_manifest_reconcile` MCP tool
+ *               (SMI-6343 Wave 4).
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile.types
+ *
+ * Plan: docs/internal/implementation/smi-6343-manifest-hygiene.md
+ * ("4. Reconciliation tool (Wave 4 ...)").
+ */
+
+import type { ClientId } from '@skillsmith/core/install'
+import type { SkillManifestEntry } from '@skillsmith/core'
+
+/**
+ * M2 error taxonomy, modeled on `StuckLockError`
+ * (`owned-lock.acquire.ts:70-94`): `errorCode` is a stable discriminant for
+ * mechanical triage (never prose-matching); `describeReconcileError()`
+ * (`apply-manifest-reconcile.errors.ts`) generates the human-readable
+ * message from the code so code and prose cannot drift, embedding the
+ * exact next remediation command inline. Mirrors the existing
+ * dot-namespaced unions on `apply_namespace_rename`
+ * (`namespace.rename.revert_ambiguous`, ...) and `undo_apply`
+ * (`undo.scope_violation`, ...).
+ */
+export type ManifestReconcileErrorCode =
+  | 'manifest.reconcile.invalid_input'
+  | 'manifest.reconcile.entry_not_found'
+  | 'manifest.reconcile.key_shape_ambiguous' // H9: bare-key vs manifestKeyFor collision
+  | 'manifest.reconcile.relink_unvalidated' // relink id/source not confirmed against the registry
+  | 'manifest.reconcile.relink_incomplete' // relink without BOTH id and source
+  | 'manifest.reconcile.backup_target_not_a_file' // C8 guard rail
+  | 'manifest.reconcile.backup_failed'
+  | 'manifest.reconcile.lock_timeout' // ManifestManager's 30s ceiling
+  | 'manifest.reconcile.entry_changed' // C7 same-entry conflict
+  | 'manifest.reconcile.revert_ambiguous' // mirrors namespace.rename.revert_ambiguous
+  | 'manifest.reconcile.ledger_version_unsupported'
+  | 'manifest.reconcile.ledger_malformed'
+  | 'manifest.reconcile.verify_unavailable' // verify could not reach the registry
+
+export type ManifestReconcileAction = 'mark_local' | 'relink' | 'drop_entry' | 'verify' | 'revert'
+
+/**
+ * Input for the `apply_manifest_reconcile` MCP tool.
+ *
+ * H9 (manifest key + scope contract): `client` defaults to
+ * `CANONICAL_CLIENT`; `scope`/`cwd` follow the same ADR-139 contract as
+ * `uninstall_skill` — the manifest path for the requested scope is
+ * resolved BEFORE any read, and the manifest key is derived ONLY via
+ * `manifestKeyFor(name, client)`, never by indexing `installedSkills[name]`
+ * directly.
+ *
+ * `name` is required for every action except `verify`, where omitting it
+ * runs the batch pass over every manifest entry (C3: "Batch by default").
+ *
+ * `revert` may target a ledger entry either precisely (`ledgerEntryId`,
+ * returned by a prior mutating action's response) or by `(name, client)`
+ * — see the revert action's own doc comment in `apply-manifest-reconcile.ts`
+ * for the disambiguation policy.
+ */
+export interface ApplyManifestReconcileInput {
+  action: ManifestReconcileAction
+  /** Required for mark_local/relink/drop_entry/revert-by-name; optional for verify (batch). */
+  name?: string
+  /** Target client (ADR-139). Defaults to the canonical client. */
+  client?: ClientId
+  /** Explicit install scope (ADR-139). Defaults to auto-detected. */
+  scope?: 'global' | 'workspace'
+  /** Ancestor-walk starting point for workspace scope resolution. */
+  cwd?: string
+  /** relink only: registry skill id (author/name). Required together with `source`. */
+  id?: string
+  /** relink only: the source reference to record (e.g. `github:owner/repo`). Required together with `id`. */
+  source?: string
+  /** Optional human-readable reason, recorded in the ledger. */
+  reason?: string
+  /** revert only: precise ledger entry id (`mrc_...`) from a prior mutating action's response. */
+  ledgerEntryId?: string
+}
+
+/** Per-entry outcome of a `verify` pass (batch or single-entry). */
+export interface ManifestReconcileVerifyResult {
+  name: string
+  manifestKey: string
+  verified: boolean
+  /** Populated when `verified` is false. */
+  reason?: 'offline' | 'quota-exhausted' | 'network-error' | 'no-registry-record' | 'hash-mismatch'
+  /** ISO-8601 UTC timestamp written on a match. Absent when not verified. */
+  verifiedAt?: string
+}
+
+/**
+ * Wire response shape. `success: true` for mark_local/relink/drop_entry
+ * carries the entry's post-write state, read back INSIDE the same
+ * `updateSafely()` transaction (M11 — the AC#2 verification-gate
+ * requirement), plus the ledger entry id for a later precise revert.
+ */
+export interface ApplyManifestReconcileResponse {
+  success: boolean
+  action: ManifestReconcileAction
+  /** Echoes the input `name` when known. */
+  name?: string
+  manifestKey?: string
+  /** Post-write entry state (mark_local/relink). Absent for drop_entry (removed) and verify (batch). */
+  entry?: SkillManifestEntry
+  /** verify only: per-entry results (length 1 for a single-name verify). */
+  verifyResults?: ManifestReconcileVerifyResult[]
+  /** mark_local/relink/drop_entry/verify(single-write): ledger entry id for a later precise revert. */
+  ledgerEntryId?: string
+  /** revert only: true when the revert was a no-op (no matching ledger entry — already reverted or never applied). */
+  noOp?: boolean
+  /** Absolute path to the pre-mutation manifest backup (C8), when a backup was taken. */
+  backupPath?: string
+  errorCode?: ManifestReconcileErrorCode
+  error?: string
+}

--- a/packages/mcp-server/src/tools/apply-manifest-reconcile.verify.ts
+++ b/packages/mcp-server/src/tools/apply-manifest-reconcile.verify.ts
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview `verify` action implementation for `apply_manifest_reconcile`
+ *               (SMI-6343 Wave 4, C3).
+ * @module @skillsmith/mcp-server/tools/apply-manifest-reconcile.verify
+ *
+ * Split out of `apply-manifest-reconcile.actions.ts` (500-line file gate) —
+ * the Wave 4 adversarial-review fix for the async-verify-then-locked-write
+ * race (see the two doc comments inside `runVerify` below) pushed the
+ * combined actions file over the limit.
+ */
+
+import { ManifestManager, type SkillManifest, type SkillManifestEntry } from '@skillsmith/core'
+
+import type { ToolContext } from '../context.js'
+import { appendReconcileLedgerEntry } from './manifest-reconcile-ledger.js'
+import type { ManifestReconcileLedgerEntry } from './manifest-reconcile-ledger.types.js'
+import type {
+  ApplyManifestReconcileInput,
+  ApplyManifestReconcileResponse,
+  ManifestReconcileVerifyResult,
+} from './apply-manifest-reconcile.types.js'
+import {
+  ReconcileGuardError,
+  resolveReconcileEntry,
+  takeManifestBackup,
+  verifyEntryAgainstRegistry,
+  type ReconcileScopeTarget,
+} from './apply-manifest-reconcile.helpers.js'
+import { withLockTimeoutMapping } from './apply-manifest-reconcile.lock-helpers.js'
+
+// ============================================================================
+// verify (C3)
+// ============================================================================
+
+export async function runVerify(
+  input: ApplyManifestReconcileInput,
+  scopeTarget: ReconcileScopeTarget,
+  context: ToolContext
+): Promise<ApplyManifestReconcileResponse> {
+  const manager = new ManifestManager(scopeTarget.manifestPath)
+  const manifest = await manager.load()
+
+  let targets: Array<{ key: string; entry: SkillManifestEntry }>
+  if (input.name) {
+    // Single-entry verify: total unavailability is a hard failure — the
+    // caller asked about ONE entry and there is nothing partial to report.
+    if (context.apiClient.isOffline()) {
+      throw new ReconcileGuardError('manifest.reconcile.verify_unavailable', {
+        name: input.name,
+        detail: 'registry is offline',
+      })
+    }
+    const { key, entry } = resolveReconcileEntry(manifest, input.name, scopeTarget.client)
+    targets = [{ key, entry }]
+  } else {
+    // Batch (C3: "Batch by default"). Never hard-fails on offline/quota —
+    // each entry degrades to an honest unverified result (H1 philosophy).
+    targets = Object.entries(manifest.installedSkills).map(([key, entry]) => ({
+      key,
+      entry: entry as SkillManifestEntry,
+    }))
+  }
+
+  let quotaExhausted = false
+  const results: ManifestReconcileVerifyResult[] = []
+  const writes: Array<{ key: string; verifiedAt: string }> = []
+
+  for (const { key, entry } of targets) {
+    const outcome = await verifyEntryAgainstRegistry(
+      entry,
+      context,
+      () => {
+        quotaExhausted = true
+      },
+      quotaExhausted
+    )
+    results.push({ name: entry.name ?? key, manifestKey: key, ...outcome })
+    if (outcome.verified && outcome.verifiedAt) {
+      writes.push({ key, verifiedAt: outcome.verifiedAt })
+    }
+  }
+
+  if (writes.length === 0) {
+    // C3: "Writes nothing on a mismatch" — no backup/ledger churn for a
+    // pass that changed nothing.
+    return { success: true, action: 'verify', verifyResults: results }
+  }
+
+  const backupPath = await takeManifestBackup(scopeTarget.manifestPath)
+  const ledgerEntries: ManifestReconcileLedgerEntry[] = []
+  // Adversarial-review finding: `writes` was PLANNED from the pre-lock
+  // registry comparison — it is not proof any of them actually happened.
+  // `actuallyWritten` records only the entries this lock's callback truly
+  // mutated, so the ledger below can never claim a write that didn't occur
+  // (the exact gap that made a `revert` of a phantom verify immediately
+  // hit `entry_changed`, since the manifest never matched the claimed
+  // `afterState` in the first place).
+  const actuallyWritten: Array<{
+    key: string
+    verifiedAt: string
+    priorEntry: SkillManifestEntry
+  }> = []
+
+  await withLockTimeoutMapping(scopeTarget.manifestPath, () =>
+    manager.updateSafely((m: SkillManifest) => {
+      const updatedSkills = { ...m.installedSkills }
+      for (const { key, verifiedAt } of writes) {
+        const current = updatedSkills[key] as SkillManifestEntry | undefined
+        const verifiedSnapshot = targets.find((t) => t.key === key)?.entry
+        // Defense-in-depth: an entry that vanished between the async verify
+        // pass and this lock (dropped by a concurrent writer) is skipped —
+        // there is nothing left to stamp verifiedAt onto. Likewise, if the
+        // entry's IDENTITY (id/installPath) changed since it was verified —
+        // e.g. a concurrent relink or reinstall of the same key — the
+        // content that was actually hashed against the registry is no
+        // longer what this entry claims to be, so stamping verifiedAt onto
+        // the NEW identity would certify a pair that was never checked.
+        if (
+          !current ||
+          !verifiedSnapshot ||
+          current.id !== verifiedSnapshot.id ||
+          current.installPath !== verifiedSnapshot.installPath
+        ) {
+          continue
+        }
+        updatedSkills[key] = { ...current, verifiedAt }
+        actuallyWritten.push({ key, verifiedAt, priorEntry: current })
+      }
+      return { ...m, installedSkills: updatedSkills }
+    })
+  )
+
+  // Ledger entries recorded AFTER the write, and ONLY for keys the lock's
+  // callback actually mutated (see `actuallyWritten` above) — never for a
+  // key that was merely planned and then skipped inside the lock.
+  for (const { key, verifiedAt, priorEntry } of actuallyWritten) {
+    const ledgerEntry = await appendReconcileLedgerEntry({
+      manifestPath: scopeTarget.manifestPath,
+      manifestKey: key,
+      name: priorEntry.name ?? key,
+      client: scopeTarget.client,
+      action: 'verify',
+      beforeState: priorEntry as unknown as Record<string, unknown>,
+      afterState: { ...priorEntry, verifiedAt } as unknown as Record<string, unknown>,
+      reason: input.reason ?? 'apply_manifest_reconcile: verify',
+    })
+    ledgerEntries.push(ledgerEntry)
+  }
+
+  return {
+    success: true,
+    action: 'verify',
+    verifyResults: results,
+    backupPath,
+    // Single-entry verify: surface the one ledger entry id directly for a
+    // later precise revert, mirroring the other single-write actions.
+    ledgerEntryId: input.name ? ledgerEntries[0]?.id : undefined,
+  }
+}

--- a/packages/mcp-server/src/tools/install.types.ts
+++ b/packages/mcp-server/src/tools/install.types.ts
@@ -373,6 +373,24 @@ export interface SkillManifestEntry {
    * until SMI-6343 Wave 3 needed it for the path-unresolved identity signal.
    */
   client?: ClientId
+  /**
+   * ADR-145 §1: who asserts this entry's identity, independent of `source`
+   * — `'registry'` (Skillsmith resolved + installed it) or `'local'` (the
+   * user positively asserted this is their own / not registry-tracked).
+   * Absent = legacy, no assertion ever recorded (NEVER defaults to
+   * `'registry'`). Mirrors core's own `SkillManifestEntry`
+   * (`skill-installation.types.ts`) — widened here, same pattern as
+   * `client` above, because `apply_manifest_reconcile` (SMI-6343 Wave 4)
+   * is the first mcp-server-local reader/writer of this field.
+   */
+  provenance?: 'local' | 'registry'
+  /**
+   * ADR-145 §3 / ADR-144 §6: ISO-8601 UTC timestamp of the last successful
+   * re-verification of this entry's on-disk content hash against the
+   * registry's content hash for the claimed `id`. Written only by
+   * `apply_manifest_reconcile`'s `verify` action, only on a hash match.
+   */
+  verifiedAt?: string
 }
 
 export interface SkillManifest {

--- a/packages/mcp-server/src/tools/manifest-reconcile-ledger.ts
+++ b/packages/mcp-server/src/tools/manifest-reconcile-ledger.ts
@@ -188,8 +188,13 @@ export async function writeReconcileLedger(
   } catch (err) {
     try {
       await fs.rm(tmpPath, { force: true })
-    } catch {
-      // best-effort cleanup
+    } catch (cleanupErr) {
+      // Best-effort cleanup — logged (not silent) so a leaked .tmp file is
+      // diagnosable, matching this repo's convention of never swallowing a
+      // caught error without at least a warning (pr-reviewer-gate finding).
+      console.warn(
+        `[manifest-reconcile-ledger] failed to remove stale tmp file '${tmpPath}': ${(cleanupErr as Error).message}`
+      )
     }
     throw err
   }

--- a/packages/mcp-server/src/tools/manifest-reconcile-ledger.ts
+++ b/packages/mcp-server/src/tools/manifest-reconcile-ledger.ts
@@ -1,0 +1,269 @@
+/**
+ * @fileoverview Atomic reader/writer for the manifest-reconcile ledger
+ *               (SMI-6343 Wave 4, C7).
+ * @module @skillsmith/mcp-server/tools/manifest-reconcile-ledger
+ *
+ * Persists `~/.skillsmith/manifest-reconcile-ledger.json` — see
+ * `manifest-reconcile-ledger.types.ts`'s module header for why this is a
+ * NEW ledger rather than a reuse of `undo_apply`'s session stack.
+ *
+ * Atomicity: every write goes through `<path>.tmp.<random>` + `fs.rename`
+ * (mirrors `namespace-overrides.ts`'s per-call-unique-tmp shape — a fixed
+ * `<path>.tmp` would race two concurrent writers on the rename target). On
+ * read, a missing file degrades gracefully to an empty ledger; malformed
+ * JSON surfaces as a typed `manifest.reconcile.ledger_malformed`
+ * discriminator; a higher-than-supported `version` returns
+ * `manifest.reconcile.ledger_version_unsupported` rather than a silent
+ * empty ledger.
+ *
+ * No advisory file lock: like `namespace-overrides.json`, this ledger is
+ * written at human-initiated-repair cadence, not install-hot-path
+ * cadence, and the atomic rename makes a torn read impossible. The
+ * MANIFEST itself is still protected by `ManifestManager`'s real lock —
+ * this ledger only records what that locked write did.
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { ulid } from 'ulid'
+
+import {
+  CURRENT_LEDGER_VERSION,
+  type ManifestReconcileLedger,
+  type ManifestReconcileLedgerEntry,
+  type ManifestReconcileMutatingAction,
+  type ReadReconcileLedgerResult,
+  type ReconcileLedgerVersionUnsupportedError,
+} from './manifest-reconcile-ledger.types.js'
+
+const ULID_PREFIX = 'mrc_'
+
+export interface ReconcileLedgerPathOptions {
+  /** Override the ledger path (default `~/.skillsmith/manifest-reconcile-ledger.json`). */
+  ledgerPath?: string
+}
+
+/**
+ * Default ledger path resolver. Re-evaluates `os.homedir()` on every call
+ * (mirrors `namespace-overrides.ts`'s `defaultLedgerPath` — a
+ * captured-at-module-load constant would freeze the path to the spawning
+ * process's home directory and silently route all writes there).
+ */
+function defaultLedgerPath(): string {
+  return path.join(os.homedir(), '.skillsmith', 'manifest-reconcile-ledger.json')
+}
+
+function emptyLedger(): ManifestReconcileLedger {
+  return { version: CURRENT_LEDGER_VERSION, entries: [] }
+}
+
+/**
+ * Read the ledger from disk and return a tagged union. Missing file ->
+ * `{ kind: 'ok', ledger: <empty> }`. Malformed JSON ->
+ * `{ kind: 'manifest.reconcile.ledger_malformed', reason }`.
+ * `version > CURRENT_LEDGER_VERSION` ->
+ * `{ kind: 'manifest.reconcile.ledger_version_unsupported', found, expected }`.
+ */
+export async function readReconcileLedgerResult(
+  opts: ReconcileLedgerPathOptions = {}
+): Promise<ReadReconcileLedgerResult> {
+  const ledgerPath = opts.ledgerPath ?? defaultLedgerPath()
+
+  let raw: string
+  try {
+    raw = await fs.readFile(ledgerPath, 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { kind: 'ok', ledger: emptyLedger() }
+    }
+    return {
+      kind: 'manifest.reconcile.ledger_malformed',
+      reason: `read failed: ${(err as Error).message}`,
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    return {
+      kind: 'manifest.reconcile.ledger_malformed',
+      reason: `parse failed: ${(err as Error).message}`,
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { kind: 'manifest.reconcile.ledger_malformed', reason: 'top-level is not an object' }
+  }
+
+  const candidate = parsed as Partial<ManifestReconcileLedger>
+  const versionValue = candidate.version
+  if (typeof versionValue !== 'number' || !Number.isInteger(versionValue) || versionValue < 1) {
+    return {
+      kind: 'manifest.reconcile.ledger_malformed',
+      reason: `invalid version: ${String(versionValue)}`,
+    }
+  }
+
+  if (versionValue > CURRENT_LEDGER_VERSION) {
+    return {
+      kind: 'manifest.reconcile.ledger_version_unsupported',
+      found: versionValue,
+      expected: CURRENT_LEDGER_VERSION,
+    } satisfies ReconcileLedgerVersionUnsupportedError
+  }
+
+  if (!Array.isArray(candidate.entries)) {
+    return { kind: 'manifest.reconcile.ledger_malformed', reason: 'entries is not an array' }
+  }
+
+  return {
+    kind: 'ok',
+    ledger: {
+      version: CURRENT_LEDGER_VERSION,
+      entries: candidate.entries as ManifestReconcileLedgerEntry[],
+    },
+  }
+}
+
+/**
+ * Convenience wrapper: returns the ledger directly, collapsing the
+ * `malformed` branch to an empty ledger plus a `console.warn`. A
+ * higher-version file still bubbles a thrown error — silently emptying a
+ * higher-version ledger would corrupt forward-compat.
+ */
+export async function readReconcileLedger(
+  opts: ReconcileLedgerPathOptions = {}
+): Promise<ManifestReconcileLedger> {
+  const result = await readReconcileLedgerResult(opts)
+  switch (result.kind) {
+    case 'ok':
+      return result.ledger
+    case 'manifest.reconcile.ledger_malformed':
+      console.warn(
+        `[manifest-reconcile-ledger] ledger malformed (${result.reason}); using empty ledger`
+      )
+      return emptyLedger()
+    case 'manifest.reconcile.ledger_version_unsupported': {
+      const err = new Error(
+        `manifest-reconcile-ledger version ${String(result.found)} is newer than supported version ${String(result.expected)}`
+      ) as Error & { kind: typeof result.kind; found: number; expected: number }
+      err.kind = result.kind
+      err.found = result.found
+      err.expected = result.expected
+      throw err
+    }
+    default: {
+      const _exhaustive: never = result
+      throw new Error(`unreachable: ${String(_exhaustive)}`)
+    }
+  }
+}
+
+/**
+ * Write the ledger atomically: `<path>.<random>.tmp` + `fs.rename`.
+ * Creates the parent directory on first run.
+ */
+export async function writeReconcileLedger(
+  ledger: ManifestReconcileLedger,
+  opts: ReconcileLedgerPathOptions = {}
+): Promise<void> {
+  const ledgerPath = opts.ledgerPath ?? defaultLedgerPath()
+  const tmpSuffix = crypto.randomBytes(6).toString('hex')
+  const tmpPath = `${ledgerPath}.${tmpSuffix}.tmp`
+
+  await fs.mkdir(path.dirname(ledgerPath), { recursive: true })
+
+  const normalized: ManifestReconcileLedger = {
+    version: CURRENT_LEDGER_VERSION,
+    entries: ledger.entries,
+  }
+  const json = JSON.stringify(normalized, null, 2)
+  try {
+    await fs.writeFile(tmpPath, json, 'utf-8')
+    await fs.rename(tmpPath, ledgerPath)
+  } catch (err) {
+    try {
+      await fs.rm(tmpPath, { force: true })
+    } catch {
+      // best-effort cleanup
+    }
+    throw err
+  }
+}
+
+/**
+ * Append a new entry to the ledger and persist it. Returns the full
+ * entry (including the generated `id`/`appliedAt`) so the caller can echo
+ * `ledgerEntryId` back to the caller for a later precise `revert`.
+ */
+export async function appendReconcileLedgerEntry(
+  input: {
+    manifestPath: string
+    manifestKey: string
+    name: string
+    client: string
+    action: ManifestReconcileMutatingAction
+    beforeState: Record<string, unknown>
+    afterState: Record<string, unknown> | null
+    reason: string
+  },
+  opts: ReconcileLedgerPathOptions = {}
+): Promise<ManifestReconcileLedgerEntry> {
+  const ledger = await readReconcileLedger(opts)
+  const entry: ManifestReconcileLedgerEntry = {
+    id: `${ULID_PREFIX}${ulid()}`,
+    manifestPath: input.manifestPath,
+    manifestKey: input.manifestKey,
+    name: input.name,
+    client: input.client,
+    action: input.action,
+    beforeState: input.beforeState,
+    afterState: input.afterState,
+    appliedAt: new Date().toISOString(),
+    reason: input.reason,
+  }
+  await writeReconcileLedger({ version: ledger.version, entries: [...ledger.entries, entry] }, opts)
+  return entry
+}
+
+/**
+ * Remove a ledger entry by id and persist the result. Used by a
+ * successful revert (C7's idempotency: the entry being gone is what makes
+ * a second revert of the same id a no-op success rather than an error).
+ */
+export async function removeReconcileLedgerEntry(
+  entryId: string,
+  opts: ReconcileLedgerPathOptions = {}
+): Promise<void> {
+  const ledger = await readReconcileLedger(opts)
+  const filtered = ledger.entries.filter((e) => e.id !== entryId)
+  if (filtered.length === ledger.entries.length) return // already gone; no-op
+  await writeReconcileLedger({ version: ledger.version, entries: filtered }, opts)
+}
+
+/**
+ * Find every ledger entry matching `(name, client, manifestPath)`,
+ * most-recent-first. Used by `revert` when the caller supplies
+ * `name`/`client` instead of an explicit `ledgerEntryId` — see
+ * `apply-manifest-reconcile.ts`'s revert action for the disambiguation
+ * policy this feeds (0 matches -> idempotent no-op, 1 -> revert it, 2+ ->
+ * `manifest.reconcile.revert_ambiguous`). Filtering on `manifestPath` too
+ * (not just `name`/`client`) matters under ADR-139: the same `(name,
+ * client)` pair can be reconciled independently at global AND workspace
+ * scope, and a by-name revert must only ever match entries from the
+ * SAME manifest the caller's own scope resolution points at.
+ */
+export function findReconcileLedgerEntriesFor(
+  ledger: ManifestReconcileLedger,
+  name: string,
+  client: string,
+  manifestPath: string
+): ManifestReconcileLedgerEntry[] {
+  return ledger.entries
+    .filter((e) => e.name === name && e.client === client && e.manifestPath === manifestPath)
+    .sort((a, b) => b.appliedAt.localeCompare(a.appliedAt))
+}

--- a/packages/mcp-server/src/tools/manifest-reconcile-ledger.types.ts
+++ b/packages/mcp-server/src/tools/manifest-reconcile-ledger.types.ts
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview Type vocabulary for the manifest-reconcile ledger
+ *               (SMI-6343 Wave 4, C7).
+ * @module @skillsmith/mcp-server/tools/manifest-reconcile-ledger.types
+ *
+ * Schema for `~/.skillsmith/manifest-reconcile-ledger.json` — the durable,
+ * cross-session revert source of truth for `apply_manifest_reconcile`.
+ * Shaped field-for-field on `audit/namespace-overrides.types.ts` (the
+ * `apply_namespace_rename` ledger), NOT on `undo_apply`'s in-process
+ * session stack (`apply-session.helpers.ts`) or its whole-file backup
+ * restore (`undo-apply.ts`) — see the plan's C7 subsection for why both
+ * were rejected as the model for THIS ledger:
+ *   1. `undo_apply` is session-scoped/in-process, with no cross-session
+ *      persistence.
+ *   2. Its never-clobber guard hashes the WHOLE target file. The manifest
+ *      has seven independent writers (plan §P-5); any unrelated write
+ *      between a reconcile and an attempted undo would permanently block
+ *      it.
+ *   3. `undo_apply`'s restore path takes no manifest lock at all.
+ *
+ * This ledger instead records ONE manifest key's complete before/after
+ * state per entry, and `revertReconcile()` (`manifest-reconcile-ledger.ts`)
+ * restores through `ManifestManager.updateSafely()` — a locked,
+ * single-key merge that leaves every other manifest entry untouched, so an
+ * unrelated install between a reconcile and its revert is invisible to the
+ * revert rather than fatal to it.
+ */
+
+/**
+ * Current ledger schema version. Bumped only when the on-disk shape
+ * changes incompatibly. `version > CURRENT_LEDGER_VERSION` on read returns
+ * a typed `manifest.reconcile.ledger_version_unsupported` error rather
+ * than silently degrading to an empty ledger (mirrors
+ * `namespace-overrides.ts`'s `readLedgerResult`).
+ */
+export const CURRENT_LEDGER_VERSION = 1 as const
+
+export type ManifestReconcileLedgerVersion = typeof CURRENT_LEDGER_VERSION
+
+/** The four `apply_manifest_reconcile` actions that mutate the manifest and are therefore revertible. `verify` is included: writing `verifiedAt` is a mutation like any other, even though it is a low-stakes one to undo. */
+export type ManifestReconcileMutatingAction = 'mark_local' | 'relink' | 'drop_entry' | 'verify'
+
+/**
+ * One reconcile action recorded in the ledger. Persisted in
+ * `~/.skillsmith/manifest-reconcile-ledger.json` under `entries[]`.
+ *
+ * `beforeState`/`afterState` are the COMPLETE manifest entry object (every
+ * field, not a diff) at the moment before/after this action's write —
+ * this is what lets `revertReconcile()` do a full single-key restore
+ * without needing to know which fields the original action touched.
+ * `afterState` is `null` for `drop_entry` (the entry no longer exists
+ * after the action) and `beforeState` is never `null` (every action
+ * requires a pre-existing entry — `entry_not_found` refuses otherwise).
+ */
+export interface ManifestReconcileLedgerEntry {
+  /** ULID prefixed with `mrc_` for log-grep readability. */
+  id: string
+  /**
+   * Absolute path to the manifest FILE this action wrote (H9: ADR-139
+   * scope resolution means the same `(name, client)` pair can exist under
+   * different manifest files — global vs. workspace-scoped). Revert reads
+   * and writes THIS exact file, never re-resolving scope from caller
+   * input, so a workspace-scoped reconcile can only ever be reverted
+   * against the same workspace manifest it touched.
+   */
+  manifestPath: string
+  /** The `installedSkills` key this action touched — `manifestKeyFor(name, client)`. */
+  manifestKey: string
+  /** Skill name, recorded independently of `manifestKey` so H9's revert
+   *  key re-derivation does not need to parse the composite key shape. */
+  name: string
+  /** Client this entry was keyed under at the time of the action. */
+  client: string
+  action: ManifestReconcileMutatingAction
+  /** Complete entry state immediately before this action's write. */
+  beforeState: Record<string, unknown>
+  /** Complete entry state immediately after this action's write, or
+   *  `null` for `drop_entry` (the entry was removed). */
+  afterState: Record<string, unknown> | null
+  /** ISO-8601 UTC timestamp recorded by the writer. */
+  appliedAt: string
+  /** Caller-supplied or auto-generated human-readable reason for the action. */
+  reason: string
+}
+
+/** On-disk shape of `~/.skillsmith/manifest-reconcile-ledger.json`. */
+export interface ManifestReconcileLedger {
+  version: ManifestReconcileLedgerVersion
+  entries: ManifestReconcileLedgerEntry[]
+}
+
+/**
+ * Typed error returned by `readReconcileLedgerResult` when the on-disk
+ * file declares a higher version than this client understands. Never
+ * thrown from the read path itself — callers decide whether to abort.
+ */
+export interface ReconcileLedgerVersionUnsupportedError {
+  kind: 'manifest.reconcile.ledger_version_unsupported'
+  found: number
+  expected: ManifestReconcileLedgerVersion
+}
+
+/** Discriminated union returned by `readReconcileLedgerResult`. */
+export type ReadReconcileLedgerResult =
+  | { kind: 'ok'; ledger: ManifestReconcileLedger }
+  | ReconcileLedgerVersionUnsupportedError
+  | { kind: 'manifest.reconcile.ledger_malformed'; reason: string }

--- a/packages/mcp-server/tests/unit/apply-manifest-reconcile.test.ts
+++ b/packages/mcp-server/tests/unit/apply-manifest-reconcile.test.ts
@@ -161,6 +161,27 @@ describe('mark_local', () => {
     expect(result.success).toBe(false)
     expect(result.errorCode).toBe('manifest.reconcile.entry_not_found')
   })
+
+  it('refuses with key_shape_ambiguous for a CANONICAL-client request against a bare-key entry recorded under a different client (adversarial-review finding)', async () => {
+    // manifestKeyFor(name, 'claude-code') returns the bare name — the SAME
+    // bare key the SMI-6358/6359 bug can leave a NON-canonical entry sitting
+    // under. Without this guard, a default (canonical) mark_local/relink/
+    // drop_entry call would silently mutate this entry believing it was the
+    // caller's own claude-code row.
+    writeManifest({ commit: makeEntry({ client: 'cursor' }) })
+    const result = await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.key_shape_ambiguous')
+    // Refused, not silently mutated.
+    expect(readManifest().installedSkills['commit']!.provenance).toBeUndefined()
+  })
+
+  it('does NOT refuse when the entry has no recorded client (legacy default, implicitly canonical)', async () => {
+    writeManifest({ commit: makeEntry() }) // no `client` field at all
+    const result = await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+    expect(result.success).toBe(true)
+  })
 })
 
 // ============================================================================
@@ -248,9 +269,15 @@ describe('relink', () => {
 // ============================================================================
 
 describe('drop_entry', () => {
-  it('removes the entry and ledgers a null afterState', async () => {
+  it('removes an entry whose installPath no longer resolves, and ledgers a null afterState', async () => {
+    // Adversarial-review finding: drop_entry's own contract is "installPath
+    // no longer resolves" — this fixture's path must genuinely be gone,
+    // not the default plantSkill() fixture (which resolves).
     writeManifest({
-      'shutdown-persistence-fixture': makeEntry({ name: 'shutdown-persistence-fixture' }),
+      'shutdown-persistence-fixture': makeEntry({
+        name: 'shutdown-persistence-fixture',
+        installPath: path.join(os.tmpdir(), 'skillsmith-reconcile-does-not-exist'),
+      }),
     })
 
     const result = await reconcile(
@@ -260,6 +287,16 @@ describe('drop_entry', () => {
 
     expect(result.success).toBe(true)
     expect(readManifest().installedSkills['shutdown-persistence-fixture']).toBeUndefined()
+  })
+
+  it('refuses with drop_target_still_resolves when installPath still resolves to a real directory (adversarial-review finding)', async () => {
+    writeManifest({ commit: makeEntry() }) // makeEntry()'s default installPath is a REAL, resolving fixture dir
+    const result = await reconcile({ action: 'drop_entry', name: 'commit' }, makeContext())
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.drop_target_still_resolves')
+    // Refused, not removed.
+    expect(readManifest().installedSkills['commit']).toBeDefined()
   })
 })
 
@@ -304,6 +341,44 @@ describe('verify', () => {
     expect(result.verifyResults?.[0]?.verified).toBe(false)
     expect(result.verifyResults?.[0]?.verifiedAt).toBeUndefined()
     expect(readManifest().installedSkills['mismatched']!.verifiedAt).toBeUndefined()
+  })
+
+  it('does NOT stamp verifiedAt when the entry was relinked to a DIFFERENT identity between the registry check and the lock (adversarial-review finding)', async () => {
+    // The registry comparison runs async, BEFORE the lock. If a concurrent
+    // writer relinks this same key to a different id/installPath in that
+    // window, the content that was actually hashed against the registry is
+    // no longer what the entry now claims to be — stamping verifiedAt onto
+    // the NEW identity would certify a pair that was never checked.
+    const content = `---\nname: racy\n---\nreal content`
+    const entry = makeEntry({ name: 'racy', installPath: plantSkill('racy', content) })
+    writeManifest({ racy: entry })
+
+    mockedLookup.mockImplementation(async () => {
+      // Simulate a concurrent writer relinking the SAME key mid-flight —
+      // by the time verify's own lock runs, the entry's id has changed.
+      const manifest = readManifest()
+      manifest.installedSkills['racy'] = {
+        ...manifest.installedSkills['racy']!,
+        id: 'someone/else',
+      }
+      fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), 'utf-8')
+      return {
+        repoUrl: 'https://github.com/a/racy',
+        name: 'racy',
+        trustTier: 'verified',
+        contentHash: hashContent(content),
+      }
+    })
+
+    const result = await reconcile({ action: 'verify', name: 'racy' }, makeContext())
+
+    // The registry comparison itself still reports a match (it checked the
+    // snapshot it had), but the write must be skipped since that snapshot
+    // is no longer what's on disk.
+    expect(result.verifyResults?.[0]?.verified).toBe(true)
+    expect(readManifest().installedSkills['racy']!.verifiedAt).toBeUndefined()
+    // No ledger entry either — nothing was actually written.
+    expect(result.ledgerEntryId).toBeUndefined()
   })
 
   it('batches over every entry when name is omitted, writing only matched entries', async () => {
@@ -403,7 +478,11 @@ describe('revert', () => {
   })
 
   it('round-trips drop_entry (re-creates the removed entry)', async () => {
-    writeManifest({ commit: makeEntry() })
+    writeManifest({
+      commit: makeEntry({
+        installPath: path.join(os.tmpdir(), 'skillsmith-reconcile-does-not-exist-revert'),
+      }),
+    })
     const applied = await reconcile({ action: 'drop_entry', name: 'commit' }, makeContext())
     expect(readManifest().installedSkills['commit']).toBeUndefined()
 

--- a/packages/mcp-server/tests/unit/apply-manifest-reconcile.test.ts
+++ b/packages/mcp-server/tests/unit/apply-manifest-reconcile.test.ts
@@ -1,0 +1,620 @@
+/**
+ * @fileoverview Unit tests for SMI-6343 Wave 4 — `apply_manifest_reconcile`
+ *               MCP tool.
+ * @module @skillsmith/mcp-server/tests/unit/apply-manifest-reconcile
+ *
+ * Plan: docs/internal/implementation/smi-6343-manifest-hygiene.md
+ * ("4. Reconciliation tool (Wave 4 ...)").
+ *
+ * Pattern: real fs against the sandboxed HOME `vitest.setup.ts` already
+ * establishes for this file's run (see that file + `skill-manifest.ts`'s
+ * `assertNotRealUserHome` doc comment) — `MANIFEST_PATH`/`SKILLSMITH_DIR`
+ * (`install.types.ts`) are frozen module-level consts computed against
+ * THAT sandbox, so every test in this file shares one manifest location
+ * and resets it in `beforeEach` rather than mutating `process.env.HOME`
+ * per test (which would NOT reach those frozen consts). Only the live
+ * registry lookup (`install.helpers.js`'s `lookupSkillFromRegistry`) is
+ * mocked — everything else (ManifestManager locking, the ledger, the
+ * `createProseBackup` backup step) runs against real files, matching this
+ * repo's `apply-namespace-rename.test.ts` / `undo-apply.test.ts` precedent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+vi.mock('../../src/tools/install.helpers.js', () => ({
+  lookupSkillFromRegistry: vi.fn(),
+}))
+
+import { lookupSkillFromRegistry } from '../../src/tools/install.helpers.js'
+import { hashContent, getBackupsDir } from '../../src/tools/install.conflict-helpers.js'
+import { SKILLSMITH_DIR, MANIFEST_PATH } from '../../src/tools/install.types.js'
+import type { SkillManifest, SkillManifestEntry } from '../../src/tools/install.types.js'
+import {
+  applyManifestReconcile,
+  applyManifestReconcileInputSchema,
+} from '../../src/tools/apply-manifest-reconcile.js'
+import { assertBackupTargetIsFile } from '../../src/tools/apply-manifest-reconcile.helpers.js'
+import { ReconcileGuardError } from '../../src/tools/apply-manifest-reconcile.helpers.js'
+import type { ToolContext } from '../../src/context.js'
+
+const mockedLookup = vi.mocked(lookupSkillFromRegistry)
+
+const LEDGER_PATH = path.join(SKILLSMITH_DIR, 'manifest-reconcile-ledger.json')
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+  mockedLookup.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+function makeEntry(overrides: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+  const now = '2026-01-01T00:00:00.000Z'
+  return {
+    id: overrides.id ?? 'jinee525/react-component-generator',
+    name: overrides.name ?? 'commit',
+    version: overrides.version ?? '1.0.0',
+    source: overrides.source ?? 'github:jinee525/react-component-generator',
+    installPath: overrides.installPath ?? plantSkill(overrides.name ?? 'commit'),
+    installedAt: overrides.installedAt ?? now,
+    lastUpdated: overrides.lastUpdated ?? now,
+    ...overrides,
+  }
+}
+
+/** Creates a real fixture skill directory with a SKILL.md, returns its path. */
+function plantSkill(name: string, content = `---\nname: ${name}\n---\nfixture body`): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `skillsmith-reconcile-${name}-`))
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), content, 'utf-8')
+  return dir
+}
+
+function writeManifest(entries: Record<string, SkillManifestEntry>): void {
+  fs.mkdirSync(SKILLSMITH_DIR, { recursive: true })
+  const manifest: SkillManifest = { version: '1.0.0', installedSkills: entries }
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), 'utf-8')
+}
+
+function readManifest(): SkillManifest {
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8')) as SkillManifest
+}
+
+function makeContext(opts: { online?: boolean } = { online: true }): ToolContext {
+  return {
+    apiClient: { isOffline: () => !opts.online },
+  } as unknown as ToolContext
+}
+
+/**
+ * Calls the tool with `scope: 'global'` forced by default. Necessary
+ * because `resolveScopedSkillsDir`'s auto-detection (ADR-139 rank 4) walks
+ * UP from the test process's real `process.cwd()` (inside this actual repo
+ * checkout, which has a real `.claude/skills` marker at `/app`) — without
+ * an explicit scope, every call in this suite would silently resolve to
+ * THAT workspace's manifest instead of the sandboxed global one the fixture
+ * helpers below manage. This is `resolveScopedSkillsDir` working exactly as
+ * designed; it just means tests must be explicit about which scope they
+ * exercise, same as any real MCP caller running from inside a repo would
+ * need to be.
+ */
+async function reconcile(
+  input: Record<string, unknown>,
+  context: ToolContext = makeContext()
+): Promise<Awaited<ReturnType<typeof applyManifestReconcile>>> {
+  return applyManifestReconcile({ scope: 'global', ...input }, context)
+}
+
+/** Reset all manifest-reconcile state between tests — see module header. */
+beforeEach(() => {
+  fs.mkdirSync(SKILLSMITH_DIR, { recursive: true })
+  fs.rmSync(MANIFEST_PATH, { force: true })
+  fs.rmSync(LEDGER_PATH, { force: true })
+  fs.rmSync(path.join(getBackupsDir(), 'manifest.json'), { recursive: true, force: true })
+})
+
+// ============================================================================
+// mark_local
+// ============================================================================
+
+describe('mark_local', () => {
+  it('writes source:"unknown" and provenance:"local" atomically, backs up, and ledgers the change', async () => {
+    writeManifest({ commit: makeEntry() })
+
+    const result = await reconcile(
+      { action: 'mark_local', name: 'commit', reason: 'wrong id/source' },
+      makeContext()
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.entry?.source).toBe('unknown')
+    expect(result.entry?.provenance).toBe('local')
+    expect(result.ledgerEntryId).toMatch(/^mrc_/)
+    expect(result.backupPath).toBeTruthy()
+
+    // ADR-145 §2: both fields land in the SAME write.
+    const onDisk = readManifest().installedSkills['commit']!
+    expect(onDisk.source).toBe('unknown')
+    expect(onDisk.provenance).toBe('local')
+
+    // SMI-6103 gate (manage.update.helpers.ts:329-334): trusts a manifest
+    // entry only when `source !== 'unknown'`. mark_local's output must be
+    // treated as untrusted by that gate with ZERO changes to it — asserting
+    // the literal condition it checks is the regression coverage, since
+    // cross-package import of the CLI's own gate function isn't available
+    // from this package.
+    expect(onDisk.source !== 'unknown').toBe(false)
+  })
+
+  it('refuses with entry_not_found for an unknown name', async () => {
+    writeManifest({})
+    const result = await reconcile({ action: 'mark_local', name: 'ghost' }, makeContext())
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.entry_not_found')
+  })
+})
+
+// ============================================================================
+// relink
+// ============================================================================
+
+describe('relink', () => {
+  it('requires BOTH id and source (guard rejection)', async () => {
+    writeManifest({ commit: makeEntry() })
+    const result = await reconcile(
+      { action: 'relink', name: 'commit', id: 'author/name' },
+      makeContext()
+    )
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.invalid_input')
+  })
+
+  it('sets id/source/provenance:"registry" after registry validation, never sets verifiedAt', async () => {
+    writeManifest({ commit: makeEntry() })
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/wrsmith108/commit',
+      name: 'commit',
+      trustTier: 'verified',
+      contentHash: 'abc123',
+    })
+
+    const result = await reconcile(
+      {
+        action: 'relink',
+        name: 'commit',
+        id: 'wrsmith108/commit',
+        source: 'github:wrsmith108/commit',
+      },
+      makeContext()
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.entry?.id).toBe('wrsmith108/commit')
+    expect(result.entry?.source).toBe('github:wrsmith108/commit')
+    expect(result.entry?.provenance).toBe('registry')
+    expect(result.entry?.verifiedAt).toBeUndefined()
+  })
+
+  it('clears a stale verifiedAt recorded against the OLD identity', async () => {
+    writeManifest({ commit: makeEntry({ verifiedAt: '2026-01-01T00:00:00.000Z' }) })
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/wrsmith108/commit',
+      name: 'commit',
+      trustTier: 'verified',
+    })
+
+    const result = await reconcile(
+      {
+        action: 'relink',
+        name: 'commit',
+        id: 'wrsmith108/commit',
+        source: 'github:wrsmith108/commit',
+      },
+      makeContext()
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.entry?.verifiedAt).toBeUndefined()
+    expect(readManifest().installedSkills['commit']!.verifiedAt).toBeUndefined()
+  })
+
+  it('refuses with relink_unvalidated when the registry does not confirm the id', async () => {
+    writeManifest({ commit: makeEntry() })
+    mockedLookup.mockResolvedValue(null)
+
+    const result = await reconcile(
+      { action: 'relink', name: 'commit', id: 'bogus/id', source: 'github:bogus/id' },
+      makeContext()
+    )
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.relink_unvalidated')
+
+    // The manifest must be untouched — no write happens before validation.
+    expect(readManifest().installedSkills['commit']!.id).not.toBe('bogus/id')
+  })
+})
+
+// ============================================================================
+// drop_entry
+// ============================================================================
+
+describe('drop_entry', () => {
+  it('removes the entry and ledgers a null afterState', async () => {
+    writeManifest({
+      'shutdown-persistence-fixture': makeEntry({ name: 'shutdown-persistence-fixture' }),
+    })
+
+    const result = await reconcile(
+      { action: 'drop_entry', name: 'shutdown-persistence-fixture' },
+      makeContext()
+    )
+
+    expect(result.success).toBe(true)
+    expect(readManifest().installedSkills['shutdown-persistence-fixture']).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// verify (C3)
+// ============================================================================
+
+describe('verify', () => {
+  it('writes verifiedAt on a hash match', async () => {
+    const content = `---\nname: matches\n---\nreal content`
+    const entry = makeEntry({ name: 'matches', installPath: plantSkill('matches', content) })
+    writeManifest({ matches: entry })
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/a/matches',
+      name: 'matches',
+      trustTier: 'verified',
+      contentHash: hashContent(content),
+    })
+
+    const result = await reconcile({ action: 'verify', name: 'matches' }, makeContext())
+
+    expect(result.success).toBe(true)
+    expect(result.verifyResults?.[0]?.verified).toBe(true)
+    expect(result.verifyResults?.[0]?.verifiedAt).toBeTruthy()
+    expect(readManifest().installedSkills['matches']!.verifiedAt).toBeTruthy()
+  })
+
+  it('does NOT write verifiedAt on a hash mismatch, and leaves the entry untouched', async () => {
+    const content = `---\nname: mismatched\n---\nreal content`
+    const entry = makeEntry({ name: 'mismatched', installPath: plantSkill('mismatched', content) })
+    writeManifest({ mismatched: entry })
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/a/mismatched',
+      name: 'mismatched',
+      trustTier: 'verified',
+      contentHash: 'totally-different-hash',
+    })
+
+    const result = await reconcile({ action: 'verify', name: 'mismatched' }, makeContext())
+
+    expect(result.success).toBe(true)
+    expect(result.verifyResults?.[0]?.verified).toBe(false)
+    expect(result.verifyResults?.[0]?.verifiedAt).toBeUndefined()
+    expect(readManifest().installedSkills['mismatched']!.verifiedAt).toBeUndefined()
+  })
+
+  it('batches over every entry when name is omitted, writing only matched entries', async () => {
+    const goodContent = `---\nname: good\n---\ngood`
+    const badContent = `---\nname: bad\n---\nbad`
+    writeManifest({
+      good: makeEntry({
+        name: 'good',
+        id: 'author/good',
+        installPath: plantSkill('good', goodContent),
+      }),
+      bad: makeEntry({
+        name: 'bad',
+        id: 'author/bad',
+        installPath: plantSkill('bad', badContent),
+      }),
+    })
+    mockedLookup.mockImplementation(async (id: string) => {
+      if (id.includes('good')) {
+        return {
+          repoUrl: 'https://github.com/a/good',
+          name: 'good',
+          trustTier: 'verified',
+          contentHash: hashContent(goodContent),
+        }
+      }
+      return {
+        repoUrl: 'https://github.com/a/bad',
+        name: 'bad',
+        trustTier: 'verified',
+        contentHash: 'nope',
+      }
+    })
+
+    const result = await reconcile({ action: 'verify' }, makeContext())
+    expect(result.success).toBe(true)
+    expect(result.verifyResults).toHaveLength(2)
+    expect(readManifest().installedSkills['good']!.verifiedAt).toBeTruthy()
+    expect(readManifest().installedSkills['bad']!.verifiedAt).toBeUndefined()
+  })
+
+  it('single-entry verify fails with verify_unavailable when offline', async () => {
+    writeManifest({ commit: makeEntry() })
+    const result = await reconcile(
+      { action: 'verify', name: 'commit' },
+      makeContext({ online: false })
+    )
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.verify_unavailable')
+  })
+})
+
+// ============================================================================
+// revert (C7)
+// ============================================================================
+
+describe('revert', () => {
+  it('round-trips mark_local', async () => {
+    writeManifest({ commit: makeEntry() })
+    const applied = await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+    expect(readManifest().installedSkills['commit']!.provenance).toBe('local')
+
+    const reverted = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(reverted.success).toBe(true)
+    expect(reverted.noOp).toBe(false)
+    expect(readManifest().installedSkills['commit']!.provenance).toBeUndefined()
+    expect(readManifest().installedSkills['commit']!.source).toBe(
+      'github:jinee525/react-component-generator'
+    )
+  })
+
+  it('round-trips relink', async () => {
+    writeManifest({ commit: makeEntry() })
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/wrsmith108/commit',
+      name: 'commit',
+      trustTier: 'verified',
+    })
+    const applied = await reconcile(
+      {
+        action: 'relink',
+        name: 'commit',
+        id: 'wrsmith108/commit',
+        source: 'github:wrsmith108/commit',
+      },
+      makeContext()
+    )
+    const reverted = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(reverted.success).toBe(true)
+    expect(readManifest().installedSkills['commit']!.id).toBe('jinee525/react-component-generator')
+  })
+
+  it('round-trips drop_entry (re-creates the removed entry)', async () => {
+    writeManifest({ commit: makeEntry() })
+    const applied = await reconcile({ action: 'drop_entry', name: 'commit' }, makeContext())
+    expect(readManifest().installedSkills['commit']).toBeUndefined()
+
+    const reverted = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(reverted.success).toBe(true)
+    expect(readManifest().installedSkills['commit']).toBeDefined()
+    expect(readManifest().installedSkills['commit']!.id).toBe('jinee525/react-component-generator')
+  })
+
+  it('round-trips verify', async () => {
+    const content = `---\nname: matches\n---\nreal content`
+    writeManifest({
+      matches: makeEntry({ name: 'matches', installPath: plantSkill('matches', content) }),
+    })
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/a/matches',
+      name: 'matches',
+      trustTier: 'verified',
+      contentHash: hashContent(content),
+    })
+    const applied = await reconcile({ action: 'verify', name: 'matches' }, makeContext())
+    expect(readManifest().installedSkills['matches']!.verifiedAt).toBeTruthy()
+
+    const reverted = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(reverted.success).toBe(true)
+    expect(readManifest().installedSkills['matches']!.verifiedAt).toBeUndefined()
+  })
+
+  it('still succeeds after an UNRELATED skill was installed in between — the exact scenario undo_apply would have failed', async () => {
+    writeManifest({ commit: makeEntry() })
+    const applied = await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+
+    // Simulate an unrelated install writing a NEW key to the same manifest
+    // file — undo_apply's whole-file hash guard would treat this as "the
+    // file changed" and permanently refuse to undo. Our per-key merge must
+    // be blind to it.
+    const manifest = readManifest()
+    manifest.installedSkills['unrelated-skill'] = makeEntry({
+      name: 'unrelated-skill',
+      id: 'someone/unrelated-skill',
+      source: 'github:someone/unrelated-skill',
+    })
+    fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), 'utf-8')
+
+    const reverted = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(reverted.success).toBe(true)
+
+    const finalManifest = readManifest()
+    expect(finalManifest.installedSkills['commit']!.provenance).toBeUndefined()
+    // The unrelated install is PRESERVED — this is the whole point of C7.
+    expect(finalManifest.installedSkills['unrelated-skill']).toBeDefined()
+    expect(finalManifest.installedSkills['unrelated-skill']!.id).toBe('someone/unrelated-skill')
+  })
+
+  it('refuses with entry_changed when the SAME entry changed since the reconcile', async () => {
+    writeManifest({ commit: makeEntry() })
+    const applied = await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+
+    // Something else touches the SAME key after the reconcile.
+    const manifest = readManifest()
+    manifest.installedSkills['commit']!.source = 'github:someone-else/commit'
+    fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), 'utf-8')
+
+    const reverted = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(reverted.success).toBe(false)
+    expect(reverted.errorCode).toBe('manifest.reconcile.entry_changed')
+  })
+
+  it('is idempotent — reverting the same ledgerEntryId twice is a no-op on the second call', async () => {
+    writeManifest({ commit: makeEntry() })
+    const applied = await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+    const first = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(first.noOp).toBe(false)
+
+    const second = await reconcile(
+      { action: 'revert', ledgerEntryId: applied.ledgerEntryId },
+      makeContext()
+    )
+    expect(second.success).toBe(true)
+    expect(second.noOp).toBe(true)
+  })
+
+  it('refuses with revert_ambiguous when 2+ ledger entries match by name and no ledgerEntryId is given', async () => {
+    writeManifest({ commit: makeEntry() })
+    await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+    mockedLookup.mockResolvedValue({
+      repoUrl: 'https://github.com/wrsmith108/commit',
+      name: 'commit',
+      trustTier: 'verified',
+    })
+    await reconcile(
+      {
+        action: 'relink',
+        name: 'commit',
+        id: 'wrsmith108/commit',
+        source: 'github:wrsmith108/commit',
+      },
+      makeContext()
+    )
+
+    const result = await reconcile({ action: 'revert', name: 'commit' }, makeContext())
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.revert_ambiguous')
+  })
+
+  it('returns a no-op success when no ledger entry matches (nothing to revert)', async () => {
+    writeManifest({ commit: makeEntry() })
+    const result = await reconcile(
+      { action: 'revert', ledgerEntryId: 'mrc_does_not_exist' },
+      makeContext()
+    )
+    expect(result.success).toBe(true)
+    expect(result.noOp).toBe(true)
+  })
+
+  it('surfaces manifest.reconcile.ledger_version_unsupported when the ledger file is a future version', async () => {
+    fs.mkdirSync(SKILLSMITH_DIR, { recursive: true })
+    fs.writeFileSync(LEDGER_PATH, JSON.stringify({ version: 99, entries: [] }), 'utf-8')
+
+    const result = await reconcile({ action: 'revert', name: 'commit' }, makeContext())
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.ledger_version_unsupported')
+  })
+})
+
+// ============================================================================
+// C8 — backup step (security)
+// ============================================================================
+
+describe('C8 — backup step security', () => {
+  it('assertBackupTargetIsFile refuses a directory (the "someone passes ~/.skillsmith/" mistake)', async () => {
+    await expect(assertBackupTargetIsFile(SKILLSMITH_DIR)).rejects.toMatchObject({
+      code: 'manifest.reconcile.backup_target_not_a_file',
+    })
+  })
+
+  it('assertBackupTargetIsFile refuses a nonexistent path', async () => {
+    await expect(
+      assertBackupTargetIsFile(path.join(SKILLSMITH_DIR, 'does-not-exist.json'))
+    ).rejects.toBeInstanceOf(ReconcileGuardError)
+  })
+
+  it('config.json never appears anywhere in the backups tree after a reconcile', async () => {
+    fs.mkdirSync(SKILLSMITH_DIR, { recursive: true })
+    fs.writeFileSync(
+      path.join(SKILLSMITH_DIR, 'config.json'),
+      JSON.stringify({ apiKey: 'sk_live_FAKE_DO_NOT_LEAK' }),
+      'utf-8'
+    )
+    writeManifest({ commit: makeEntry() })
+
+    await reconcile({ action: 'mark_local', name: 'commit' }, makeContext())
+
+    const backupsRoot = getBackupsDir()
+    const offenders: string[] = []
+    function walk(dir: string): void {
+      if (!fs.existsSync(dir)) return
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) walk(full)
+        else if (entry.name === 'config.json') offenders.push(full)
+      }
+    }
+    walk(backupsRoot)
+    expect(offenders).toEqual([])
+
+    // And the real manifest DID get backed up, proving the walk isn't
+    // vacuously passing over an empty tree.
+    const manifestBackupDir = path.join(backupsRoot, 'manifest.json')
+    expect(fs.existsSync(manifestBackupDir)).toBe(true)
+  })
+})
+
+// ============================================================================
+// Input validation
+// ============================================================================
+
+describe('input validation', () => {
+  it('rejects an unknown action', async () => {
+    const result = await reconcile({ action: 'bogus' }, makeContext())
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('manifest.reconcile.invalid_input')
+  })
+
+  it('rejects mark_local/relink/drop_entry with no name', async () => {
+    const parsed = applyManifestReconcileInputSchema.safeParse({ action: 'mark_local' })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects revert with neither name nor ledgerEntryId', async () => {
+    const parsed = applyManifestReconcileInputSchema.safeParse({ action: 'revert' })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts verify with no name (batch)', async () => {
+    const parsed = applyManifestReconcileInputSchema.safeParse({ action: 'verify' })
+    expect(parsed.success).toBe(true)
+  })
+})

--- a/packages/mcp-server/tests/unit/apply-recommended-edit.test.ts
+++ b/packages/mcp-server/tests/unit/apply-recommended-edit.test.ts
@@ -285,13 +285,15 @@ describe('audit-tool-dispatch — apply_recommended_edit conditional registratio
   // SMI-5213: newAuditToolDefinitions feeds index.ts's toolDefinitions so
   // the three tools are client-discoverable via ListTools.
   // SMI-5456 §7 / SMI-5470: undo_apply joined the always-registered set.
-  it('newAuditToolDefinitions returns the 4 new tools (live registry) and excludes skill_audit', async () => {
+  // SMI-6343 Wave 4: apply_manifest_reconcile joined the always-registered set.
+  it('newAuditToolDefinitions returns the 5 new tools (live registry) and excludes skill_audit', async () => {
     const dispatch = await import('../../src/audit-tool-dispatch.js')
     const names = dispatch.newAuditToolDefinitions().map((d) => d.name)
     expect(names).toEqual([
       'skill_inventory_audit',
       'apply_namespace_rename',
       'undo_apply',
+      'apply_manifest_reconcile',
       'apply_recommended_edit',
     ])
     // Must NOT re-list the already-registered audit tools.
@@ -311,7 +313,12 @@ describe('audit-tool-dispatch — apply_recommended_edit conditional registratio
     try {
       const dispatch = await import('../../src/audit-tool-dispatch.js')
       const names = dispatch.newAuditToolDefinitions().map((d) => d.name)
-      expect(names).toEqual(['skill_inventory_audit', 'apply_namespace_rename', 'undo_apply'])
+      expect(names).toEqual([
+        'skill_inventory_audit',
+        'apply_namespace_rename',
+        'undo_apply',
+        'apply_manifest_reconcile',
+      ])
       expect(names).not.toContain('apply_recommended_edit')
     } finally {
       vi.doUnmock('../../src/audit/edit-applier.js')

--- a/packages/mcp-server/tests/unit/manifest-reconcile-ledger.test.ts
+++ b/packages/mcp-server/tests/unit/manifest-reconcile-ledger.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for SMI-6343 Wave 4 — manifest-reconcile ledger (C7).
+ * Mirrors namespace-overrides.test.ts's coverage shape for the sibling
+ * ledger this one is modeled on.
+ *
+ * Coverage:
+ *   1. Read empty / missing file returns an empty ledger.
+ *   2. Append + read round-trip preserves entries.
+ *   3. `version > CURRENT_LEDGER_VERSION` returns typed
+ *      `manifest.reconcile.ledger_version_unsupported` (NOT silently empty).
+ *   4. Malformed JSON returns the typed
+ *      `manifest.reconcile.ledger_malformed` discriminator (readLedger
+ *      warns + degrades to empty).
+ *   5. Atomic write semantics — no `.tmp` file remains after success.
+ *   6. removeReconcileLedgerEntry is idempotent (removing twice is a no-op).
+ *   7. findReconcileLedgerEntriesFor filters by (name, client, manifestPath)
+ *      and sorts most-recent-first.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  appendReconcileLedgerEntry,
+  findReconcileLedgerEntriesFor,
+  readReconcileLedger,
+  readReconcileLedgerResult,
+  removeReconcileLedgerEntry,
+  writeReconcileLedger,
+} from '../../src/tools/manifest-reconcile-ledger.js'
+import { CURRENT_LEDGER_VERSION } from '../../src/tools/manifest-reconcile-ledger.types.js'
+
+let TEST_HOME: string
+let LEDGER_PATH: string
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-reconcile-ledger-'))
+  LEDGER_PATH = path.join(TEST_HOME, '.skillsmith', 'manifest-reconcile-ledger.json')
+})
+
+afterEach(() => {
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+  vi.restoreAllMocks()
+})
+
+function makeAppendInput(
+  overrides: Partial<Parameters<typeof appendReconcileLedgerEntry>[0]> = {}
+) {
+  return {
+    manifestPath: '/home/test/.skillsmith/manifest.json',
+    manifestKey: 'my-skill',
+    name: 'my-skill',
+    client: 'claude-code',
+    action: 'mark_local' as const,
+    beforeState: { id: 'author/my-skill', name: 'my-skill', source: 'github:author/my-skill' },
+    afterState: { id: 'author/my-skill', name: 'my-skill', source: 'unknown', provenance: 'local' },
+    reason: 'test',
+    ...overrides,
+  }
+}
+
+describe('readReconcileLedger / readReconcileLedgerResult', () => {
+  it('returns an empty ledger when the file does not exist (case 1)', async () => {
+    expect(fs.existsSync(LEDGER_PATH)).toBe(false)
+    const ledger = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(ledger.version).toBe(CURRENT_LEDGER_VERSION)
+    expect(ledger.entries).toEqual([])
+  })
+
+  it('readReconcileLedgerResult also returns ok+empty for a missing file', async () => {
+    const result = await readReconcileLedgerResult({ ledgerPath: LEDGER_PATH })
+    expect(result.kind).toBe('ok')
+    if (result.kind === 'ok') {
+      expect(result.ledger.entries).toEqual([])
+    }
+  })
+
+  it('returns typed version_unsupported when version > CURRENT_LEDGER_VERSION (case 3)', async () => {
+    await fsp.mkdir(path.dirname(LEDGER_PATH), { recursive: true })
+    await fsp.writeFile(LEDGER_PATH, JSON.stringify({ version: 99, entries: [] }))
+
+    const result = await readReconcileLedgerResult({ ledgerPath: LEDGER_PATH })
+    expect(result.kind).toBe('manifest.reconcile.ledger_version_unsupported')
+    if (result.kind === 'manifest.reconcile.ledger_version_unsupported') {
+      expect(result.found).toBe(99)
+      expect(result.expected).toBe(CURRENT_LEDGER_VERSION)
+    }
+
+    // readReconcileLedger: throws (does NOT silently degrade to empty).
+    await expect(readReconcileLedger({ ledgerPath: LEDGER_PATH })).rejects.toMatchObject({
+      kind: 'manifest.reconcile.ledger_version_unsupported',
+      found: 99,
+      expected: CURRENT_LEDGER_VERSION,
+    })
+  })
+
+  it('returns malformed discriminator for invalid JSON; readReconcileLedger warns + degrades (case 4)', async () => {
+    await fsp.mkdir(path.dirname(LEDGER_PATH), { recursive: true })
+    await fsp.writeFile(LEDGER_PATH, '{not json at all')
+
+    const typedResult = await readReconcileLedgerResult({ ledgerPath: LEDGER_PATH })
+    expect(typedResult.kind).toBe('manifest.reconcile.ledger_malformed')
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const ledger = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(ledger.entries).toEqual([])
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/ledger malformed/)
+  })
+})
+
+describe('appendReconcileLedgerEntry + read round-trip', () => {
+  it('round-trips a single appended entry (case 2)', async () => {
+    const entry = await appendReconcileLedgerEntry(makeAppendInput(), { ledgerPath: LEDGER_PATH })
+    expect(entry.id).toMatch(/^mrc_[0-9A-HJKMNP-TV-Z]{26}$/)
+    expect(entry.appliedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+
+    const restored = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(restored.entries).toHaveLength(1)
+    expect(restored.entries[0]!.name).toBe('my-skill')
+    expect(restored.entries[0]!.action).toBe('mark_local')
+    expect(restored.entries[0]!.beforeState).toEqual(makeAppendInput().beforeState)
+    expect(restored.entries[0]!.afterState).toEqual(makeAppendInput().afterState)
+  })
+
+  it('supports a null afterState (drop_entry has no post-write entry)', async () => {
+    await appendReconcileLedgerEntry(makeAppendInput({ action: 'drop_entry', afterState: null }), {
+      ledgerPath: LEDGER_PATH,
+    })
+    const restored = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(restored.entries[0]!.afterState).toBeNull()
+  })
+
+  it('atomic write — no .tmp file remains after success (case 5)', async () => {
+    await appendReconcileLedgerEntry(makeAppendInput(), { ledgerPath: LEDGER_PATH })
+    const dir = path.dirname(LEDGER_PATH)
+    const stragglers = fs.readdirSync(dir).filter((e) => e.endsWith('.tmp'))
+    expect(stragglers).toEqual([])
+    expect(fs.existsSync(LEDGER_PATH)).toBe(true)
+  })
+})
+
+describe('removeReconcileLedgerEntry', () => {
+  it('removes the matching entry and is idempotent on a second call (case 6)', async () => {
+    const entry = await appendReconcileLedgerEntry(makeAppendInput(), { ledgerPath: LEDGER_PATH })
+    await removeReconcileLedgerEntry(entry.id, { ledgerPath: LEDGER_PATH })
+
+    const afterFirst = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(afterFirst.entries).toEqual([])
+
+    // Second removal of the same (now-gone) id must not throw or corrupt
+    // the ledger — this is what makes revert idempotent.
+    await expect(
+      removeReconcileLedgerEntry(entry.id, { ledgerPath: LEDGER_PATH })
+    ).resolves.toBeUndefined()
+    const afterSecond = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(afterSecond.entries).toEqual([])
+  })
+
+  it('leaves other entries untouched', async () => {
+    const a = await appendReconcileLedgerEntry(makeAppendInput({ name: 'skill-a' }), {
+      ledgerPath: LEDGER_PATH,
+    })
+    await appendReconcileLedgerEntry(makeAppendInput({ name: 'skill-b' }), {
+      ledgerPath: LEDGER_PATH,
+    })
+    await removeReconcileLedgerEntry(a.id, { ledgerPath: LEDGER_PATH })
+
+    const restored = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    expect(restored.entries).toHaveLength(1)
+    expect(restored.entries[0]!.name).toBe('skill-b')
+  })
+})
+
+describe('findReconcileLedgerEntriesFor', () => {
+  it('filters by (name, client, manifestPath) and sorts most-recent-first (case 7)', async () => {
+    await appendReconcileLedgerEntry(
+      makeAppendInput({ name: 'skill-a', manifestPath: '/home/a/.skillsmith/manifest.json' }),
+      { ledgerPath: LEDGER_PATH }
+    )
+    await new Promise((r) => setTimeout(r, 2))
+    await appendReconcileLedgerEntry(
+      makeAppendInput({ name: 'skill-a', manifestPath: '/home/a/.skillsmith/manifest.json' }),
+      { ledgerPath: LEDGER_PATH }
+    )
+    // Different manifestPath — must NOT be matched (workspace vs. global scope).
+    await appendReconcileLedgerEntry(
+      makeAppendInput({
+        name: 'skill-a',
+        manifestPath: '/home/a/project/.skillsmith/manifest.json',
+      }),
+      { ledgerPath: LEDGER_PATH }
+    )
+    // Different name — must NOT be matched.
+    await appendReconcileLedgerEntry(
+      makeAppendInput({ name: 'skill-b', manifestPath: '/home/a/.skillsmith/manifest.json' }),
+      { ledgerPath: LEDGER_PATH }
+    )
+
+    const ledger = await readReconcileLedger({ ledgerPath: LEDGER_PATH })
+    const matches = findReconcileLedgerEntriesFor(
+      ledger,
+      'skill-a',
+      'claude-code',
+      '/home/a/.skillsmith/manifest.json'
+    )
+    expect(matches).toHaveLength(2)
+    // Most-recent-first.
+    expect(new Date(matches[0]!.appliedAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(matches[1]!.appliedAt).getTime()
+    )
+  })
+})
+
+describe('writeReconcileLedger', () => {
+  it('normalizes the written version to CURRENT_LEDGER_VERSION', async () => {
+    await writeReconcileLedger(
+      { version: CURRENT_LEDGER_VERSION, entries: [] },
+      { ledgerPath: LEDGER_PATH }
+    )
+    const raw = JSON.parse(await fsp.readFile(LEDGER_PATH, 'utf-8'))
+    expect(raw.version).toBe(CURRENT_LEDGER_VERSION)
+  })
+})

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+- **Added**: `McpClient` gains `applyManifestReconcile()` and a matching `McpApplyManifestReconcileResponse` type (new `mcp/types.apply.ts`), calling the new `apply_manifest_reconcile` MCP tool (SMI-6343 Wave 4). Also fixes two pre-existing drift bugs found while wiring this in: `applyNamespaceRename`'s `action` type was missing `'revert'` (shipped server-side in SMI-5671), and there was no `undoApply` method or `McpUndoApplyResponse` type at all for the existing `undo_apply` tool — both added alongside the new tool's own types.
+
 ## v0.7.8
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.7.7).

--- a/packages/vscode-extension/src/mcp/McpClient.ts
+++ b/packages/vscode-extension/src/mcp/McpClient.ts
@@ -20,6 +20,8 @@ import {
   type McpInventoryAuditResponse,
   type McpApplyNamespaceRenameResponse,
   type McpApplyRecommendedEditResponse,
+  type McpUndoApplyResponse,
+  type McpApplyManifestReconcileResponse,
   DEFAULT_MCP_CONFIG,
 } from './types.js'
 import type { JsonRpcRequest, JsonRpcResponse } from './jsonrpc.types.js'
@@ -411,12 +413,14 @@ export class McpClient {
    * UNGATED. Mutates `~/.claude/` (backup + revert ledger) only when
    * `confirmed: true`; else returns a non-mutating preview. The UI sends
    * `action: 'apply'` (`'custom'`/`'skip'` are reserved for SMI-5328).
+   * `'revert'` (SMI-5671) undoes a previously applied apply/custom rename
+   * for the same `auditId`/`collisionId` — durable and cross-session.
    * App-level failure arrives as `success: false` + `errorCode`, not a throw.
    */
   async applyNamespaceRename(args: {
     auditId: string
     collisionId: string
-    action: 'apply' | 'custom' | 'skip'
+    action: 'apply' | 'custom' | 'skip' | 'revert'
     customName?: string
     confirmed?: boolean
   }): Promise<McpApplyNamespaceRenameResponse> {
@@ -435,6 +439,36 @@ export class McpClient {
     confirmed?: boolean
   }): Promise<McpApplyRecommendedEditResponse> {
     return this.callTool<McpApplyRecommendedEditResponse>('apply_recommended_edit', args)
+  }
+
+  /**
+   * Undo the most recent apply_namespace_rename/apply_recommended_edit
+   * changeset(s) made in THIS server session (SMI-5456/SMI-5470).
+   * Session-scoped; `count`/`suggestion_id` are mutually exclusive.
+   */
+  async undoApply(
+    args: { count?: number; suggestion_id?: string } = {}
+  ): Promise<McpUndoApplyResponse> {
+    return this.callTool<McpUndoApplyResponse>('undo_apply', args)
+  }
+
+  /**
+   * Repair a corrupted/ambiguous `~/.skillsmith/manifest.json` entry
+   * (SMI-6343 Wave 4). Community tier, no confirm/preview gate. `name` is
+   * required except for a batch `verify` or a by-`ledgerEntryId` `revert`.
+   */
+  async applyManifestReconcile(args: {
+    action: 'mark_local' | 'relink' | 'drop_entry' | 'verify' | 'revert'
+    name?: string
+    client?: string
+    scope?: 'global' | 'workspace'
+    cwd?: string
+    id?: string
+    source?: string
+    reason?: string
+    ledgerEntryId?: string
+  }): Promise<McpApplyManifestReconcileResponse> {
+    return this.callTool<McpApplyManifestReconcileResponse>('apply_manifest_reconcile', args)
   }
 
   /**

--- a/packages/vscode-extension/src/mcp/types.apply.ts
+++ b/packages/vscode-extension/src/mcp/types.apply.ts
@@ -1,0 +1,129 @@
+/**
+ * MCP Client Type Definitions — apply family
+ *
+ * Split out of `types.ts` (SMI-6343 Wave 4, 500-line file gate): the
+ * response types for the four "apply"-family MCP tools
+ * (`apply_namespace_rename`, `undo_apply`, `apply_manifest_reconcile`,
+ * `apply_recommended_edit`) — re-exported from `types.ts` so every
+ * existing `from './types.js'` import keeps working unchanged.
+ */
+
+/**
+ * Response from MCP `apply_namespace_rename` (SMI-5325). UNGATED. Mirrors the
+ * server envelope (`apply-namespace-rename.types.ts`). Application-level failure
+ * is `success: false` + `errorCode` (the dispatcher wraps every result with
+ * `okBody` → `isError: false`, so this never surfaces as a thrown McpToolError).
+ * The SMI-5213 preview fields are present (with `applied: false`) when the tool
+ * was called without `confirmed: true`. `result` is opaque to the extension.
+ */
+export interface McpApplyNamespaceRenameResponse {
+  success: boolean
+  collisionId: string
+  result?: unknown
+  errorCode?:
+    | 'namespace.audit.invalid_input'
+    | 'namespace.audit.history_not_found'
+    | 'namespace.audit.collision_not_found'
+    | 'namespace.rename.subcall_failed'
+  error?: string
+  preview?: boolean
+  action?: string
+  target?: string
+  before?: string
+  after?: string
+  applied?: boolean
+}
+
+/**
+ * Response from MCP `undo_apply` (SMI-5456 Wave 1 Step 3 / SMI-5470).
+ * Session-scoped undo of the most recent `apply_namespace_rename` /
+ * `apply_recommended_edit` changeset(s), restored from the apply tool's own
+ * backup. Mirrors the server envelope (`undo-apply.types.ts`).
+ */
+export interface McpUndoApplyResponse {
+  success: boolean
+  undone: Array<{
+    tool: string
+    suggestionId: string
+    targetPath: string
+    restoredHash: string
+  }>
+  errorCode?:
+    | 'undo.invalid_input'
+    | 'undo.no_session_applies'
+    | 'undo.backup_missing'
+    | 'undo.content_changed'
+    | 'undo.scope_violation'
+    | 'undo.restore_failed'
+  error?: string
+}
+
+/**
+ * Response from MCP `apply_manifest_reconcile` (SMI-6343 Wave 4). Community
+ * tier. Repairs a corrupted or ambiguous `~/.skillsmith/manifest.json` entry
+ * — mirrors the server envelope (`apply-manifest-reconcile.types.ts`). Unlike
+ * {@link McpApplyNamespaceRenameResponse}, this tool has no confirm/preview
+ * gate — every call mutates when it succeeds.
+ */
+export interface McpApplyManifestReconcileResponse {
+  success: boolean
+  action: 'mark_local' | 'relink' | 'drop_entry' | 'verify' | 'revert'
+  name?: string
+  manifestKey?: string
+  entry?: Record<string, unknown>
+  verifyResults?: Array<{
+    name: string
+    manifestKey: string
+    verified: boolean
+    reason?:
+      | 'offline'
+      | 'quota-exhausted'
+      | 'network-error'
+      | 'no-registry-record'
+      | 'hash-mismatch'
+    verifiedAt?: string
+  }>
+  ledgerEntryId?: string
+  noOp?: boolean
+  backupPath?: string
+  errorCode?:
+    | 'manifest.reconcile.invalid_input'
+    | 'manifest.reconcile.entry_not_found'
+    | 'manifest.reconcile.key_shape_ambiguous'
+    | 'manifest.reconcile.relink_unvalidated'
+    | 'manifest.reconcile.relink_incomplete'
+    | 'manifest.reconcile.backup_target_not_a_file'
+    | 'manifest.reconcile.backup_failed'
+    | 'manifest.reconcile.lock_timeout'
+    | 'manifest.reconcile.entry_changed'
+    | 'manifest.reconcile.revert_ambiguous'
+    | 'manifest.reconcile.ledger_version_unsupported'
+    | 'manifest.reconcile.ledger_malformed'
+    | 'manifest.reconcile.verify_unavailable'
+  error?: string
+}
+
+/**
+ * Response from MCP `apply_recommended_edit` (SMI-5325). UNGATED but the tool is
+ * conditionally registered server-side (`APPLY_TEMPLATE_REGISTRY`). Mirrors the
+ * server envelope (`apply-recommended-edit.types.ts`); same preview/error-code
+ * contract as {@link McpApplyNamespaceRenameResponse}. `result` is opaque.
+ */
+export interface McpApplyRecommendedEditResponse {
+  success: boolean
+  collisionId: string
+  result?: unknown
+  errorCode?:
+    | 'namespace.audit.invalid_input'
+    | 'namespace.audit.history_not_found'
+    | 'namespace.audit.collision_not_found'
+    | 'edit.template_not_in_apply_registry'
+    | 'edit.subcall_failed'
+  error?: string
+  preview?: boolean
+  action?: string
+  target?: string
+  before?: string
+  after?: string
+  applied?: boolean
+}

--- a/packages/vscode-extension/src/mcp/types.apply.ts
+++ b/packages/vscode-extension/src/mcp/types.apply.ts
@@ -92,6 +92,7 @@ export interface McpApplyManifestReconcileResponse {
     | 'manifest.reconcile.key_shape_ambiguous'
     | 'manifest.reconcile.relink_unvalidated'
     | 'manifest.reconcile.relink_incomplete'
+    | 'manifest.reconcile.drop_target_still_resolves'
     | 'manifest.reconcile.backup_target_not_a_file'
     | 'manifest.reconcile.backup_failed'
     | 'manifest.reconcile.lock_timeout'

--- a/packages/vscode-extension/src/mcp/types.ts
+++ b/packages/vscode-extension/src/mcp/types.ts
@@ -339,56 +339,17 @@ export interface McpInventoryAuditResponse {
   }
 }
 
-/**
- * Response from MCP `apply_namespace_rename` (SMI-5325). UNGATED. Mirrors the
- * server envelope (`apply-namespace-rename.types.ts`). Application-level failure
- * is `success: false` + `errorCode` (the dispatcher wraps every result with
- * `okBody` → `isError: false`, so this never surfaces as a thrown McpToolError).
- * The SMI-5213 preview fields are present (with `applied: false`) when the tool
- * was called without `confirmed: true`. `result` is opaque to the extension.
- */
-export interface McpApplyNamespaceRenameResponse {
-  success: boolean
-  collisionId: string
-  result?: unknown
-  errorCode?:
-    | 'namespace.audit.invalid_input'
-    | 'namespace.audit.history_not_found'
-    | 'namespace.audit.collision_not_found'
-    | 'namespace.rename.subcall_failed'
-  error?: string
-  preview?: boolean
-  action?: string
-  target?: string
-  before?: string
-  after?: string
-  applied?: boolean
-}
-
-/**
- * Response from MCP `apply_recommended_edit` (SMI-5325). UNGATED but the tool is
- * conditionally registered server-side (`APPLY_TEMPLATE_REGISTRY`). Mirrors the
- * server envelope (`apply-recommended-edit.types.ts`); same preview/error-code
- * contract as {@link McpApplyNamespaceRenameResponse}. `result` is opaque.
- */
-export interface McpApplyRecommendedEditResponse {
-  success: boolean
-  collisionId: string
-  result?: unknown
-  errorCode?:
-    | 'namespace.audit.invalid_input'
-    | 'namespace.audit.history_not_found'
-    | 'namespace.audit.collision_not_found'
-    | 'edit.template_not_in_apply_registry'
-    | 'edit.subcall_failed'
-  error?: string
-  preview?: boolean
-  action?: string
-  target?: string
-  before?: string
-  after?: string
-  applied?: boolean
-}
+// SMI-6343 Wave 4 (500-line file gate): the apply-family response types
+// (`McpApplyNamespaceRenameResponse`, `McpUndoApplyResponse`,
+// `McpApplyManifestReconcileResponse`, `McpApplyRecommendedEditResponse`)
+// moved to `types.apply.ts` — re-exported here so every existing
+// `from './types.js'` import keeps working unchanged.
+export type {
+  McpApplyNamespaceRenameResponse,
+  McpUndoApplyResponse,
+  McpApplyManifestReconcileResponse,
+  McpApplyRecommendedEditResponse,
+} from './types.apply.js'
 
 /**
  * MCP connection status

--- a/packages/website/public/llms-full.txt
+++ b/packages/website/public/llms-full.txt
@@ -67,6 +67,7 @@ When using the MCP server, these tools are available:
 | `apply_namespace_rename` (Team+) | auditId, collisionId, action (apply/custom/skip/revert), customName, confirmed | Apply a rename suggestion from an inventory audit |
 | `apply_recommended_edit` (Team+) | auditId, collisionId, confirmed | Apply a recommended prose edit from an inventory audit |
 | `undo_apply` (Team+) | count, suggestion_id | Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s) |
+| `apply_manifest_reconcile` | action (mark_local/relink/drop_entry/verify/revert), name, client, scope, cwd, id, source, reason, ledgerEntryId | Repair a corrupted or ambiguous ~/.skillsmith/manifest.json entry |
 | `team_workspace` (Team+) | action (create/list/get/delete), name, description, workspaceId | Manage team workspaces |
 | `share_skill` (Team+) | action (add/remove/list), workspaceId, skillId | Add, remove, or list skills in a team workspace |
 | `publish_private` (Team+) | skillId | Mark a skill private on this device, hiding it from your own search results |

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -98,6 +98,7 @@ When using Skillsmith MCP server:
 - `apply_namespace_rename` (Team+): Apply a rename suggestion from an inventory audit (apply/custom/skip)
 - `apply_recommended_edit` (Team+): Apply a recommended prose edit from an inventory audit
 - `undo_apply` (Team+): Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s)
+- `apply_manifest_reconcile`: Repair a corrupted or ambiguous manifest entry (mark_local/relink/drop_entry/verify/revert)
 - `team_workspace` (Team+): Manage team workspaces (create, list, get, delete)
 - `share_skill` (Team+): Add, remove, or list skills in a team workspace
 - `publish_private` (Team+): Mark a skill private on this device, hiding it from your own search results

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -494,10 +494,11 @@ EOF`}</code></pre>
   <h2 id="namespace-collision-tools-team">Local Namespace-Collision Audit Tools</h2>
 
   <p>
-    These tools detect and resolve namespace collisions across your local skills, commands, agents, and CLAUDE.md files.
+    These tools detect and resolve namespace collisions across your local skills, commands, agents, and CLAUDE.md files, plus the durable undo mechanism and the separate manifest-identity-repair tool that round out the apply family.
     <code>skill_inventory_audit</code>, <code>apply_namespace_rename</code>, and
     <code>apply_recommended_edit</code> are all available on every tier today — Team/Enterprise
-    tier-gating for these tools is not yet enforced.
+    tier-gating for these tools is not yet enforced. <code>undo_apply</code> and
+    <code>apply_manifest_reconcile</code> are Community tier.
   </p>
 
   <h3>skill_inventory_audit</h3>
@@ -566,6 +567,56 @@ EOF`}</code></pre>
   <p><strong>Example prompts:</strong></p>
   <ul>
     <li>"Use Skillsmith to apply the suggested domain-qualifier edit to my skill description"</li>
+  </ul>
+
+  <h3>undo_apply</h3>
+
+  <p>Undo the most recent <code>apply_namespace_rename</code> / <code>apply_recommended_edit</code> changeset(s) made in the current MCP server session, restoring each file from the backup the apply tool wrote before it changed anything.</p>
+
+  <pre><code>{`// Tool: undo_apply
+// Parameters:
+{
+  "count": 1               // optional, defaults to 1 — undo the N most-recent changesets
+  // or: "suggestion_id": "rename-1"   // undo one specific changeset by id (mutually exclusive with count)
+}`}</code></pre>
+
+  <p>
+    Session-scoped: once the server process restarts, its undo history is gone. Refuses (rather than overwrites) when the file has changed since the apply, the backup is missing, or the restore target falls outside the confined skill roots — treat those as normal, expected outcomes.
+  </p>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Undo the last skill rename you applied"</li>
+  </ul>
+
+  <h3>apply_manifest_reconcile</h3>
+
+  <p>Repair a corrupted or ambiguous <code>~/.skillsmith/manifest.json</code> entry through a supported path — never a hand-edit. Use after <code>skill_outdated</code> reports <code>identity-mismatch</code> or <code>local-drift</code>, or after <code>skill_recover_source</code> found low or no confidence.</p>
+
+  <pre><code>{`// Tool: apply_manifest_reconcile
+// Parameters:
+{
+  "action": "mark_local",   // mark_local | relink | drop_entry | verify | revert
+  "name": "my-skill"        // required for mark_local/relink/drop_entry; optional for verify (batch) and revert
+  // relink also requires: "id": "author/name", "source": "github:author/name"
+  // revert accepts either "ledgerEntryId" (precise) or "name" (by most-recent, refuses if ambiguous)
+}`}</code></pre>
+
+  <p>
+    Five actions: <code>mark_local</code> stops tracking an entry against the registry
+    (<code>source: 'unknown'</code> + <code>provenance: 'local'</code>, written together); <code>relink</code>
+    asserts an explicit, registry-validated <code>id</code>/<code>source</code> pair — it never infers an
+    identity on its own; <code>drop_entry</code> hard-removes an entry whose install path no longer resolves;
+    <code>verify</code> re-checks on-disk content against the registry's current content hash for one entry or,
+    by default, every entry, writing <code>verifiedAt</code> only on a match; <code>revert</code> is a durable,
+    cross-session undo of a prior reconcile on a single entry — unlike <code>undo_apply</code>, it survives an
+    unrelated skill install happening in between and works across server restarts.
+  </p>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"skill_outdated says the commit skill's identity doesn't match what's installed — mark it as my own local skill"</li>
+    <li>"Undo that last manifest reconcile"</li>
   </ul>
 
   <h2>Usage Examples</h2>

--- a/scripts/smoke-prod/mcp-server.sh
+++ b/scripts/smoke-prod/mcp-server.sh
@@ -156,6 +156,27 @@ check_apply_namespace_rename_tool_listed() {
   return 0
 }
 
+# SMI-6343 Wave 4 — verify `apply_manifest_reconcile` ships.
+check_apply_manifest_reconcile_tool_listed() {
+  local t0 t1 ms install dispatch
+  t0=$(now_ms)
+  _smoke_mcp_install_once "mcp-server-published" "check_apply_manifest_reconcile_tool_listed" || return 1
+  install="$SMOKE_MCP_INSTALL_DIR"
+  dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  if [ ! -f "$dispatch" ]; then
+    report_fail "mcp-server-published" "check_apply_manifest_reconcile_tool_listed" "stat audit-tool-dispatch.js" "file present" "missing" "$ms"
+    return 1
+  fi
+  if ! grep -q "'apply_manifest_reconcile'" "$dispatch"; then
+    report_fail "mcp-server-published" "check_apply_manifest_reconcile_tool_listed" "grep apply_manifest_reconcile" "string present" "missing in dispatch" "$ms"
+    return 1
+  fi
+  report_pass "mcp-server-published" "check_apply_manifest_reconcile_tool_listed" "grep apply_manifest_reconcile" "$ms"
+  return 0
+}
+
 # SMI-4590 Wave 4 PR 5/6 — verify `apply_recommended_edit` is conditionally
 # registered. The dispatcher source MUST contain the conditional push
 # referencing APPLY_TEMPLATE_REGISTRY (the exact registration mechanism).

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -115,7 +115,8 @@
         "check_mcp_server_version_exits_zero",
         "check_skill_inventory_audit_tool_listed",
         "check_apply_namespace_rename_tool_listed",
-        "check_apply_recommended_edit_conditional"
+        "check_apply_recommended_edit_conditional",
+        "check_apply_manifest_reconcile_tool_listed"
       ]
     },
     {

--- a/scripts/tests/smoke-prod-lib.test.ts
+++ b/scripts/tests/smoke-prod-lib.test.ts
@@ -118,8 +118,10 @@ describe('smoke-prod/mcp-server.sh — no command-substitution around _smoke_mcp
     const src = readFileSync(MCP_SERVER_SH, 'utf-8')
     const callSites =
       src.match(/_smoke_mcp_install_once\s+"[^"]+"\s+"[^"]+"\s*\|\|\s*return 1/g) ?? []
-    // Four checks share the helper (version + three audit-tool dispatch greps).
-    expect(callSites.length).toBe(4)
+    // Five checks share the helper (version + four audit-tool dispatch greps —
+    // SMI-6343 Wave 4 added apply_manifest_reconcile's own smoke check
+    // alongside the pre-existing three).
+    expect(callSites.length).toBe(5)
     for (const call of callSites) {
       const idx = src.indexOf(call)
       const nextLine = src.slice(idx + call.length, idx + call.length + 200)


### PR DESCRIPTION
## Business Summary

**What shipped:** A new `apply_manifest_reconcile` tool that repairs a corrupted or ambiguous `~/.skillsmith/manifest.json` entry through a supported path instead of a hand-edit. Five actions: stop tracking an entry against the registry, relink it to an explicit and confirmed registry identity, remove an entry whose install is genuinely gone, re-verify content against the registry, and revert any of the above.

**Quality bar:** Governance review, Codex (GPT-5.6-Sol) adversarial review, and the pr-reviewer 14-check gate all complete. The adversarial round found and fixed three real High-severity bugs (a wrong-client key-ambiguity gap, a verify-action race that could certify an identity it never checked, an unenforced delete precondition). The full host-side pre-push test suite (744 files, 11482 tests, the config CI/pre-push actually run) caught one real stale-fixture regression, also fixed.

**Found along the way:** none filed this wave.

**Net result:** Fully shipped (PR pending, SMI-6343 Wave 4 of 4 — closes out the initiative). AC#2 closure (re-applying the fix to the `commit`/`linear` entries through the new tool) and publishing the package are the two remaining post-merge steps.

---

## Technical detail

New `packages/mcp-server/src/tools/apply-manifest-reconcile.ts` (+ `.types.ts`, `.helpers.ts`, `.actions.ts`, `.errors.ts`, `.verify.ts`, `.lock-helpers.ts`) and `manifest-reconcile-ledger.ts` (+ `.types.ts`). The `revert` action is a new, from-scratch durable ledger at `~/.skillsmith/manifest-reconcile-ledger.json`, modeled on `rename-engine.revert.ts` — deliberately not an extension of `undo_apply` (rejected in plan review: session-scoped, a whole-file hash guard hostile to the manifest's seven independent writers, unlocked restore path). Every mutating action backs up via `createProseBackup` only, never `createSkillBackup` (which could otherwise leak `config.json`'s live API key into the backups tree), guarded by a `stat().isFile()` precondition with a regression test walking the entire backups tree.

Registered across all four MCP dispatch sites plus ~15 consumer surfaces (README, VS Code extension, website docs, agent-pack prompts, smoke surfaces, `llms.txt`, CLAUDE.md).

`SkillManifestEntry` gains `provenance`/`verifiedAt` per ADR-145. Reports: `docs/internal/code_review/2026-09-05-smi-6343-wave4-governance-review.md`, `2026-09-05-smi-6343-wave4-adversarial-review.md`, and the pr-reviewer gate report.

CHANGELOG entries added for `@skillsmith/core` and `@skillsmith/mcp-server`.
