### PR TITLE
fix(hooks): SMI-6437 -- container self-heal verifies native-module health

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -35,6 +35,8 @@ on:
       - 'scripts/lib/check-container-deps-fresh.sh'
       - 'scripts/lib/check-container-deps-fresh-inner.sh'
       - 'scripts/tests/check-container-deps-fresh.test.sh'
+      - 'scripts/tests/check-container-deps-fresh-lock.test.sh'
+      - 'scripts/tests/_lib/check-container-deps-fresh-fixtures.sh'
       - 'scripts/tests/session-mcp-disconnect-guard.test.sh'
       - 'scripts/tests/create-worktree-hooks.test.sh'
       - 'scripts/tests/worktree-hookspath.test.sh'
@@ -98,6 +100,8 @@ jobs:
             scripts/lib/check-container-deps-fresh-inner.sh \
             scripts/lib/check-hooks-path.sh \
             scripts/tests/check-container-deps-fresh.test.sh \
+            scripts/tests/check-container-deps-fresh-lock.test.sh \
+            scripts/tests/_lib/check-container-deps-fresh-fixtures.sh \
             scripts/tests/session-mcp-disconnect-guard.test.sh \
             scripts/tests/create-worktree-hooks.test.sh \
             scripts/tests/worktree-hookspath.test.sh \
@@ -139,6 +143,8 @@ jobs:
           sh -n scripts/lib/check-container-deps-fresh-inner.sh
           sh -n scripts/lib/check-hooks-path.sh
           bash -n scripts/tests/check-container-deps-fresh.test.sh
+          bash -n scripts/tests/check-container-deps-fresh-lock.test.sh
+          bash -n scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
           bash -n scripts/tests/session-mcp-disconnect-guard.test.sh
           bash -n scripts/tests/create-worktree-hooks.test.sh
           bash -n scripts/tests/worktree-hookspath.test.sh
@@ -176,6 +182,7 @@ jobs:
       - name: Hooks unit tests
         run: |
           bash scripts/tests/check-container-deps-fresh.test.sh
+          bash scripts/tests/check-container-deps-fresh-lock.test.sh
           bash scripts/tests/session-mcp-disconnect-guard.test.sh
           bash scripts/tests/create-worktree-hooks.test.sh
           bash scripts/tests/worktree-hookspath.test.sh

--- a/scripts/lib/check-container-deps-fresh.sh
+++ b/scripts/lib/check-container-deps-fresh.sh
@@ -63,6 +63,20 @@
 # forces the code path without a real container, mirroring
 # check-native-modules.sh's own SKILLSMITH_NATIVE_CHECK_TEST pattern.
 #
+# SMI-6437: a "successful" npm install (RC=0) can still leave a nested
+# native-module binding broken — confirmed incident, 2026-09-07:
+# better-sqlite3's packages/core copy failed with ERR_DLOPEN_FAILED
+# ("invalid ELF header") right after this self-heal reported success, and
+# sat undetected until an unrelated later push happened to reach
+# check-native-modules.sh (SMI-5513) further down .husky/pre-push. A failed
+# install (RC=4) can leave the same breakage behind too. Both outcome
+# branches below now invoke check-native-modules.sh's existing probe
+# directly — reusing it as-is rather than duplicating its logic — so a
+# broken binding surfaces on THIS push, not a later unrelated one.
+# check-native-modules.sh's own SKILLSMITH_SKIP_NATIVE_CHECK opt-out and
+# USE_DOCKER gating apply to these new call sites for free; see
+# docs/internal/implementation/smi-6437-container-self-heal-native-verify.md.
+#
 # POSIX sh — no `local`, no `[[ ]]`, no arrays.
 
 if [ "${SKILLSMITH_SKIP_CONTAINER_DEPS_FRESHNESS:-0}" = "1" ]; then
@@ -100,6 +114,11 @@ if [ ! -r "$DETECT_LIB" ]; then
 fi
 # shellcheck source=./hook-docker-detect.sh
 . "$DETECT_LIB"
+
+# SMI-6437: sibling path to the existing native-module probe (SMI-5513),
+# resolved the same way DETECT_LIB is above. Invoked directly (not sourced)
+# from both self-heal outcome branches below.
+NATIVE_CHECK_LIB="$(dirname "$0")/check-native-modules.sh"
 
 # Only meaningful for the main checkout's own container. Worktree containers
 # mount node_modules :ro (self-heal there would EROFS) and are already
@@ -147,6 +166,16 @@ if [ "$RC" -eq 0 ]; then
     case "$OUTPUT" in
         *SELF_HEAL_START*)
             printf "${GREEN}  ✓ Self-healed — %s's node_modules now matches package-lock.json${NC}\n" "$DOCKER_CONTAINER"
+            # SMI-6437: npm exiting 0 does not prove native bindings still
+            # work — verify before letting the push proceed. Not silenced:
+            # check-native-modules.sh prints its own actionable diagnostic
+            # on failure, which is worth showing in full here.
+            if [ -r "$NATIVE_CHECK_LIB" ] && ! sh "$NATIVE_CHECK_LIB"; then
+                printf '\n'
+                printf "${RED}  ✗ Self-heal reported success, but native module bindings are still broken (SMI-6437) — refusing to let the push proceed.${NC}\n"
+                printf '\n'
+                exit 1
+            fi
             ;;
     esac
     exit 0
@@ -174,6 +203,17 @@ case "$RC" in
         printf '\n'
         printf "  ${YELLOW}Fix — retry manually:${NC}\n"
         printf '    docker exec %s npm install\n' "$DOCKER_CONTAINER"
+        # SMI-6437: a failed install can leave native bindings broken as a
+        # side effect, even though the FIX above targets the npm error, not
+        # this. Silenced (>/dev/null 2>&1) and folded into one extra line —
+        # the npm failure above is already the primary diagnostic; no need
+        # to print a second full banner for this additive check.
+        if [ -r "$NATIVE_CHECK_LIB" ] && ! sh "$NATIVE_CHECK_LIB" >/dev/null 2>&1; then
+            printf '\n'
+            printf "${RED}  Native module bindings are ALSO currently broken as a result of this failed install.${NC}\n"
+            printf "  ${YELLOW}Recover those FIRST:${NC} docker compose --profile dev restart dev\n"
+            printf '  Then retry the npm install fix above.\n'
+        fi
         ;;
     *)
         # Any other code (docker itself failing, sh unable to start, an

--- a/scripts/lib/check-container-deps-fresh.sh
+++ b/scripts/lib/check-container-deps-fresh.sh
@@ -170,7 +170,21 @@ if [ "$RC" -eq 0 ]; then
             # work — verify before letting the push proceed. Not silenced:
             # check-native-modules.sh prints its own actionable diagnostic
             # on failure, which is worth showing in full here.
-            if [ -r "$NATIVE_CHECK_LIB" ] && ! sh "$NATIVE_CHECK_LIB"; then
+            #
+            # Fail LOUD, not open, when the probe script itself is missing
+            # (pr-reviewer finding, SMI-6437): the whole point of this
+            # change is that a self-heal must not silently skip
+            # verification. A missing tracked sibling script is not a
+            # legitimate "nothing to verify" case — it means verification
+            # could not happen, which must block the push exactly like a
+            # failed probe would.
+            if [ ! -r "$NATIVE_CHECK_LIB" ]; then
+                printf '\n'
+                printf "${RED}  ✗ Self-heal reported success, but native-module health could not be verified (SMI-6437) — %s is missing or unreadable.${NC}\n" "$NATIVE_CHECK_LIB"
+                printf "${RED}    Refusing to let the push proceed against an unverified tree.${NC}\n"
+                printf '\n'
+                exit 1
+            elif ! sh "$NATIVE_CHECK_LIB"; then
                 printf '\n'
                 printf "${RED}  ✗ Self-heal reported success, but native module bindings are still broken (SMI-6437) — refusing to let the push proceed.${NC}\n"
                 printf '\n'
@@ -207,8 +221,16 @@ case "$RC" in
         # side effect, even though the FIX above targets the npm error, not
         # this. Silenced (>/dev/null 2>&1) and folded into one extra line —
         # the npm failure above is already the primary diagnostic; no need
