### PR TITLE
fix(tooling): SMI-6388 -- correct worktree-check.sh's Prettier ignore-path bug

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,7 +22,12 @@ packages/*/.vercel/
 .ruvector/
 test-results/
 
-# Scripts with embedded GraphQL that Prettier cannot parse
+# SMI-6388: Prettier parses this file fine — the original "cannot parse" claim was
+# wrong. The real reason to exclude it: Prettier's embedded-language formatter
+# rewrites the GraphQL inside the query template literals (verified — it collapses
+# `issueLabels(filter: ..., first: $first, after: $after)` onto one 106-char line,
+# past the printWidth 100 this repo sets, because embedded GraphQL is measured
+# separately). Keep the exclusion so the hand-wrapped queries stay readable.
 scripts/linear-api.mjs
 
 # Git-crypt encrypted directories - cannot be parsed when locked (CI, fresh clones)

--- a/scripts/worktree-check.sh
+++ b/scripts/worktree-check.sh
@@ -39,7 +39,15 @@ echo "  ✓ ESLint passed"
 
 echo ""
 echo "[3/3] Running Prettier check..."
-npx prettier --check "**/*.{ts,tsx,js,jsx,json,md,yml,yaml}" --ignore-path .prettierignore
+# SMI-6388: must stay byte-identical to `npm run format:check` (CI + pre-push).
+# Do NOT pass --ignore-path here: it is an `array: true` option whose Prettier 3.x
+# default is [".gitignore", ".prettierignore"], so naming one file REPLACES the
+# whole default list and silently drops .gitignore — which then flags git-tracked
+# but gitignored files (e.g. packages/skillsmith-cli/bin.js, matched by
+# .gitignore's `packages/**/*.js`). Both ignore files are picked up automatically.
+# Do NOT substitute an extension glob either: "**/*.{ts,...}" omits .astro/.mjs/
+# .cjs/.mts/.cts/.css/.html, so it would pass locally on diffs CI then rejects.
+npx prettier --check .
 echo "  ✓ Prettier check passed"
 
 echo ""


### PR DESCRIPTION
## Business Summary

**What shipped:** The reported bug ("three `.prettierignore` entries aren't honored") turned out not to exist — all three paths were already correctly excluded. What was actually broken: `scripts/worktree-check.sh`'s Prettier invocation used a flag that silently disabled `.gitignore`-based exclusions too, which could pass a change locally that CI would reject. Fixed by aligning it to the same command CI and pre-push already use.

**Quality bar:** Root cause confirmed by direct reproduction (not just reading the code) — measured file counts with and without each ignore-file entry, and identified the exact command whose output diverged from CI's. Full `format:check`, `lint`, `typecheck`, and `audit:standards` all verified clean after the fix.

**Found along the way:** a pre-existing, unrelated bug where `npm run format:check` runs out of memory from the main checkout once several worktrees exist (SMI-6408) — filed separately, out of scope here.

**Net result:** Fully shipped, no follow-up needed on this issue itself.

---

## Technical detail

- `scripts/worktree-check.sh`: `prettier --check "**/*.{ts,...}" --ignore-path .prettierignore` → `prettier --check .`. Prettier 3.x's `ignorePath` option is array-typed with a default of `[".gitignore", ".prettierignore"]`; naming one file replaces the whole array rather than extending it, so the old invocation silently stopped honoring `.gitignore` (flagging git-tracked-but-gitignored files like `packages/skillsmith-cli/bin.js`) and used a narrower extension glob than CI's whole-tree check.
- `.prettierignore`: corrected a stale comment on the `scripts/linear-api.mjs` entry — Prettier parses that file fine; the real reason to exclude it is that its embedded-GraphQL formatter would rewrap the hand-formatted queries past this repo's `printWidth`.
- SMI-6388 (Linear) has the full investigation writeup, including why both going-in hypotheses were refuted.