### PR TITLE
fix(tests): SMI-6402 -- git-crypt-lock-aware static assertions in Post-Merge Verify

### DIFF
--- a/scripts/tests/indexer/smi5879-census.heartbeat.test.ts
+++ b/scripts/tests/indexer/smi5879-census.heartbeat.test.ts
@@ -240,7 +240,39 @@ describe("migration's documented ordering invariant (SMI-5879 cross-model review
     process.cwd(),
     'supabase/migrations/20260808000000_smi5879_snapshot_generations.sql'
   )
-  const migrationText = readFileSync(migrationPath, 'utf8')
+
+  // SMI-6402: `supabase/migrations/**` is git-crypt encrypted (`.gitattributes`), and
+  // `post-merge-verify.yml` intentionally has no unlock step (SMI-4221 — a workflow
+  // holding `issues: write` shouldn't also hold a decrypt key). On that locked checkout
+  // this file is ciphertext, so the regex extraction below can never find its patterns —
+  // that is expected, not a migration drift, and must not fail the run. Same 9-byte
+  // magic-header contract and `SKILLSMITH_GIT_CRYPT_EXPECTED_LOCKED` gate as
+  // `scripts/tests/private-registry-rls.test.ts` / `search-metrics-analytics-rls.helpers.ts`
+  // (each test that reads git-crypt content directly keeps its own copy of this check,
+  // scoped to the specific file(s) it reads, per those files' own doc comments). The
+  // unlocked PR-matrix CI remains the authoritative check for this invariant.
+  const GIT_CRYPT_MAGIC = Buffer.from([0x00, 0x47, 0x49, 0x54, 0x43, 0x52, 0x59, 0x50, 0x54]) // "\x00GITCRYPT"
+  const EXPECT_LOCKED_ENV_VAR = 'SKILLSMITH_GIT_CRYPT_EXPECTED_LOCKED'
+  const migrationBuf = readFileSync(migrationPath)
+  const migrationLocked = migrationBuf.subarray(0, GIT_CRYPT_MAGIC.length).equals(GIT_CRYPT_MAGIC)
+
+  it('locates the migration this invariant reads from', () => {
+    expect(migrationBuf.length).toBeGreaterThan(0)
+  })
+
+  if (migrationLocked) {
+    if (process.env[EXPECT_LOCKED_ENV_VAR] !== '1') {
+      throw new Error(
+        `${migrationPath} appears git-crypt-locked, but ${EXPECT_LOCKED_ENV_VAR} isn't set — ` +
+          'this checkout is not expected to be locked here. If this is post-merge-verify.yml, ' +
+          `set ${EXPECT_LOCKED_ENV_VAR}=1 on the job. Otherwise git-crypt likely failed to ` +
+          'unlock (SMI-5702/SMI-5861 filter fragility) — treat as a real failure, not a lock edge case.'
+      )
+    }
+    return // post-merge-verify.yml, by design (SMI-4221/SMI-5984)
+  }
+
+  const migrationText = migrationBuf.toString('utf8')
 
   /** Parses a Postgres interval literal of the exact shape this migration uses ('N hours' / 'N minutes') to milliseconds. */
   function intervalLiteralToMs(literal: string): number {

--- a/scripts/tests/search-metrics-analytics-rls.test.ts
+++ b/scripts/tests/search-metrics-analytics-rls.test.ts
@@ -153,6 +153,14 @@ describe('T-RLS-1..4 — search_metrics RLS + analytics RPC security declaration
 // ============================================================================
 
 describe('T-RLS-6 — cleanup_search_metrics() still hardens the partitions it creates', () => {
+  // SMI-6402: an unconditional `it()` must precede the lock-state `return` below — vitest
+  // fails an entirely empty `describe()` with "No test found in suite", which is exactly
+  // what this block did on post-merge-verify.yml's locked checkout before this fix (the
+  // describe-level guard alone, with no `it()` ahead of it, left zero registered on lock).
+  it('locates every migration this suite asserts against', () => {
+    expect(MIGRATIONS).toBeDefined()
+  })
+
   if (MIGRATIONS.locked) return
   const { partitionRls, wiring } = MIGRATIONS
 
@@ -180,6 +188,12 @@ describe('T-RLS-6 — cleanup_search_metrics() still hardens the partitions it c
 // ============================================================================
 
 describe('T-RLS-7 — the self-read branch is unchanged and documented-inert (D-2b consequence 1)', () => {
+  // SMI-6402: see T-RLS-6's comment above — an unconditional `it()` must precede the
+  // lock-state `return` or vitest fails the whole (then-empty) suite on a locked checkout.
+  it('locates every migration this suite asserts against', () => {
+    expect(MIGRATIONS).toBeDefined()
+  })
+
   if (MIGRATIONS.locked) return
   const { parentTable } = MIGRATIONS
 
@@ -225,6 +239,12 @@ describe('T-RLS-7 — the self-read branch is unchanged and documented-inert (D-
 // ============================================================================
 
 describe('T-GRANT-1 — the five analytics RPCs are authenticated-only', () => {
+  // SMI-6402: see T-RLS-6's comment above — an unconditional `it()` must precede the
+  // lock-state `return` or vitest fails the whole (then-empty) suite on a locked checkout.
+  it('locates every migration this suite asserts against', () => {
+    expect(MIGRATIONS).toBeDefined()
+  })
+
   if (MIGRATIONS.locked) return
   const { wiring } = MIGRATIONS
 
@@ -241,6 +261,12 @@ describe('T-GRANT-1 — the five analytics RPCs are authenticated-only', () => {
 })
 
 describe('T-GRANT-2 — resolve_telemetry_identity is UNREACHABLE from PostgREST', () => {
+  // SMI-6402: see T-RLS-6's comment above — an unconditional `it()` must precede the
+  // lock-state `return` or vitest fails the whole (then-empty) suite on a locked checkout.
+  it('locates every migration this suite asserts against', () => {
+    expect(MIGRATIONS).toBeDefined()
+  })
+
   if (MIGRATIONS.locked) return
   const { wiring } = MIGRATIONS
 
@@ -278,7 +304,21 @@ describe('T-PROV-1 static half — p_user_id provenance preconditions (D-2f rule
   const IDENTITY_MODULE = 'supabase/functions/_shared/telemetry-identity.ts'
   const ROW_BUILDER = 'supabase/functions/events/row-builder.ts'
 
+  // SMI-6402: both files above live under `supabase/functions/**`, which locks and
+  // unlocks together with `supabase/migrations/**` (same git-crypt key, same checkout) —
+  // `MIGRATIONS.locked` is therefore a valid proxy for whether these are readable too.
+  // This block originally read them unconditionally (the one gap among this file's
+  // describe blocks), so on post-merge-verify.yml's intentionally-locked checkout
+  // (SMI-4221/SMI-5984) both `it()`s below read ciphertext and failed on a false "not
+  // found" — not a real provenance regression. Gated per-`it()` (return early inside the
+  // body) rather than at the describe level: vitest fails an entirely empty `describe()`
+  // with "No test found in suite", so a describe-level-only `if (locked) return` with no
+  // unconditional `it()` ahead of it is unsafe (the exact bug T-RLS-6/7 and T-GRANT-1/2
+  // below had — fixed alongside this). The unlocked PR-matrix CI remains the authoritative
+  // check for this half.
+
   it('resolve_telemetry_identity has exactly ONE non-test RPC call site', () => {
+    if (MIGRATIONS.locked) return
     // DISCREPANCY WITH THE PLAN TEXT, resolved here rather than deferred. AC-6 writes this
     // rule as the literal shell command
     //   grep -rn "resolve_telemetry_identity" supabase/functions/ --include="*.ts" | grep -v _tests_
@@ -305,6 +345,7 @@ describe('T-PROV-1 static half — p_user_id provenance preconditions (D-2f rule
   })
 
   it("`user_id` is absent from sanitizeMetadata's allowlist (D-2f consequence 1)", () => {
+    if (MIGRATIONS.locked) return
     // Adding it — for any reason, including a plausible "let the client tell us who it is
     // for debugging" — converts D-2f rule 2 from structurally-true to merely-currently-true.
     const src = readFileSync(ROW_BUILDER, 'utf8')


### PR DESCRIPTION
## Business Summary

**What shipped:** Every push to `main` today has been alerting with a failing "Post-Merge Verify" check, opening a growing pile of false-alarm GitHub issues. The root cause: three tests were reading encrypted database migration files directly, without checking whether the encryption was unlocked first -- so they were comparing against scrambled data, not the real thing. Nothing in the actual product code was ever broken.

**Quality bar:** Fixed all three tests using the same "check the lock first" pattern the rest of the test suite already follows. Found and fixed four more broken tests in the same file along the way (empty test blocks that Vitest fails outright). Full verification: typecheck, lint, format, and the complete test suite -- 18,766 tests passing, zero failures.

**Found along the way:** none filed separately -- the four bonus fixes landed in this same PR.

**Net result:** Post-Merge Verify should go green on the next push to `main`, closing GitHub issue #2640 and its ~12 accumulated false-alarm comments.

## Technical detail

- `scripts/tests/indexer/smi5879-census.heartbeat.test.ts`: added the same 9-byte-magic-header + env-var-gate contract already used by `scripts/tests/private-registry-rls.test.ts`.
- `scripts/tests/search-metrics-analytics-rls.test.ts`: gated the "T-PROV-1 static half" block on `MIGRATIONS.locked`, matching every sibling `describe` block in the same file. Also fixed 4 empty `describe()` blocks (T-RLS-6, T-RLS-7, T-GRANT-1, T-GRANT-2) that Vitest fails outright with no test registered.

Linear: SMI-6402

[skip-impl-check]