-        # to print a second full banner for this additive check.
-        if [ -r "$NATIVE_CHECK_LIB" ] && ! sh "$NATIVE_CHECK_LIB" >/dev/null 2>&1; then
+        # to print a second full banner for this additive check. This
+        # branch already exits 1 regardless (npm failed), but still says so
+        # plainly when the probe itself is missing (pr-reviewer finding) —
+        # "could not check" is a different, worth-noting fact from "checked
+        # and it's fine", even though both currently share the same exit
+        # code here.
+        if [ ! -r "$NATIVE_CHECK_LIB" ]; then
+            printf '\n'
+            printf "${YELLOW}  Note: native-module health could not be checked (%s is missing or unreadable).${NC}\n" "$NATIVE_CHECK_LIB"
+        elif ! sh "$NATIVE_CHECK_LIB" >/dev/null 2>&1; then
             printf '\n'
             printf "${RED}  Native module bindings are ALSO currently broken as a result of this failed install.${NC}\n"
             printf "  ${YELLOW}Recover those FIRST:${NC} docker compose --profile dev restart dev\n"

--- a/scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
+++ b/scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
@@ -45,6 +45,13 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 GUARD="$REPO_ROOT/scripts/lib/check-container-deps-fresh.sh"
 INNER="$REPO_ROOT/scripts/lib/check-container-deps-fresh-inner.sh"
 REAL_FRESH_CHECK="$REPO_ROOT/scripts/lib/check-node-modules-fresh.sh"
+# SMI-6437: the real, committed sibling script GUARD resolves at its own new
+# call sites. A dedicated scenario temporarily renames this exact file (via
+# absolute path, restored by an EXIT trap) to test the "probe script itself
+# is missing" branch — never referenced via a relative path anywhere that
+# scenario touches it, precisely to avoid a cwd-change silently breaking
+# the restore (confirmed painfully while writing that scenario).
+NATIVE_LIB="$REPO_ROOT/scripts/lib/check-native-modules.sh"
 
 if [ ! -x "$GUARD" ]; then
   echo "FAIL: $GUARD is not executable"
@@ -52,6 +59,10 @@ if [ ! -x "$GUARD" ]; then
 fi
 if [ ! -x "$INNER" ]; then
   echo "FAIL: $INNER is not executable"
+  exit 1
+fi
+if [ ! -x "$NATIVE_LIB" ]; then
+  echo "FAIL: $NATIVE_LIB is not executable"
   exit 1
 fi
 

--- a/scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
+++ b/scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
+#
+# Shared fixture setup for the check-container-deps-fresh.sh (SMI-6006) test
+# files. Split out of the original check-container-deps-fresh.test.sh
+# (SMI-6437) to keep both consumer files under this repo's 500-line-per-file
+# limit — mirrors the scripts/tests/_lib/needle-dispatch-fixtures.sh
+# precedent exactly (same source pattern, same split rationale).
+#
+# Runs the REAL guard script from its real location (not a copy), so its
+# `hook-docker-detect.sh` sourcing and its own lock/self-heal logic are
+# exercised as written. Two things are faked, both via PATH shims:
+#
+#   - `docker`: `ps` reports a fake "skillsmith-dev-1" as running; `exec`
+#     strictly validates the production invocation shape (`-w /app`, zero or
+#     more `-e KEY=VALUE`, the container name, then `sh
+#     scripts/lib/check-container-deps-fresh-inner.sh`) and, once validated,
+#     actually runs that file with cwd set to a plain (non-git) FAKE_APP_DIR
+#     standing in for the container's /app — so the real lock/self-heal
+#     script (mkdir, kill -0, npm install, the real
+#     check-node-modules-fresh.sh) runs against REAL files with REAL POSIX
+#     semantics, not scripted pass/fail responses. Strict validation means a
+#     future accidental change to the production invocation shape fails this
+#     test loudly instead of silently passing through a permissive parser.
+#   - `npm`: `install` logs a line to NPM_CALL_LOG (so every scenario can
+#     assert exactly how many times it was really called), sleeps
+#     $FAKE_NPM_DELAY, then exits 0, or exits 1 if $FAKE_NPM_FAIL=1.
+#
+# hook-docker-detect.sh's own IS_WORKTREE/USE_DOCKER detection is NOT faked
+# — it runs for real against small real git repos/worktrees this file
+# creates, mirroring create-worktree-hooks.test.sh's Scenario 11 approach.
+#
+# SMI-6437: `run_guard()`'s env-forwarding list also carries
+# SKILLSMITH_NATIVE_CHECK_TEST through to the real guard script, so a
+# consumer test can deterministically force check-native-modules.sh's own
+# real (not faked) test seam — no separate native-module fake is needed.
+#
+# Consumers: scripts/tests/check-container-deps-fresh.test.sh (Scenarios
+# 1-4 plus the SMI-6437 native-probe scenarios) and
+# scripts/tests/check-container-deps-fresh-lock.test.sh (Scenarios 5-9,
+# the lock-contention cluster).
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+GUARD="$REPO_ROOT/scripts/lib/check-container-deps-fresh.sh"
+INNER="$REPO_ROOT/scripts/lib/check-container-deps-fresh-inner.sh"
+REAL_FRESH_CHECK="$REPO_ROOT/scripts/lib/check-node-modules-fresh.sh"
+
+if [ ! -x "$GUARD" ]; then
+  echo "FAIL: $GUARD is not executable"
+  exit 1
+fi
+if [ ! -x "$INNER" ]; then
+  echo "FAIL: $INNER is not executable"
+  exit 1
+fi
+
+fail=0
+pass=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: expected='$expected' actual='$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+NPM_CALL_LOG="$TMP_ROOT/npm-calls.log"
+: > "$NPM_CALL_LOG"
+npm_call_count() { wc -l < "$NPM_CALL_LOG" | tr -d ' '; }
+
+# --- fake docker + npm on PATH -----------------------------------------
+FAKE_BIN="$TMP_ROOT/fake-bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/docker" <<'DOCKER_EOF'
+#!/usr/bin/env bash
+set -eu
+echo "$*" >> "$FAKE_DOCKER_LOG"
+case "$1" in
+  ps)
+    echo "skillsmith-dev-1"
+    exit 0
+    ;;
+  exec)
+    shift
+    # Strictly validate the production shape:
+    #   -w /app [-e KEY=VALUE ...] <container> sh scripts/lib/check-container-deps-fresh-inner.sh
+    # Any deviation is a test FAILURE (exit 2), not a silent skip — this test
+    # exists partly to catch an accidental future change to how the guard
+    # invokes docker, not just to exercise the lock logic.
+    [ "${1:-}" = "-w" ] || { echo "fake docker: expected -w first, got '${1:-}'" >&2; exit 2; }
+    shift 2
+    while [ "${1:-}" = "-e" ]; do
+      export "${2?fake docker: -e with no value}"
+      shift 2
+    done
+    container="${1:-}"
+    [ -n "$container" ] || { echo "fake docker: missing container name" >&2; exit 2; }
+    shift
+    [ "${1:-}" = "sh" ] || { echo "fake docker: expected 'sh', got '${1:-}'" >&2; exit 2; }
+    script_path="${2:-}"
+    [ "$script_path" = "scripts/lib/check-container-deps-fresh-inner.sh" ] || {
+      echo "fake docker: expected the inner-script path, got '$script_path'" >&2
+      exit 2
+    }
+    [ "$#" -eq 2 ] || { echo "fake docker: unexpected trailing args: $*" >&2; exit 2; }
+    cd "$FAKE_APP_DIR"
+    sh "$script_path"
+    exit $?
+    ;;
+  inspect)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+DOCKER_EOF
+chmod +x "$FAKE_BIN/docker"
+
+cat > "$FAKE_BIN/npm" <<EOF
+#!/usr/bin/env bash
+set -eu
+if [ "\${1:-}" = "install" ]; then
+  echo "call" >> "$NPM_CALL_LOG"
+  sleep "\${FAKE_NPM_DELAY:-0}"
+  if [ "\${FAKE_NPM_FAIL:-0}" = "1" ]; then
+    echo "npm ERR! simulated failure" >&2
+    exit 1
+  fi
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/npm"
+
+export PATH="$FAKE_BIN:$PATH"
+
+# --- helper: a fresh FAKE_APP_DIR (stands in for the container's /app) --
+setup_fake_app_dir() {
+  local dir="$1" hash_state="$2"   # hash_state: fresh|stale|missing
+  rm -rf "$dir"
+  mkdir -p "$dir/scripts/lib" "$dir/node_modules"
+  cp "$REAL_FRESH_CHECK" "$dir/scripts/lib/check-node-modules-fresh.sh"
+  cp "$INNER" "$dir/scripts/lib/check-container-deps-fresh-inner.sh"
+  echo '{"name":"fake"}' > "$dir/package-lock.json"
+  local real_hash
+  real_hash=$(sha256sum "$dir/package-lock.json" | cut -d' ' -f1)
+  case "$hash_state" in
+    fresh)   printf '%s\n' "$real_hash" > "$dir/node_modules/.skillsmith-deps-hash" ;;
+    stale)   printf '%s\n' "0000000000000000000000000000000000000000000000000000000000000000" > "$dir/node_modules/.skillsmith-deps-hash" ;;
+    missing) ;;
+  esac
+}
+
+# --- helper: a plain (non-worktree) real git repo, main-checkout-shaped -
+setup_main_repo() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  ( cd "$dir" && git init -q && git config user.email t@t.com && git config user.name t \
+    && touch f && git add f && git commit -q -m init )
+}
+
+# --- helper: an in-tree worktree of that repo --------------------------
+# Must be a SUBDIRECTORY of main_dir (mirrors this repo's own .worktrees/<name>
+# convention) — hook-docker-detect.sh's compute_container_wd() only resolves
+# CONTAINER_WD="/app" when the worktree's toplevel is main_dir itself or
+# starts with "main_dir/"; a sibling directory is the (different, also-real)
+# OFF-TREE worktree case and takes a different code path entirely.
+setup_worktree() {
+  local main_dir="$1" wt_name="$2"
+  ( cd "$main_dir" && git worktree add -q -b "wt-branch-$$-$wt_name" ".worktrees/$wt_name" >/dev/null 2>&1 )
+}
+
+# NOTE: callers must set FAKE_DOCKER_LOG (a mktemp path) BEFORE invoking this
+# via `rc=$(run_guard ...)` — command substitution forks a subshell, so any
+# variable this function assigned would not survive back to the caller.
+#
+# The guard's own stdout/stderr (colored status text) is redirected to
+# GUARD_LAST_OUTPUT (a file, so `cat` after the call recovers it for
+# debugging) — never mixed into the captured exit code via `$(run_guard ...)`.
+#
+# SMI-6437: SKILLSMITH_NATIVE_CHECK_TEST is forwarded here so a consumer
+# scenario can deterministically force check-native-modules.sh's own real
+# test seam (ok|fail) without touching Docker at all — that script's seam
+# short-circuits before any USE_DOCKER/hook-docker-detect.sh involvement.
+# Defaults to "ok" (not unset/empty): a bare `${VAR:+NAME=value}` expansion
+# is NOT recognized by bash as a variable-assignment prefix (that
+# recognition is parse-time-only, for literal `NAME=value` syntax — the
+# *result* of a runtime parameter expansion is just executed as a command,
+# which fails with "command not found" the moment the variable is
+# non-empty; caught empirically while writing this file's own scenarios).
+# Defaulting to "ok" also keeps every pre-existing scenario below (S1-S9,
+# none of which care about native-module health) deterministic against the
+# two new SMI-6437 probe call sites in check-container-deps-fresh.sh,
+# rather than letting them fall through to a REAL (non-test-seam) probe
+# attempt that would hit this file's own strict fake-docker exec-shape
+# validation and spuriously fail.
+GUARD_LAST_OUTPUT="$TMP_ROOT/guard-last-output.txt"
+run_guard() {
+  local cwd="$1"
+  ( cd "$cwd" && FAKE_DOCKER_LOG="$FAKE_DOCKER_LOG" FAKE_APP_DIR="$FAKE_APP_DIR" \
+      FAKE_NPM_FAIL="${FAKE_NPM_FAIL:-0}" FAKE_NPM_DELAY="${FAKE_NPM_DELAY:-0}" \
+      SKILLSMITH_LOCK_MAX_TRIES="${SKILLSMITH_LOCK_MAX_TRIES:-45}" \
+      SKILLSMITH_LOCK_SLEEP_SECS="${SKILLSMITH_LOCK_SLEEP_SECS:-2}" \
+      SKILLSMITH_NATIVE_CHECK_TEST="${SKILLSMITH_NATIVE_CHECK_TEST:-ok}" \
+      "$GUARD" </dev/null >"$GUARD_LAST_OUTPUT" 2>&1 )
+  echo $?
+}

