### PR TITLE
fix(tests): SMI-6420 -- copy mcp-command-guard.plugin-scan.mjs sibling in isolated test repo

### DIFF
--- a/scripts/tests/session-start-mcp-command-guard.test.sh
+++ b/scripts/tests/session-start-mcp-command-guard.test.sh
@@ -65,6 +65,10 @@ mk_test_repo() {
   cp "$HOOK" "$dir/scripts/session-start-mcp-command-guard.sh"
   chmod +x "$dir/scripts/session-start-mcp-command-guard.sh"
   cp "$REPO_ROOT/scripts/lib/mcp-command-guard.mjs" "$dir/scripts/lib/mcp-command-guard.mjs"
+  # SMI-6229 added a local import of ./mcp-command-guard.plugin-scan.mjs; the
+  # isolated throwaway repo needs that sibling too, or the hook process dies
+  # with ERR_MODULE_NOT_FOUND before it can emit anything to stderr/stdout.
+  cp "$REPO_ROOT/scripts/lib/mcp-command-guard.plugin-scan.mjs" "$dir/scripts/lib/mcp-command-guard.plugin-scan.mjs"
   echo "$dir"
 }
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a pre-existing `main` bug where 2 of 14 assertions in a hooks test always failed once its CI workflow actually ran against a diff touching `scripts/remove-worktree.sh`. A test helper builds an isolated throwaway repo to run the MCP command guard hook in; it copied the hook's main script but not a sibling file that script imports, so the hook crashed before it could print the warning the test was checking for.

**Quality bar:** Verified directly — ran the test standalone before (2 failures) and after (14/14 pass) the fix.

**Net result:** Done, no follow-up.

---

## Technical detail

Found while landing SMI-6401 — `validate-hooks.yml`'s path filter includes `scripts/remove-worktree.sh`, so that PR triggered this workflow (likely for the first time in a while) and hit the bug. `scripts/tests/session-start-mcp-command-guard.test.sh`'s `mk_test_repo()` now also copies `scripts/lib/mcp-command-guard.plugin-scan.mjs` (added by SMI-6229) alongside `mcp-command-guard.mjs`.