### PR TITLE
fix(website): SMI-6424 -- reorder account nav, move Admin group to bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Account navigation group order: Admin moved to the bottom** (2026-09-06,
+  SMI-6424): the account area's left navigation now lists Tools,
+  Preferences, and Resources first, with Admin (Overview, Summary,
+  Subscription, Billing History, Email Address) moved to the bottom. The
+  "Account" heading, every destination, its URL, and the team-plan lock
+  affordance are unchanged — only the order of the four groups moves, on
+  both the desktop sidebar and the narrow-viewport disclosure.
 - **Skill-lookup requests that return no match now count toward your API quota**
   (2026-08-29, SMI-6283): the `skills-get` endpoint (used when you look up a
   specific skill by `author/name` or ID) previously did not count a request

--- a/packages/website/src/components/AccountMobileNav.astro
+++ b/packages/website/src/components/AccountMobileNav.astro
@@ -7,7 +7,7 @@
  *
  * A native `<details>` disclosure — no custom client JavaScript for
  * opening, closing, or selecting entries. Renders the exact same
- * Admin/Tools/Preferences/Resources groups as the desktop sidebar, from the
+ * Tools/Preferences/Resources/Admin groups as the desktop sidebar, from the
  * same `account-nav.ts` data contract: neither component owns a second
  * hardcoded copy of labels, hrefs, order, or team-gated metadata.
  *

--- a/packages/website/src/components/AccountSidebar.astro
+++ b/packages/website/src/components/AccountSidebar.astro
@@ -13,7 +13,7 @@
  * that range instead (SMI-6128; previously `AccountHubNav.astro`, retired).
  *
  * Renders a visible "Account" root heading (h2) above four static,