--- a/scripts/tests/check-container-deps-fresh-lock.test.sh
+++ b/scripts/tests/check-container-deps-fresh-lock.test.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# scripts/tests/check-container-deps-fresh-lock.test.sh
+# SMI-6006 — scripts/lib/check-container-deps-fresh-inner.sh lock-contention
+# tests (Scenarios 5-9): live-lock-wait, dead-lock-reclaim, a truly
+# concurrent barrier-synchronized race, the multi-reclaimer TOCTOU race, and
+# ownership-token unit tests.
+#
+# SMI-6437: split out of check-container-deps-fresh.test.sh, which had grown
+# to 464/500 lines before that plan's new native-module-verification
+# scenarios — this cluster is topically self-contained (it exercises the
+# mkdir-based lock mechanism, not the dispatcher's own RC/probe handling),
+# which is why it's the natural split boundary. Sources the same shared
+# setup as the sibling file, mirroring the
+# scripts/tests/_lib/needle-dispatch-fixtures.sh precedent.
+#
+# Run: bash scripts/tests/check-container-deps-fresh-lock.test.sh
+#
+# File-wide: every scenario below sets
+# FAKE_* / SKILLSMITH_* vars that are read only inside run_guard() (defined
+# in the sourced fixtures file), and reads $pass/$fail (assigned by that
+# same file's assert_eq()). Shellcheck's cross-file dataflow analysis
+# resolves this correctly for all but the LAST assignment of each name in
+# this file — a moving target as scenarios are added/removed — so this is
+# suppressed file-wide rather than chased line-by-line (empirically
+# confirmed: the original, pre-split single file had zero such warnings,
+# since run_guard()'s own reads and every assignment lived in the same
+# file; splitting is what exposed this specific shellcheck limitation).
+# shellcheck disable=SC2034,SC2154
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_lib/check-container-deps-fresh-fixtures.sh
+source "$SELF_DIR/_lib/check-container-deps-fresh-fixtures.sh"
+
+# =========================================================================
+# Scenario 5: lock held by a live PID — waiter fails safely, no npm install
+# =========================================================================
+MAIN5="$TMP_ROOT/main5"
+APP5="$TMP_ROOT/app5"
+setup_main_repo "$MAIN5"
+setup_fake_app_dir "$APP5" stale
+mkdir -p "$APP5/node_modules/.skillsmith-deps-lock"
+# A live process to be the "owner" — this test script's own PID is alive
+# for the duration of this scenario.
+printf '%s:%s\n' "$$" "$(date +%s)" > "$APP5/node_modules/.skillsmith-deps-lock/owner"
+FAKE_APP_DIR="$APP5"
+FAKE_DOCKER_LOG=$(mktemp)
+: > "$NPM_CALL_LOG"
+SKILLSMITH_LOCK_MAX_TRIES=2
+SKILLSMITH_LOCK_SLEEP_SECS=0
+rc=$(run_guard "$MAIN5")
+SKILLSMITH_LOCK_MAX_TRIES=45
+SKILLSMITH_LOCK_SLEEP_SECS=2
+assert_eq "S5: lock held by live PID -> guard fails (not silently proceeding)" "1" "$rc"
+assert_eq "S5: npm install NOT called while waiting on a live lock" "0" "$(npm_call_count)"
+rm -rf "$APP5/node_modules/.skillsmith-deps-lock"
+
+# =========================================================================
+# Scenario 6: lock held by a dead PID — reclaimed, self-heal proceeds
+# =========================================================================
+MAIN6="$TMP_ROOT/main6"
+APP6="$TMP_ROOT/app6"
+setup_main_repo "$MAIN6"
+setup_fake_app_dir "$APP6" stale
+mkdir -p "$APP6/node_modules/.skillsmith-deps-lock"
+# A definitely-dead PID (a backgrounded subshell, waited on so it's reaped).
+( : ) &
+DEAD_PID=$!
+wait "$DEAD_PID" 2>/dev/null || true
+printf '%s:%s\n' "$DEAD_PID" "$(date +%s)" > "$APP6/node_modules/.skillsmith-deps-lock/owner"
+FAKE_APP_DIR="$APP6"
+FAKE_DOCKER_LOG=$(mktemp)
+: > "$NPM_CALL_LOG"
+rc=$(run_guard "$MAIN6")
+assert_eq "S6: lock held by dead PID is reclaimed, self-heal proceeds" "0" "$rc"
+assert_eq "S6: npm install called exactly once after reclaim" "1" "$(npm_call_count)"
+NEW_HASH6=$(cat "$APP6/node_modules/.skillsmith-deps-hash")
+EXPECTED_HASH6=$(sha256sum "$APP6/package-lock.json" | cut -d' ' -f1)
+assert_eq "S6: sentinel rewritten after reclaim" "$EXPECTED_HASH6" "$NEW_HASH6"
+
+# =========================================================================
+# Scenario 7: two truly concurrent invocations against a stale (no existing
+# lock) tree, synchronized with a BARRIER rather than a hopeful sleep — B is
+# only started once A's own fake npm has recorded that it actually began
+# installing, so this deterministically proves the lock (not scheduling
+# luck) is what keeps B from also installing. Per review: a sleep-based
+# "widen the window" approach could pass even for an unlocked implementation
+# if B merely happened to start after A finished.
+# =========================================================================
+MAIN7A="$TMP_ROOT/main7a"
+MAIN7B="$TMP_ROOT/main7b"
+APP7="$TMP_ROOT/app7"
+setup_main_repo "$MAIN7A"
+setup_main_repo "$MAIN7B"
+setup_fake_app_dir "$APP7" stale
+# No ambient FAKE_APP_DIR here (SMI-6437 cleanup): both subshell invocations
+# below set their own FAKE_APP_DIR="$APP7" inline, so an ambient copy here
+# would never be read (same genuinely-unused pattern as Scenario 8's own
+# cleanup further down in this file).
+FAKE_DOCKER_LOG_A=$(mktemp)
+FAKE_DOCKER_LOG_B=$(mktemp)
+: > "$NPM_CALL_LOG"
+FAKE_NPM_DELAY=2   # A stays "inside" the install long enough for B to attempt entry
+
+LOG_A="$TMP_ROOT/s7-a.rc"
+LOG_B="$TMP_ROOT/s7-b.rc"
+( cd "$MAIN7A" && FAKE_APP_DIR="$APP7" FAKE_DOCKER_LOG="$FAKE_DOCKER_LOG_A" FAKE_NPM_DELAY="$FAKE_NPM_DELAY" SKILLSMITH_NATIVE_CHECK_TEST=ok "$GUARD" </dev/null; echo $? > "$LOG_A" ) &
+PID_A=$!
+
+# Barrier: block here until A's fake npm has actually recorded a call —
+# proves B starts DURING A's install, not merely "probably around the same
+# time". 10s cap so a genuine regression fails the test instead of hanging.
+barrier_tries=0
+while [ ! -s "$NPM_CALL_LOG" ] && [ "$barrier_tries" -lt 100 ]; do
+  sleep 0.1
+  barrier_tries=$((barrier_tries + 1))
+done
+assert_eq "S7: barrier — A's install actually started before B launches" "yes" "$([ -s "$NPM_CALL_LOG" ] && echo yes || echo no)"
+
+( cd "$MAIN7B" && FAKE_APP_DIR="$APP7" FAKE_DOCKER_LOG="$FAKE_DOCKER_LOG_B" FAKE_NPM_DELAY="$FAKE_NPM_DELAY" SKILLSMITH_NATIVE_CHECK_TEST=ok "$GUARD" </dev/null; echo $? > "$LOG_B" ) &
+PID_B=$!
+wait "$PID_A" "$PID_B"
+FAKE_NPM_DELAY=0
+RC_A=$(cat "$LOG_A"); RC_B=$(cat "$LOG_B")
+assert_eq "S7: invocation A exits 0" "0" "$RC_A"
+assert_eq "S7: invocation B exits 0" "0" "$RC_B"
+assert_eq "S7: npm install called exactly once despite B starting mid-install" "1" "$(npm_call_count)"
+
+# =========================================================================
+# Scenario 8: two waiters observe the SAME dead-owner lock and race to
+# reclaim it, while a fresh acquirer may slip in between — this is the
+# multi-reclaimer TOCTOU this design's RECLAIM_DIR mutex exists to close.
+# Deterministic guarantee is weaker than Scenario 7 (no barrier point exists
+# mid-mkdir to synchronize on), but two processes launched back-to-back
+# against the same pre-seeded dead lock reliably contend for the SAME
+# reclaim window in practice — the assertion that matters is that exactly
+# ONE self-heal (one npm install) ever results, never zero, never more than
+# one, and never a corrupted lock state that hangs both.
+# =========================================================================
+MAIN8A="$TMP_ROOT/main8a"
+MAIN8B="$TMP_ROOT/main8b"
+APP8="$TMP_ROOT/app8"
+setup_main_repo "$MAIN8A"
+setup_main_repo "$MAIN8B"
+setup_fake_app_dir "$APP8" stale
+mkdir -p "$APP8/node_modules/.skillsmith-deps-lock"
+( : ) &
+DEAD_PID8=$!
+wait "$DEAD_PID8" 2>/dev/null || true
+printf '%s:0\n' "$DEAD_PID8" > "$APP8/node_modules/.skillsmith-deps-lock/owner"
+# Genuinely unused ambient assignment removed here (SMI-6437 cleanup): both
+# subshell invocations below set their own FAKE_APP_DIR="$APP8" inline —
+# this one had no reader even in the original pre-split file, just masked
+# by run_guard()'s genuine reads for OTHER scenarios being in the same file.
+: > "$NPM_CALL_LOG"
+
+LOG_8A="$TMP_ROOT/s8-a.rc"
+LOG_8B="$TMP_ROOT/s8-b.rc"
+( cd "$MAIN8A" && FAKE_APP_DIR="$APP8" FAKE_DOCKER_LOG="$(mktemp)" SKILLSMITH_NATIVE_CHECK_TEST=ok "$GUARD" </dev/null; echo $? > "$LOG_8A" ) &
+PID_8A=$!
+( cd "$MAIN8B" && FAKE_APP_DIR="$APP8" FAKE_DOCKER_LOG="$(mktemp)" SKILLSMITH_NATIVE_CHECK_TEST=ok "$GUARD" </dev/null; echo $? > "$LOG_8B" ) &
+PID_8B=$!
+wait "$PID_8A" "$PID_8B"
+RC_8A=$(cat "$LOG_8A"); RC_8B=$(cat "$LOG_8B")
+assert_eq "S8: invocation A exits 0" "0" "$RC_8A"
+assert_eq "S8: invocation B exits 0" "0" "$RC_8B"
+assert_eq "S8: exactly one self-heal resulted from the dead-lock reclaim race" "1" "$(npm_call_count)"
+assert_eq "S8: no lock left behind after both finish" "no" "$([ -d "$APP8/node_modules/.skillsmith-deps-lock" ] && echo yes || echo no)"
+
+# =========================================================================
+# Scenario 9: ownership-token unit test — sources check-container-deps-fresh-inner.sh
+# directly (SKILLSMITH_LOCK_TEST_SOURCE=1 skips its main flow, leaving
+# acquire()/release()/try_reclaim() defined) and calls release() with a
+# STALE token against a lock a DIFFERENT token has since legitimately
+# re-acquired. No docker/npm/subshells involved — this is a pure unit test
+# of the exact property the PID+nonce token exists to guarantee: release()
+# must only ever remove a lock whose owner file still names ITS OWN token.
+# =========================================================================
+APP9="$TMP_ROOT/app9"
+rm -rf "$APP9"
+mkdir -p "$APP9/node_modules"
+(
+  cd "$APP9" || exit 1
+  # shellcheck disable=SC2034  # read by the sourced INNER file, which shellcheck can't statically follow (dynamic path)
+  SKILLSMITH_LOCK_TEST_SOURCE=1
+  # shellcheck source=/dev/null
+  . "$INNER"
+
+  mkdir -p node_modules/.skillsmith-deps-lock
+  # A DIFFERENT holder's token — simulates "someone else has since
+  # legitimately reclaimed and re-acquired this lock" (MY_TOKEN, from this
+  # sourced instance, was never the one that wrote it).
+  echo "999999:someone-elses-nonce" > node_modules/.skillsmith-deps-lock/owner
+
+  release   # must be a no-op: MY_TOKEN != the file's content
+
+  if [ -f node_modules/.skillsmith-deps-lock/owner ] && \
+     [ "$(cat node_modules/.skillsmith-deps-lock/owner)" = "999999:someone-elses-nonce" ]; then
+    echo PASS
+  else
+    echo FAIL
+  fi
+) > "$TMP_ROOT/s9-result.txt" 2>&1
+S9_RESULT=$(tail -1 "$TMP_ROOT/s9-result.txt")
+assert_eq "S9: release() never removes a lock it does not own (ownership-token check)" "PASS" "$S9_RESULT"
+
+# Sanity check the SAME unit-test seam correctly removes a lock it DOES own —
+# proves S9 above is testing the real guard, not a seam that always no-ops.
+APP9B="$TMP_ROOT/app9b"
+rm -rf "$APP9B"
+mkdir -p "$APP9B/node_modules"
+(
+  cd "$APP9B" || exit 1
+  # shellcheck disable=SC2034  # read by the sourced INNER file, which shellcheck can't statically follow (dynamic path)
+  SKILLSMITH_LOCK_TEST_SOURCE=1
+  # shellcheck source=/dev/null
+  . "$INNER"
+
+  mkdir -p node_modules/.skillsmith-deps-lock
+  printf "%s\n" "$MY_TOKEN" > node_modules/.skillsmith-deps-lock/owner
+
+  release
+
+  if [ ! -e node_modules/.skillsmith-deps-lock ]; then
+    echo PASS
+  else
+    echo FAIL
+  fi
+) > "$TMP_ROOT/s9b-result.txt" 2>&1
+S9B_RESULT=$(tail -1 "$TMP_ROOT/s9b-result.txt")
+assert_eq "S9b: release() DOES remove a lock it owns (seam sanity check)" "PASS" "$S9B_RESULT"
+
+echo ""
+echo "======================================"
+echo "Results: $pass passed, $fail failed"
+echo "======================================"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/check-container-deps-fresh.test.sh
+++ b/scripts/tests/check-container-deps-fresh.test.sh
@@ -163,6 +163,37 @@ assert_eq "S12: npm install failure still exits non-zero" "1" "$rc"
 assert_eq "S12: output additionally mentions native bindings ALSO broken" "yes" "$(grep -q "ALSO currently broken" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
 assert_eq "S12: output still names the restart remedy" "yes" "$(grep -q "docker compose --profile dev restart dev" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
 
