### PR TITLE
fix(security): SMI-6425 -- allowlist lucas-lima-s/claude-skill-repo-audit sensitive_path FP

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -110,6 +110,15 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-08-27",
       "expiresAt": "2026-11-25"
+    },
+    {
+      "skillId": "github/lucas-lima-s/claude-skill-repo-audit",
+      "findingType": "sensitive_path",
+      "messagePattern": "secrets\\?\\\\\\/\\[a-z0-9",
+      "reason": "Publish-readiness audit skill whose GitHub repo description reads 'Publish-readiness gate for any repository: secret/PII scans, git-history identity leaks...'. Fetched all 44 files in the repo tree and found zero literal 'secret(s)/' matches in any file content — the only hit anywhere is the repo's own GitHub description phrase 'secret/PII', which the bare-keyword sensitive_path regex matches case-insensitively (the [a-z0-9_.-]+ class swallows 'PII'). Same false-positive class as github/binnukarunakar/icm-shipwright (SMI-6237, 'secret/PII guardrails') and github/RobinGase/skill-protocol-rs. messagePattern is scoped to the path-form pattern's echoed source only (SENSITIVE_PATH_PATTERNS' \\bsecrets?\\/[a-z0-9_.-]+, not the sibling assignment-form \\bsecrets?\\s*[:=] — both feed sensitive_path, and a bare 'secrets?' pattern here would also suppress a real future assignment-form secret leak in this skill). Triaged 2026-09-06 under SMI-6425 — closes GH #2616 + #2060 (recurring Weekly Security Scan failures since 2026-07-26).",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-09-06",
+      "expiresAt": "2026-12-05"
     }
   ]
 }

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -424,11 +424,15 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // description-advertises-a-security-feature FP class as skill-protocol-rs
   // and qpay-skills. Closes GH #2059 (7 straight Weekly Security Scan
   // failures on this exact skill/finding since 2026-07-26).
+  // SMI-6425 (2026-09-06): lucas-lima-s/claude-skill-repo-audit added —
+  // publish-readiness audit skill whose repo description says 'secret/PII
+  // scans'; same description-advertises-a-security-feature FP class as
+  // icm-shipwright. Closes GH #2616 + #2060.
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(12)
+    expect(parsed.allowlist.length).toBe(13)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
@@ -442,6 +446,7 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
         'github/fitz2882/narthex',
         'github/kcmadden/claude-code-1password-skill',
         'github/leksman/ai-security-guard',
+        'github/lucas-lima-s/claude-skill-repo-audit',
         'github/rhysha/claude-security-research-skill',
         'github/straygizmo/mdium',
       ].sort()
@@ -472,5 +477,37 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
         `${entry.skillId}: expiresAt window too long (max 1 year); got ${gapDays}d`
       ).toBeLessThanOrEqual(ONE_YEAR_MS)
     }
+  })
+
+  // SMI-6425 regression boundary: the new lucas-lima-s/claude-skill-repo-audit
+  // entry's messagePattern is scoped to the path-form sensitive_path pattern's
+  // echoed source only. A future genuine leak matching the SIBLING
+  // assignment-form pattern (\bsecrets?\s*[:=]/i) for the same skill and
+  // finding type must still be quarantined, not silently swallowed by this
+  // entry. This proves the scoping is airtight against the real production
+  // allowlist, not just narrowly worded in the JSON reason field.
+  it('does not allowlist the sibling assignment-form sensitive_path pattern for the new entry', () => {
+    const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+    const parsed = parseAllowlistFile(raw)
+    const matcher = buildMatcher(parsed.allowlist)
+    const skillId = 'github/lucas-lima-s/claude-skill-repo-audit'
+
+    // The path-form match this entry exists to suppress.
+    const pathFormFinding = finding({
+      type: 'sensitive_path',
+      severity: 'high',
+      message: 'Reference to potentially sensitive path: \\bsecrets?\\/[a-z0-9_.-]+',
+    })
+    expect(matcher.isAllowed(skillId, pathFormFinding)).toBe(true)
+
+    // A hypothetical future assignment-form leak for the SAME skill and
+    // finding type must still be caught.
+    const assignmentFormFinding = finding({
+      type: 'sensitive_path',
+      severity: 'high',
+      message: 'Reference to potentially sensitive path: \\bsecrets?\\s*[:=]',
+    })
+    expect(matcher.isAllowed(skillId, assignmentFormFinding)).toBe(false)
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** The weekly Security Scan false-positive on `lucas-lima-s/claude-skill-repo-audit` is resolved. The scanner was flagging the skill's own GitHub description ("secret/PII scans") as a sensitive-path reference, not a real embedded secret.

**Quality bar:** Implementation plan reviewed by GPT-5.6-Sol (cross-family second opinion, NEEDLE dispatch) before any code was written — it found one real blocker (a wrong field name in the planned verification fixture) and three should-fix issues, all applied before implementation. Local scanner dry-run confirms zero post-allowlist quarantine for this skill. A new regression test proves a genuine future secret leak for this same skill would still be caught.

**Found along the way:** The original hypothesis that Linear issue SMI-4558 was the open root-cause backlog item was wrong — it's actually Done. The real backlog item is SMI-5207 (still Backlog), flagged separately with a recurrence-count comment rather than folded into this PR.

**Net result:** Fully shipped, no follow-up. SMI-5207's prioritization is a team decision, left open.

---

## Technical detail

- `data/skills-security-allowlist.json` — new scoped entry for `github/lucas-lima-s/claude-skill-repo-audit`, `findingType: sensitive_path`, scoped to the path-form pattern's echoed source only, 90-day expiry.
- `packages/core/tests/skill-scanner/allowlist.test.ts` — bumped the entry-count and skillId-list assertions, plus a new regression test proving the sibling assignment-form pattern (`\bsecrets?\s*[:=]/i`) still fires for this skillId.
- Plan doc: `docs/internal/implementation/smi-6425-security-allowlist-lucas-lima-s-repo-audit-fp.md`.
- Verified locally in this worktree's own container (`./scripts/worktree-docker.sh exec --`): scanner CLI dry-run against a fixture matching the live skill's description, full `allowlist.test.ts` suite (25/25 passing), lint, typecheck, and `audit:standards` (0 failures, 92% compliance).
- Closes #2616, #2060.
- Linear: SMI-6425.



[skip-impl-check] — data-only allowlist entry + test update, no packages/*/src implementation code touched.