- * always-expanded groups (h3): Admin, Tools, Preferences, Resources. The
+ * always-expanded groups (h3): Tools, Preferences, Resources, Admin. The
  * root heading and the groups are data-driven from `account-nav.ts` — this
  * component owns no second copy of labels, hrefs, order, or team-gated
  * metadata. Admin and Tools are grouping labels only, not routes (plan

--- a/packages/website/src/lib/account-nav.test.ts
+++ b/packages/website/src/lib/account-nav.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the account navigation data contract + active-link logic
- * (SMI-5475, reorganized SMI-6128).
+ * (SMI-5475, reorganized SMI-6128, group order revised SMI-6424).
  *
  * This also absorbs the retired `account-hub-nav.ts`'s active-path and
  * exact-list coverage: no dedicated `account-hub-nav.test.ts` ever existed
@@ -25,18 +25,8 @@ describe('ACCOUNT_NAV_ROOT_LABEL', () => {
 })
 
 describe('ACCOUNT_NAV_GROUPS', () => {
-  it('matches the Admin/Tools/Preferences/Resources structure exactly', () => {
+  it('matches the Tools/Preferences/Resources/Admin structure exactly', () => {
     expect(ACCOUNT_NAV_GROUPS).toEqual([
-      {
-        heading: 'Admin',
-        items: [
-          { href: '/account', label: 'Overview', icon: 'home' },
-          { href: '/account/summary', label: 'Summary', icon: 'bar-chart-2' },
-          { href: '/account/subscription', label: 'Subscription', icon: 'repeat' },
-          { href: '/account/billing', label: 'Billing History', icon: 'credit-card' },
-          { href: '/account/profile', label: 'Email Address', icon: 'mail' },
-        ],
-      },
       {
         heading: 'Tools',
         items: [
@@ -82,12 +72,22 @@ describe('ACCOUNT_NAV_GROUPS', () => {
           { href: '/docs/api', label: 'API Docs', icon: 'code' },
         ],
       },
+      {
+        heading: 'Admin',
+        items: [
+          { href: '/account', label: 'Overview', icon: 'home' },
+          { href: '/account/summary', label: 'Summary', icon: 'bar-chart-2' },
+          { href: '/account/subscription', label: 'Subscription', icon: 'repeat' },
+          { href: '/account/billing', label: 'Billing History', icon: 'credit-card' },
+          { href: '/account/profile', label: 'Email Address', icon: 'mail' },
+        ],
+      },
     ])
   })
 
   it('has exactly the four group headings, in order, with no Billing or Team heading', () => {
     const headings = ACCOUNT_NAV_GROUPS.map((g) => g.heading)
-    expect(headings).toEqual(['Admin', 'Tools', 'Preferences', 'Resources'])
+    expect(headings).toEqual(['Tools', 'Preferences', 'Resources', 'Admin'])
     expect(headings).not.toContain('Billing')
     expect(headings).not.toContain('Team')
     expect(headings).not.toContain('Account')

--- a/packages/website/src/lib/account-nav.ts
+++ b/packages/website/src/lib/account-nav.ts
@@ -1,6 +1,8 @@
 /**
  * Account-area navigation data + active-link logic (SMI-5475, reorganized
- * SMI-6128 per docs/internal/implementation/account-nav-admin-tools-reorg.md).
+ * SMI-6128 per docs/internal/implementation/account-nav-admin-tools-reorg.md;
+ * group order revised SMI-6424 per
+ * docs/internal/implementation/smi-6424-account-nav-admin-to-bottom.md).
  *
  * Pure module so `isActiveAccountNav` (and the rest of this contract) is
  * unit-testable outside Astro (same pattern as other extracted utils in
@@ -13,7 +15,7 @@
  * This module also absorbs the retired `account-hub-nav.ts`'s canonical
  * tab list and active-path matcher — the eight-destination hub tab row
  * (`AccountHubNav.astro`) is gone; every destination it used to own now
- * lives in the Admin/Tools groups below.
+ * lives in the Tools/Admin groups below.
  */
 
 import { normalizeAccountPath } from './account-page-path'
@@ -38,20 +40,10 @@ export interface AccountNavGroup {
   items: readonly AccountNavItem[]
 }
 
-/** Visible root heading above the Admin/Tools/Preferences/Resources groups. */
+/** Visible root heading above the Tools/Preferences/Resources/Admin groups. */
 export const ACCOUNT_NAV_ROOT_LABEL = 'Account'
 
 export const ACCOUNT_NAV_GROUPS: readonly AccountNavGroup[] = [
-  {
-    heading: 'Admin',
-    items: [
-      { href: '/account', label: 'Overview', icon: 'home' },
-      { href: '/account/summary', label: 'Summary', icon: 'bar-chart-2' },
-      { href: '/account/subscription', label: 'Subscription', icon: 'repeat' },
-      { href: '/account/billing', label: 'Billing History', icon: 'credit-card' },
-      { href: '/account/profile', label: 'Email Address', icon: 'mail' },
-    ],
-  },
   {
     heading: 'Tools',
     items: [
@@ -96,6 +88,16 @@ export const ACCOUNT_NAV_GROUPS: readonly AccountNavGroup[] = [
     items: [
       { href: '/docs/quickstart', label: 'Getting Started', icon: 'play-circle' },
       { href: '/docs/api', label: 'API Docs', icon: 'code' },
+    ],
+  },
+  {
+    heading: 'Admin',
+    items: [
+      { href: '/account', label: 'Overview', icon: 'home' },
+      { href: '/account/summary', label: 'Summary', icon: 'bar-chart-2' },
+      { href: '/account/subscription', label: 'Subscription', icon: 'repeat' },
+      { href: '/account/billing', label: 'Billing History', icon: 'credit-card' },
+      { href: '/account/profile', label: 'Email Address', icon: 'mail' },
     ],
   },
 ] as const

--- a/packages/website/tests/e2e/account-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/account-page-load-guards.spec.ts
@@ -58,7 +58,8 @@ const NULL_DEREF =
 // Sibling pages reachable via a real `<a>` in the account sidebar (SMI-5475
 // — replaced the Quick Links grid; SMI-6128 — reorganized into Account /
 // Admin / Tools / Preferences / Resources, absorbing every destination the
-// retired AccountHubNav tab row used to own), so ClientRouter (not a full
+// retired AccountHubNav tab row used to own; SMI-6424 — group order revised
+// to Tools / Preferences / Resources / Admin), so ClientRouter (not a full
 // reload) performs the transition that re-fires `astro:page-load` on the
 // previously-visited page's leaked listener. /account (Overview) is the
 // loop's anchor page — it is not its own sibling, so it is not listed here;

--- a/packages/website/tests/e2e/account-sidebar.spec.ts
+++ b/packages/website/tests/e2e/account-sidebar.spec.ts
@@ -8,8 +8,8 @@
  * were folded into the AccountHubNav tab row instead of the sidebar.
  *
  * SMI-6128 — AccountHubNav is retired. `account-nav.ts` now expresses one
- * root ("Account") with four groups (Admin, Tools, Preferences, Resources)
- * rendered by two components sharing the same data: `AccountSidebar.astro`
+ * root ("Account") with four groups (Tools, Preferences, Resources, Admin —
+ * order revised SMI-6424) rendered by two components sharing the same data: `AccountSidebar.astro`
  * (desktop, hidden at/below 1024px) and `AccountMobileNav.astro` (a native
  * `<details>` disclosure, hidden above 1024px). This spec asserts:
  *   - the exact grouped data (root/group/order/hrefs) renders on both,
@@ -57,7 +57,7 @@ const RESOURCES_ITEMS = [
   { href: '/docs/api', label: 'API Docs' },
 ]
 
-const ALL_ITEMS = [...ADMIN_ITEMS, ...TOOLS_ITEMS, ...PREFERENCES_ITEMS, ...RESOURCES_ITEMS]
+const ALL_ITEMS = [...TOOLS_ITEMS, ...PREFERENCES_ITEMS, ...RESOURCES_ITEMS, ...ADMIN_ITEMS]
 
 const TEAM_GATED_HREFS = [
   '/account/team/registry',
@@ -87,7 +87,7 @@ test.afterEach(() => {
   ).toEqual([])
 })
 
-test.describe('account navigation — Account/Admin/Tools/Preferences/Resources (SMI-6128)', () => {
+test.describe('account navigation — Account/Tools/Preferences/Resources/Admin (SMI-6128, SMI-6424)', () => {
   test.beforeEach(async ({ page }) => {
     await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
     // Resolve the team gate as entitled: this describe block asserts pure
@@ -134,17 +134,17 @@ test.describe('account navigation — Account/Admin/Tools/Preferences/Resources 
     await expect(nav).toHaveAttribute('aria-labelledby', headingId as string)
   })
 
-  test('desktop sidebar renders exactly the Admin, Tools, Preferences, and Resources groups in order', async ({
+  test('desktop sidebar renders exactly the Tools, Preferences, Resources, and Admin groups in order', async ({
     page,
   }) => {
     await page.goto('/account')
 
     const headings = page.locator('.account-sidebar h3')
     await expect(headings).toHaveCount(4)
-    await expect(headings.nth(0)).toHaveText('Admin')
-    await expect(headings.nth(1)).toHaveText('Tools')
-    await expect(headings.nth(2)).toHaveText('Preferences')
-    await expect(headings.nth(3)).toHaveText('Resources')
+    await expect(headings.nth(0)).toHaveText('Tools')
+    await expect(headings.nth(1)).toHaveText('Preferences')
+    await expect(headings.nth(2)).toHaveText('Resources')
+    await expect(headings.nth(3)).toHaveText('Admin')
   })
 
   test('desktop sidebar renders every item, in order, with the exact href and label', async ({
@@ -165,10 +165,10 @@ test.describe('account navigation — Account/Admin/Tools/Preferences/Resources 
 
     const groupHeadings = page.locator('.account-mobile-nav h3')
     await expect(groupHeadings).toHaveCount(4)
-    await expect(groupHeadings.nth(0)).toHaveText('Admin')
-    await expect(groupHeadings.nth(1)).toHaveText('Tools')
-    await expect(groupHeadings.nth(2)).toHaveText('Preferences')
-    await expect(groupHeadings.nth(3)).toHaveText('Resources')
+    await expect(groupHeadings.nth(0)).toHaveText('Tools')
+    await expect(groupHeadings.nth(1)).toHaveText('Preferences')
+    await expect(groupHeadings.nth(2)).toHaveText('Resources')
+    await expect(groupHeadings.nth(3)).toHaveText('Admin')
 
     const links = page.locator('.account-mobile-nav a.account-mobile-nav-link')
     await expect(links).toHaveCount(ALL_ITEMS.length)


### PR DESCRIPTION
## Business Summary

**What shipped:** The account-page left navigation now lists Tools, Preferences, and Resources first, with the Admin group (Overview, Summary, Subscription, Billing History, Email Address) moved to the bottom. This applies to both the desktop sidebar and the narrow-viewport disclosure. The "Account" heading, every destination, and the team-plan lock behavior are unchanged.

**Quality bar:** Reviewed by GPT-5.6-Sol (cross-provider second opinion via NEEDLE) before implementation, and by the governance skill after. Unit tests (17/17), lint, typecheck, and the standards audit all pass. Playwright's account-nav specs run locally: 41 passed, including every order-specific assertion; 5 failures reproduced identically against the unmodified code in a stash-and-rerun control, confirming they're a pre-existing local `astro dev`-vs-`vercel dev` environment gap, not a regression — the real gate is this PR's own CI E2E run.

**Found along the way:** a pre-existing, unrelated Docker infra defect — `npm run build` for the website package fails inside a worktree container with a cross-device rename error (named-volume `.vercel/output` vs bind-mounted `dist`). Filed as [SMI-6426](https://linear.app/smith-horn-group/issue/SMI-6426/worktree-docker-build-fails-with-exdev-cross-device-rename); confirmed it doesn't affect the real CI/deploy path (single-filesystem runners), so it's out of scope here and gated by ADR-109 (Docker/infra change).

**Net result:** Fully shipped, pending staging preview review and CI.

---

## Technical detail

- `packages/website/src/lib/account-nav.ts` — moved the `Admin` group object to the end of `ACCOUNT_NAV_GROUPS`; no item-level (href/label/icon/teamGated) change.
- `packages/website/src/lib/account-nav.test.ts`, `packages/website/tests/e2e/account-sidebar.spec.ts` — updated order-sensitive assertions (whole-array `toEqual`, heading-order arrays, and the `ALL_ITEMS` concatenation that drives indexed Playwright locators).
- `packages/website/src/components/AccountSidebar.astro`, `AccountMobileNav.astro`, `packages/website/tests/e2e/account-page-load-guards.spec.ts` — comment-only order updates (history preserved, SMI-6424 appended).
- `CHANGELOG.md` — `[Unreleased]` entry.
- New implementation doc: `docs/internal/implementation/smi-6424-account-nav-admin-to-bottom.md`. Code review report: `docs/internal/code_review/2026-09-06-account-nav-admin-to-bottom.md`.
- Linear: [SMI-6424](https://linear.app/smith-horn-group/issue/SMI-6424/reorder-account-nav-move-admin-group-below-toolspreferencesresources).
- CI: `website-account-e2e.yml`'s path filter covers `account-nav.ts` and `account-sidebar.spec.ts`, so it will run automatically against the real `vercel dev` server (shadow, non-required, but a red run is a real failure — worth checking before merge).
- Staging preview: `website-preview-pr.yml` will post a preview URL as a PR comment once CI runs.