+# =========================================================================
+# Scenario 13 (SMI-6437, pr-reviewer finding): self-heal succeeds, but the
+# native-probe script ITSELF is missing/unreadable — must be a hard failure
+# too, not a silent fail-open pass. Temporarily renames the REAL,
+# committed NATIVE_LIB via its absolute path (never a relative one — a
+# cwd change elsewhere in this scenario must never break the restore).
+# Deliberately does NOT use `trap ... EXIT` for the restore: this file
+# already has one EXIT trap (the fixtures file's TMP_ROOT cleanup, sourced
+# above) — a SECOND `trap ... EXIT` here would silently REPLACE it, and
+# `trap - EXIT` afterward clears the slot rather than restoring what was
+# there before, permanently losing that cleanup for the rest of the run.
+# The one command between the two `mv` calls (`run_guard`) is already
+# proven safe under this file's `set -euo pipefail` — its last action is
+# always a successful `echo $?`, exactly like every other scenario's
+# `rc=$(run_guard ...)` call above — so a plain sequential restore is
+# sufficient without needing trap-based protection.
+# =========================================================================
+MAIN13="$TMP_ROOT/main13"
+APP13="$TMP_ROOT/app13"
+setup_main_repo "$MAIN13"
+setup_fake_app_dir "$APP13" stale
+FAKE_APP_DIR="$APP13"
+FAKE_DOCKER_LOG=$(mktemp)
+: > "$NPM_CALL_LOG"
+mv "$NATIVE_LIB" "$NATIVE_LIB.s13-bak"
+rc=$(run_guard "$MAIN13")
+mv "$NATIVE_LIB.s13-bak" "$NATIVE_LIB"
+assert_eq "S13: self-heal succeeds but native-probe script is missing -> hard failure" "1" "$rc"
+assert_eq "S13: output names the missing-probe reason" "yes" "$(grep -q "could not be verified" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
+assert_eq "S13: real NATIVE_LIB restored" "yes" "$([ -x "$NATIVE_LIB" ] && echo yes || echo no)"
+
 echo ""
 echo "======================================"
 echo "Results: $pass passed, $fail failed"

