### PR TITLE
fix(ci): SMI-6403 hotfix -- row-visible check's select=session_id doesn't exist

### DIFF
--- a/scripts/smoke-prod/events.sh
+++ b/scripts/smoke-prod/events.sh
@@ -135,7 +135,16 @@ check_events_skill_invoke_row_visible() {
   fi
 
   local session_id="$_EVENTS_LAST_RUN_ID"
-  local rest_url="${SMOKE_SUPABASE_URL}/rest/v1/search_metrics?select=session_id&metadata->>session_id=eq.${session_id}&limit=1"
+  # select=id, not session_id -- search_metrics has no top-level session_id
+  # column (it only lives inside metadata JSONB). Requesting a nonexistent
+  # column makes PostgREST return an error object instead of a row array,
+  # which the caller's isinstance(rows, list) check silently reads as
+  # count=0 -- this bug predates this fix (present in the original
+  # staging-pointed query too) and was never exposed until the query
+  # actually reached a real row for the first time. Confirmed live against
+  # prod: the identical query with select=session_id returns
+  # {"code":"42703",...}; select=id returns the row correctly.
+  local rest_url="${SMOKE_SUPABASE_URL}/rest/v1/search_metrics?select=id&metadata->>session_id=eq.${session_id}&limit=1"
   local t0 t1 ms resp count
 
   # Probe once immediately, then once after 5s if no row yet (10s total budget).


### PR DESCRIPTION
## Business Summary

**What shipped:** A follow-up fix to the smoke-check repair that merged an hour ago (PR #2727). The required post-merge verification caught a second, independent bug in the same check: it asked the database for a column named `session_id` that doesn't actually exist (the real data lives inside a JSON field instead), so the database correctly refused the request -- and the check's own error handling silently treated that refusal the same as "row not found," reporting a false failure.

**Quality bar:** Confirmed live against production data before writing any code: the smoke event genuinely landed in the database within 2 seconds, and the corrected query (asking for a column that actually exists) returns it correctly. This bug predates PR #2727 -- it was already in the original broken query -- and was never caught before because the check never previously reached a real row to test the request shape against.

**Found along the way:** none filed separately.

**Net result:** Once merged, the required 3-consecutive-pass verification for SMI-6403 will actually be able to succeed.

## Technical detail

`scripts/smoke-prod/events.sh`: `select=session_id` -> `select=id` in the row-visible check's REST query. `search_metrics` has no top-level `session_id` column (only `metadata->>session_id`); PostgREST returns a `42703` error object for the nonexistent-column request, which the caller's `isinstance(rows, list)` check silently reads as `count=0`.

Verified directly: `curl` with `select=session_id` against the real failing row returns `{"code":"42703",...}`; the same request with `select=id` returns `[{"id":9216965}]`.

Linear: SMI-6403