### PR TITLE
chore(gitignore): ignore root-level smi5879 census/simulation working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,13 @@ docs/site/
 .batch-transform-checkpoint.json
 .batch-transform-checkpoint.json.bak
 .hive-mind/
+
+# SMI-6015/SMI-5879: root-level working files for census/simulation dispatches
+# (smi5879-census.ts / smi5879-simulate-full.ts --checkpoint-path/--report-path
+# defaults). Never committed — deleted once the run reaches a terminal state.
+smi5879-simulate-checkpoint-*.json
+smi5879-simulate-report-*.json
+smi5879-census-checkpoint-*.json
 .vercel
 
 # DNS and Email Provider Exports


### PR DESCRIPTION
## Business Summary

**What shipped**: Added a `.gitignore` entry so the working files a long-running census/scanner-parity dispatch writes to the repo root (a checkpoint and report file, both JSON) can never be accidentally committed. Nothing functional changed — this only affects what git tracks.

**Quality bar**: Full test suite, typecheck, security tests, and format checks all passed on push.

**Found along the way**: A peer session correctly flagged that the checkpoint file for SMI-6015's active decision-purpose census dispatch was sitting untracked at repo root, which is against repo convention. The file can't simply be moved — the dispatch's container has that exact path hardcoded and is mid-run, already recovered from 10 incidents — so ignoring the whole working-file family (for both `smi5879-census.ts` and `smi5879-simulate-full.ts`) is the safe fix.

**Net result**: The census dispatch's working files are now protected from accidental commit, with zero disruption to the live run.

## Technical detail

Adds three glob patterns to `.gitignore`:
- `smi5879-simulate-checkpoint-*.json`
- `smi5879-simulate-report-*.json`
- `smi5879-census-checkpoint-*.json`

An earlier attempt at this same fix (commit `6363e4bd7`) landed directly on the shared main checkout and got orphaned when another session ran `sync-main.sh`. Redone here properly on a dedicated worktree branch.