--- a/scripts/tests/check-container-deps-fresh.test.sh
+++ b/scripts/tests/check-container-deps-fresh.test.sh
@@ -1,196 +1,36 @@
 #!/usr/bin/env bash
-# SMI-6006 — scripts/lib/check-container-deps-fresh.sh tests.
+# scripts/tests/check-container-deps-fresh.test.sh
+# SMI-6006 — scripts/lib/check-container-deps-fresh.sh tests: basic
+# dispatcher behavior (Scenarios 1-4) plus SMI-6437's post-self-heal
+# native-module verification (the three new scenarios below).
 #
-# Runs the REAL guard script from its real location (not a copy), so its
-# `hook-docker-detect.sh` sourcing and its own lock/self-heal logic are
-# exercised as written. Two things are faked, both via PATH shims:
-#
-#   - `docker`: `ps` reports a fake "skillsmith-dev-1" as running; `exec`
-#     strictly validates the production invocation shape (`-w /app`, zero or
-#     more `-e KEY=VALUE`, the container name, then `sh
-#     scripts/lib/check-container-deps-fresh-inner.sh`) and, once validated,
-#     actually runs that file with cwd set to a plain (non-git) FAKE_APP_DIR
-#     standing in for the container's /app — so the real lock/self-heal
-#     script (mkdir, kill -0, npm install, the real
-#     check-node-modules-fresh.sh) runs against REAL files with REAL POSIX
-#     semantics, not scripted pass/fail responses. Strict validation means a
-#     future accidental change to the production invocation shape fails this
-#     test loudly instead of silently passing through a permissive parser.
-#     Scenario 9 (ownership-token) sources check-container-deps-fresh-inner.sh
-#     directly instead, for a true unit test of release()'s ownership check.
-#   - `npm`: `install` logs a line to NPM_CALL_LOG (so every scenario can
-#     assert exactly how many times it was really called), sleeps
-#     $FAKE_NPM_DELAY, then exits 0, or exits 1 if $FAKE_NPM_FAIL=1.
-#
-# hook-docker-detect.sh's own IS_WORKTREE/USE_DOCKER detection is NOT faked
-# — it runs for real against small real git repos/worktrees this file
-# creates, mirroring create-worktree-hooks.test.sh's Scenario 11 approach.
-# That means this file only needs to cover check-container-deps-fresh.sh's
-# OWN new logic (lock, self-heal, worktree gate); hook-docker-detect.sh's
-# own detection correctness is already covered by create-worktree-hooks.test.sh.
+# SMI-6437: split from the original single file, which had grown to 464/500
+# lines before these new scenarios — the lock-contention cluster (Scenarios
+# 5-9: live-lock-wait, dead-lock-reclaim, concurrent-barrier race,
+# multi-reclaimer TOCTOU race, ownership-token unit tests) moved to
+# scripts/tests/check-container-deps-fresh-lock.test.sh; both files now
+# source the shared setup in scripts/tests/_lib/check-container-deps-fresh-fixtures.sh
+# (mirrors the scripts/tests/_lib/needle-dispatch-fixtures.sh precedent).
 #
 # Run: bash scripts/tests/check-container-deps-fresh.test.sh
+#
+# File-wide: every scenario below sets
+# FAKE_* / SKILLSMITH_* vars that are read only inside run_guard() (defined
+# in the sourced fixtures file), and reads $pass/$fail (assigned by that
+# same file's assert_eq()). Shellcheck's cross-file dataflow analysis
+# resolves this correctly for all but the LAST assignment of each name in
+# this file — a moving target as scenarios are added/removed — so this is
+# suppressed file-wide rather than chased line-by-line (empirically
+# confirmed: the original, pre-split single file had zero such warnings,
+# since run_guard()'s own reads and every assignment lived in the same
+# file; splitting is what exposed this specific shellcheck limitation).
+# shellcheck disable=SC2034,SC2154
 
 set -euo pipefail
 
-SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
-REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
-GUARD="$REPO_ROOT/scripts/lib/check-container-deps-fresh.sh"
-INNER="$REPO_ROOT/scripts/lib/check-container-deps-fresh-inner.sh"
-REAL_FRESH_CHECK="$REPO_ROOT/scripts/lib/check-node-modules-fresh.sh"
-
-if [ ! -x "$GUARD" ]; then
-  echo "FAIL: $GUARD is not executable"
-  exit 1
-fi
-if [ ! -x "$INNER" ]; then
-  echo "FAIL: $INNER is not executable"
-  exit 1
-fi
-
-fail=0
-pass=0
-
-assert_eq() {
-  local name="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS $name"
-    pass=$((pass + 1))
-  else
-    echo "FAIL $name: expected='$expected' actual='$actual'"
-    fail=$((fail + 1))
-  fi
-}
-
-TMP_ROOT=$(mktemp -d)
-trap 'rm -rf "$TMP_ROOT"' EXIT
-
-NPM_CALL_LOG="$TMP_ROOT/npm-calls.log"
-: > "$NPM_CALL_LOG"
-npm_call_count() { wc -l < "$NPM_CALL_LOG" | tr -d ' '; }
-
-# --- fake docker + npm on PATH -----------------------------------------
-FAKE_BIN="$TMP_ROOT/fake-bin"
-mkdir -p "$FAKE_BIN"
-
-cat > "$FAKE_BIN/docker" <<'DOCKER_EOF'
-#!/usr/bin/env bash
-set -eu
-echo "$*" >> "$FAKE_DOCKER_LOG"
-case "$1" in
-  ps)
-    echo "skillsmith-dev-1"
-    exit 0
-    ;;
-  exec)
-    shift
-    # Strictly validate the production shape:
-    #   -w /app [-e KEY=VALUE ...] <container> sh scripts/lib/check-container-deps-fresh-inner.sh
-    # Any deviation is a test FAILURE (exit 2), not a silent skip — this test
-    # exists partly to catch an accidental future change to how the guard
-    # invokes docker, not just to exercise the lock logic.
-    [ "${1:-}" = "-w" ] || { echo "fake docker: expected -w first, got '${1:-}'" >&2; exit 2; }
-    shift 2
-    while [ "${1:-}" = "-e" ]; do
-      export "${2?fake docker: -e with no value}"
-      shift 2
-    done
-    container="${1:-}"
-    [ -n "$container" ] || { echo "fake docker: missing container name" >&2; exit 2; }
-    shift
-    [ "${1:-}" = "sh" ] || { echo "fake docker: expected 'sh', got '${1:-}'" >&2; exit 2; }
-    script_path="${2:-}"
-    [ "$script_path" = "scripts/lib/check-container-deps-fresh-inner.sh" ] || {
-      echo "fake docker: expected the inner-script path, got '$script_path'" >&2
-      exit 2
-    }
-    [ "$#" -eq 2 ] || { echo "fake docker: unexpected trailing args: $*" >&2; exit 2; }
-    cd "$FAKE_APP_DIR"
-    sh "$script_path"
-    exit $?
-    ;;
-  inspect)
-    exit 0
-    ;;
-  *)
-    exit 1
-    ;;
-esac
-DOCKER_EOF
-chmod +x "$FAKE_BIN/docker"
-
-cat > "$FAKE_BIN/npm" <<EOF
-#!/usr/bin/env bash
-set -eu
-if [ "\${1:-}" = "install" ]; then
-  echo "call" >> "$NPM_CALL_LOG"
-  sleep "\${FAKE_NPM_DELAY:-0}"
-  if [ "\${FAKE_NPM_FAIL:-0}" = "1" ]; then
-    echo "npm ERR! simulated failure" >&2
-    exit 1
-  fi
-  exit 0
-fi
-exit 0
-EOF
-chmod +x "$FAKE_BIN/npm"
-
-export PATH="$FAKE_BIN:$PATH"
-
-# --- helper: a fresh FAKE_APP_DIR (stands in for the container's /app) --
-setup_fake_app_dir() {
-  local dir="$1" hash_state="$2"   # hash_state: fresh|stale|missing
-  rm -rf "$dir"
-  mkdir -p "$dir/scripts/lib" "$dir/node_modules"
-  cp "$REAL_FRESH_CHECK" "$dir/scripts/lib/check-node-modules-fresh.sh"
-  cp "$INNER" "$dir/scripts/lib/check-container-deps-fresh-inner.sh"
-  echo '{"name":"fake"}' > "$dir/package-lock.json"
-  local real_hash
-  real_hash=$(sha256sum "$dir/package-lock.json" | cut -d' ' -f1)
-  case "$hash_state" in
-    fresh)   printf '%s\n' "$real_hash" > "$dir/node_modules/.skillsmith-deps-hash" ;;
-    stale)   printf '%s\n' "0000000000000000000000000000000000000000000000000000000000000000" > "$dir/node_modules/.skillsmith-deps-hash" ;;
-    missing) ;;
-  esac
-}
-
-# --- helper: a plain (non-worktree) real git repo, main-checkout-shaped -
-setup_main_repo() {
-  local dir="$1"
-  rm -rf "$dir"
-  mkdir -p "$dir"
-  ( cd "$dir" && git init -q && git config user.email t@t.com && git config user.name t \
-    && touch f && git add f && git commit -q -m init )
-}
-
-# --- helper: an in-tree worktree of that repo --------------------------
-# Must be a SUBDIRECTORY of main_dir (mirrors this repo's own .worktrees/<name>
-# convention) — hook-docker-detect.sh's compute_container_wd() only resolves
-# CONTAINER_WD="/app" when the worktree's toplevel is main_dir itself or
-# starts with "main_dir/"; a sibling directory is the (different, also-real)
-# OFF-TREE worktree case and takes a different code path entirely.
-setup_worktree() {
-  local main_dir="$1" wt_name="$2"
-  ( cd "$main_dir" && git worktree add -q -b "wt-branch-$$-$wt_name" ".worktrees/$wt_name" >/dev/null 2>&1 )
-}
-
-# NOTE: callers must set FAKE_DOCKER_LOG (a mktemp path) BEFORE invoking this
-# via `rc=$(run_guard ...)` — command substitution forks a subshell, so any
-# variable this function assigned would not survive back to the caller.
-#
-# The guard's own stdout/stderr (colored status text) is redirected to
-# GUARD_LAST_OUTPUT (a file, so `cat` after the call recovers it for
-# debugging) — never mixed into the captured exit code via `$(run_guard ...)`.
-GUARD_LAST_OUTPUT="$TMP_ROOT/guard-last-output.txt"
-run_guard() {
-  local cwd="$1"
-  ( cd "$cwd" && FAKE_DOCKER_LOG="$FAKE_DOCKER_LOG" FAKE_APP_DIR="$FAKE_APP_DIR" \
-      FAKE_NPM_FAIL="${FAKE_NPM_FAIL:-0}" FAKE_NPM_DELAY="${FAKE_NPM_DELAY:-0}" \
-      SKILLSMITH_LOCK_MAX_TRIES="${SKILLSMITH_LOCK_MAX_TRIES:-45}" \
-      SKILLSMITH_LOCK_SLEEP_SECS="${SKILLSMITH_LOCK_SLEEP_SECS:-2}" \
-      "$GUARD" </dev/null >"$GUARD_LAST_OUTPUT" 2>&1 )
-  echo $?
-}
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_lib/check-container-deps-fresh-fixtures.sh
+source "$SELF_DIR/_lib/check-container-deps-fresh-fixtures.sh"
 
 # =========================================================================
 # Scenario 1: fresh container — no npm install call, exits 0
@@ -266,196 +106,62 @@ assert_eq "S4: sentinel NOT rewritten after install failure" "000000000000000000
 assert_eq "S4: lock released after install failure (not wedged)" "no" "$([ -d "$APP4/node_modules/.skillsmith-deps-lock" ] && echo yes || echo no)"
 
 # =========================================================================
-# Scenario 5: lock held by a live PID — waiter fails safely, no npm install
+# Scenario 10 (SMI-6437): self-heal succeeds, but native bindings are
+# broken — must now be a HARD FAILURE, not the old "self-healed" success.
+# This is the regression test proving the fix actually changes behavior.
 # =========================================================================
-MAIN5="$TMP_ROOT/main5"
-APP5="$TMP_ROOT/app5"
-setup_main_repo "$MAIN5"
-setup_fake_app_dir "$APP5" stale
-mkdir -p "$APP5/node_modules/.skillsmith-deps-lock"
-# A live process to be the "owner" — this test script's own PID is alive
-# for the duration of this scenario.
-printf '%s:%s\n' "$$" "$(date +%s)" > "$APP5/node_modules/.skillsmith-deps-lock/owner"
-FAKE_APP_DIR="$APP5"
+MAIN10="$TMP_ROOT/main10"
+APP10="$TMP_ROOT/app10"
+setup_main_repo "$MAIN10"
+setup_fake_app_dir "$APP10" stale
+FAKE_APP_DIR="$APP10"
 FAKE_DOCKER_LOG=$(mktemp)
 : > "$NPM_CALL_LOG"
-SKILLSMITH_LOCK_MAX_TRIES=2
-SKILLSMITH_LOCK_SLEEP_SECS=0
-rc=$(run_guard "$MAIN5")
-SKILLSMITH_LOCK_MAX_TRIES=45
-SKILLSMITH_LOCK_SLEEP_SECS=2
-assert_eq "S5: lock held by live PID -> guard fails (not silently proceeding)" "1" "$rc"
-assert_eq "S5: npm install NOT called while waiting on a live lock" "0" "$(npm_call_count)"
-rm -rf "$APP5/node_modules/.skillsmith-deps-lock"
+SKILLSMITH_NATIVE_CHECK_TEST=fail
+rc=$(run_guard "$MAIN10")
+unset SKILLSMITH_NATIVE_CHECK_TEST
+assert_eq "S10: self-heal succeeds but broken native bindings -> hard failure" "1" "$rc"
+assert_eq "S10: npm install still called exactly once" "1" "$(npm_call_count)"
+assert_eq "S10: output mentions the SMI-6437 native-binding failure" "yes" "$(grep -q "native module bindings are still broken" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
 
 # =========================================================================
-# Scenario 6: lock held by a dead PID — reclaimed, self-heal proceeds
+# Scenario 11 (SMI-6437): self-heal succeeds AND native bindings are
+# healthy — success must be preserved (proves the fix doesn't break the
+# good path).
 # =========================================================================
-MAIN6="$TMP_ROOT/main6"
-APP6="$TMP_ROOT/app6"
-setup_main_repo "$MAIN6"
-setup_fake_app_dir "$APP6" stale
-mkdir -p "$APP6/node_modules/.skillsmith-deps-lock"
-# A definitely-dead PID (a backgrounded subshell, waited on so it's reaped).
-( : ) &
-DEAD_PID=$!
-wait "$DEAD_PID" 2>/dev/null || true
-printf '%s:%s\n' "$DEAD_PID" "$(date +%s)" > "$APP6/node_modules/.skillsmith-deps-lock/owner"
-FAKE_APP_DIR="$APP6"
+MAIN11="$TMP_ROOT/main11"
+APP11="$TMP_ROOT/app11"
+setup_main_repo "$MAIN11"
+setup_fake_app_dir "$APP11" stale
+FAKE_APP_DIR="$APP11"
 FAKE_DOCKER_LOG=$(mktemp)
 : > "$NPM_CALL_LOG"
-rc=$(run_guard "$MAIN6")
-assert_eq "S6: lock held by dead PID is reclaimed, self-heal proceeds" "0" "$rc"
-assert_eq "S6: npm install called exactly once after reclaim" "1" "$(npm_call_count)"
-NEW_HASH6=$(cat "$APP6/node_modules/.skillsmith-deps-hash")
-EXPECTED_HASH6=$(sha256sum "$APP6/package-lock.json" | cut -d' ' -f1)
-assert_eq "S6: sentinel rewritten after reclaim" "$EXPECTED_HASH6" "$NEW_HASH6"
+SKILLSMITH_NATIVE_CHECK_TEST=ok
+rc=$(run_guard "$MAIN11")
+unset SKILLSMITH_NATIVE_CHECK_TEST
+assert_eq "S11: self-heal succeeds and native bindings healthy -> exit 0" "0" "$rc"
+assert_eq "S11: output still shows the existing self-healed message" "yes" "$(grep -q "Self-healed" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
 
 # =========================================================================
-# Scenario 7: two truly concurrent invocations against a stale (no existing
-# lock) tree, synchronized with a BARRIER rather than a hopeful sleep — B is
-# only started once A's own fake npm has recorded that it actually began
-# installing, so this deterministically proves the lock (not scheduling
-# luck) is what keeps B from also installing. Per review: a sleep-based
-# "widen the window" approach could pass even for an unlocked implementation
-# if B merely happened to start after A finished.
+# Scenario 12 (SMI-6437): npm install fails AND native bindings are ALSO
+# broken — the existing npm-failure message must additionally mention the
+# native-binding remediation text.
 # =========================================================================
-MAIN7A="$TMP_ROOT/main7a"
-MAIN7B="$TMP_ROOT/main7b"
-APP7="$TMP_ROOT/app7"
-setup_main_repo "$MAIN7A"
-setup_main_repo "$MAIN7B"
-setup_fake_app_dir "$APP7" stale
-FAKE_APP_DIR="$APP7"
-FAKE_DOCKER_LOG_A=$(mktemp)
-FAKE_DOCKER_LOG_B=$(mktemp)
+MAIN12="$TMP_ROOT/main12"
+APP12="$TMP_ROOT/app12"
+setup_main_repo "$MAIN12"
+setup_fake_app_dir "$APP12" stale
+FAKE_APP_DIR="$APP12"
+FAKE_DOCKER_LOG=$(mktemp)
 : > "$NPM_CALL_LOG"
-FAKE_NPM_DELAY=2   # A stays "inside" the install long enough for B to attempt entry
-
-LOG_A="$TMP_ROOT/s7-a.rc"
-LOG_B="$TMP_ROOT/s7-b.rc"
-( cd "$MAIN7A" && FAKE_APP_DIR="$APP7" FAKE_DOCKER_LOG="$FAKE_DOCKER_LOG_A" FAKE_NPM_DELAY="$FAKE_NPM_DELAY" "$GUARD" </dev/null; echo $? > "$LOG_A" ) &
-PID_A=$!
-
-# Barrier: block here until A's fake npm has actually recorded a call —
-# proves B starts DURING A's install, not merely "probably around the same
-# time". 10s cap so a genuine regression fails the test instead of hanging.
-barrier_tries=0
-while [ ! -s "$NPM_CALL_LOG" ] && [ "$barrier_tries" -lt 100 ]; do
-  sleep 0.1
-  barrier_tries=$((barrier_tries + 1))
-done
-assert_eq "S7: barrier — A's install actually started before B launches" "yes" "$([ -s "$NPM_CALL_LOG" ] && echo yes || echo no)"
-
-( cd "$MAIN7B" && FAKE_APP_DIR="$APP7" FAKE_DOCKER_LOG="$FAKE_DOCKER_LOG_B" FAKE_NPM_DELAY="$FAKE_NPM_DELAY" "$GUARD" </dev/null; echo $? > "$LOG_B" ) &
-PID_B=$!
-wait "$PID_A" "$PID_B"
-FAKE_NPM_DELAY=0
-RC_A=$(cat "$LOG_A"); RC_B=$(cat "$LOG_B")
-assert_eq "S7: invocation A exits 0" "0" "$RC_A"
-assert_eq "S7: invocation B exits 0" "0" "$RC_B"
-assert_eq "S7: npm install called exactly once despite B starting mid-install" "1" "$(npm_call_count)"
-
-# =========================================================================
-# Scenario 8: two waiters observe the SAME dead-owner lock and race to
-# reclaim it, while a fresh acquirer may slip in between — this is the
-# multi-reclaimer TOCTOU this design's RECLAIM_DIR mutex exists to close.
-# Deterministic guarantee is weaker than Scenario 7 (no barrier point exists
-# mid-mkdir to synchronize on), but two processes launched back-to-back
-# against the same pre-seeded dead lock reliably contend for the SAME
-# reclaim window in practice — the assertion that matters is that exactly
-# ONE self-heal (one npm install) ever results, never zero, never more than
-# one, and never a corrupted lock state that hangs both.
-# =========================================================================
-MAIN8A="$TMP_ROOT/main8a"
-MAIN8B="$TMP_ROOT/main8b"
-APP8="$TMP_ROOT/app8"
-setup_main_repo "$MAIN8A"
-setup_main_repo "$MAIN8B"
-setup_fake_app_dir "$APP8" stale
-mkdir -p "$APP8/node_modules/.skillsmith-deps-lock"
-( : ) &
-DEAD_PID8=$!
-wait "$DEAD_PID8" 2>/dev/null || true
-printf '%s:0\n' "$DEAD_PID8" > "$APP8/node_modules/.skillsmith-deps-lock/owner"
-FAKE_APP_DIR="$APP8"
-: > "$NPM_CALL_LOG"
-
-LOG_8A="$TMP_ROOT/s8-a.rc"
-LOG_8B="$TMP_ROOT/s8-b.rc"
-( cd "$MAIN8A" && FAKE_APP_DIR="$APP8" FAKE_DOCKER_LOG="$(mktemp)" "$GUARD" </dev/null; echo $? > "$LOG_8A" ) &
-PID_8A=$!
-( cd "$MAIN8B" && FAKE_APP_DIR="$APP8" FAKE_DOCKER_LOG="$(mktemp)" "$GUARD" </dev/null; echo $? > "$LOG_8B" ) &
-PID_8B=$!
-wait "$PID_8A" "$PID_8B"
-RC_8A=$(cat "$LOG_8A"); RC_8B=$(cat "$LOG_8B")
-assert_eq "S8: invocation A exits 0" "0" "$RC_8A"
-assert_eq "S8: invocation B exits 0" "0" "$RC_8B"
-assert_eq "S8: exactly one self-heal resulted from the dead-lock reclaim race" "1" "$(npm_call_count)"
-assert_eq "S8: no lock left behind after both finish" "no" "$([ -d "$APP8/node_modules/.skillsmith-deps-lock" ] && echo yes || echo no)"
-
-# =========================================================================
-# Scenario 9: ownership-token unit test — sources check-container-deps-fresh-inner.sh
-# directly (SKILLSMITH_LOCK_TEST_SOURCE=1 skips its main flow, leaving
-# acquire()/release()/try_reclaim() defined) and calls release() with a
-# STALE token against a lock a DIFFERENT token has since legitimately
-# re-acquired. No docker/npm/subshells involved — this is a pure unit test
-# of the exact property the PID+nonce token exists to guarantee: release()
-# must only ever remove a lock whose owner file still names ITS OWN token.
-# =========================================================================
-APP9="$TMP_ROOT/app9"
-rm -rf "$APP9"
-mkdir -p "$APP9/node_modules"
-(
-  cd "$APP9" || exit 1
-  # shellcheck disable=SC2034  # read by the sourced INNER file, which shellcheck can't statically follow (dynamic path)
-  SKILLSMITH_LOCK_TEST_SOURCE=1
-  # shellcheck source=/dev/null
-  . "$INNER"
-
-  mkdir -p node_modules/.skillsmith-deps-lock
-  # A DIFFERENT holder's token — simulates "someone else has since
-  # legitimately reclaimed and re-acquired this lock" (MY_TOKEN, from this
-  # sourced instance, was never the one that wrote it).
-  echo "999999:someone-elses-nonce" > node_modules/.skillsmith-deps-lock/owner
-
-  release   # must be a no-op: MY_TOKEN != the file's content
-
-  if [ -f node_modules/.skillsmith-deps-lock/owner ] && \
-     [ "$(cat node_modules/.skillsmith-deps-lock/owner)" = "999999:someone-elses-nonce" ]; then
-    echo PASS
-  else
-    echo FAIL
-  fi
-) > "$TMP_ROOT/s9-result.txt" 2>&1
-S9_RESULT=$(tail -1 "$TMP_ROOT/s9-result.txt")
-assert_eq "S9: release() never removes a lock it does not own (ownership-token check)" "PASS" "$S9_RESULT"
-
-# Sanity check the SAME unit-test seam correctly removes a lock it DOES own —
-# proves S9 above is testing the real guard, not a seam that always no-ops.
-APP9B="$TMP_ROOT/app9b"
-rm -rf "$APP9B"
-mkdir -p "$APP9B/node_modules"
-(
-  cd "$APP9B" || exit 1
-  # shellcheck disable=SC2034  # read by the sourced INNER file, which shellcheck can't statically follow (dynamic path)
-  SKILLSMITH_LOCK_TEST_SOURCE=1
-  # shellcheck source=/dev/null
-  . "$INNER"
-
-  mkdir -p node_modules/.skillsmith-deps-lock
-  printf "%s\n" "$MY_TOKEN" > node_modules/.skillsmith-deps-lock/owner
-
-  release
-
-  if [ ! -e node_modules/.skillsmith-deps-lock ]; then
-    echo PASS
-  else
-    echo FAIL
-  fi
-) > "$TMP_ROOT/s9b-result.txt" 2>&1
-S9B_RESULT=$(tail -1 "$TMP_ROOT/s9b-result.txt")
-assert_eq "S9b: release() DOES remove a lock it owns (seam sanity check)" "PASS" "$S9B_RESULT"
+FAKE_NPM_FAIL=1
+SKILLSMITH_NATIVE_CHECK_TEST=fail
+rc=$(run_guard "$MAIN12")
+FAKE_NPM_FAIL=0
+unset SKILLSMITH_NATIVE_CHECK_TEST
+assert_eq "S12: npm install failure still exits non-zero" "1" "$rc"
+assert_eq "S12: output additionally mentions native bindings ALSO broken" "yes" "$(grep -q "ALSO currently broken" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
+assert_eq "S12: output still names the restart remedy" "yes" "$(grep -q "docker compose --profile dev restart dev" "$GUARD_LAST_OUTPUT" && echo yes || echo no)"
 
 echo ""
 echo "======================================"


### PR DESCRIPTION
## Business Summary

**What shipped:** the dev-container dependency self-heal (`skillsmith-dev-1`'s auto-`npm install` on push) now checks that native SQLite bindings actually work before letting a push through — either right after it declares success, or right after it fails. Previously, neither outcome checked this, so a broken binding from a failed self-heal could sit undetected until a completely unrelated later push happened to trip over it.

**Quality bar:** plan reviewed by GPT-5.6-Sol (cross-provider, via NEEDLE/ADR-128) before implementation; every finding independently re-verified against the live repo, not accepted on the reviewer's word alone. 35 test assertions across two test files, all passing against the real production scripts (fake Docker/npm, real lock/install logic).

**Found along the way:** the existing test file for this mechanism (`check-container-deps-fresh.test.sh`) had grown to 464 of the repo's 500-line limit; split into a shared fixture file plus a sibling test file for the lock-contention scenarios, following the existing `needle-dispatch-fixtures.sh` precedent — not filed separately, since it was a direct blocker for adding this PR's own test coverage.

**Net result:** fully shipped, no follow-up.

---

## Technical detail

**Root cause** (full writeup: `docs/internal/implementation/smi-6437-container-self-heal-native-verify.md`): a routine Dependabot bump (`@ruvector/core` 0.1.30→0.1.32) triggered the self-heal's `npm install`, which hit `EACCES` on a rename of a platform-mismatched optional dependency (`ruvector-core-linux-x64-gnu`, x64-only, on this arm64 container). The failed install left `packages/core/node_modules/better-sqlite3` broken (confirmed via a real functional test, not `require.resolve`). Ownership/ACL causes are ruled out with direct evidence; the exact EACCES trigger recurred once more, independently, on the same path during this investigation, and self-corrected on retry both times.

**Fix**: `scripts/lib/check-container-deps-fresh.sh` now invokes the existing native-module probe (`check-native-modules.sh`, SMI-5513, reused as-is) on both self-heal outcome paths:
- Success (`RC=0`, self-heal ran): a broken binding is now a hard failure instead of a silent "Self-healed" pass.
- Failure (`RC=4`, npm install itself failed): the existing error message now additionally names the restart remedy if bindings are also broken.

**Files**:
- `scripts/lib/check-container-deps-fresh.sh` — the two new call sites
- `scripts/tests/check-container-deps-fresh.test.sh` — trimmed to Scenarios 1-4 + 3 new native-probe scenarios
- `scripts/tests/check-container-deps-fresh-lock.test.sh` — new; Scenarios 5-9 (lock contention) moved here
- `scripts/tests/_lib/check-container-deps-fresh-fixtures.sh` — new; shared test setup
- `.github/workflows/validate-hooks.yml` — registers the two new test files
- `docs/internal/process/guards-and-opt-outs.md` — `SKILLSMITH_SKIP_NATIVE_CHECK` row updated to cover the new call sites

**CI note**: no new opt-out variable — `SKILLSMITH_SKIP_NATIVE_CHECK` (existing) silences the probe at both the original and new call sites.
