### PR TITLE
fix(indexer): SMI-6436 -- bundle_absent no longer masks real verdict deltas

### DIFF
--- a/scripts/indexer/smi5879-gate-check.helpers.ts
+++ b/scripts/indexer/smi5879-gate-check.helpers.ts
@@ -218,9 +218,9 @@ export function computeR(rows: readonly SimRowResult[]): SimRowResult[] {
 /**
  * The five scoring outcomes that carry `prePortRiskScore`/`postPortRiskScore`
  * — verified against `smi5879-simulate-full.helpers.ts`'s `processRow`:
- * `bundle_absent` (lines ~316-326) and the final `classifyVerdictDelta`
+ * `bundle_absent` (lines ~399-407) and the final `classifyVerdictDelta`
  * branch (unchanged_clean/unchanged_quarantined/newly_quarantined/
- * newly_cleared, ~328-335) are the ONLY paths that populate the score
+ * newly_cleared, ~410-417) are the ONLY paths that populate the score
  * fields. `unevaluable`/`unfetchable`/`content_drifted` all return early
  * before scoring and never carry them.
  */

--- a/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
+++ b/scripts/indexer/smi5879-merge-shards.outcome-coherence.ts
@@ -52,10 +52,18 @@ import { MAX_IDS_IN_ERROR } from './smi5879-merge-shards.merge-rules.ts'
 /**
  * The four "verdict-delta" outcomes — the only ones `classifyVerdictDelta`
  * (`smi5879-simulate-full.helpers.ts`) ever produces. `bundle_absent` also
- * carries `prePortQuarantine`/`postPortQuarantine` but is NOT one of these:
- * its outcome label is deliberately overridden past whatever those booleans
- * would classify to (`processRow`'s `isBundleAbsent` branch), so checking it
- * here would flag a correct row as a false positive.
+ * carries `prePortQuarantine`/`postPortQuarantine` but is NOT one of these —
+ * it is checked separately by {@link assertBundleAbsentCoherence} below.
+ *
+ * SMI-6436: prior to that fix, `processRow` checked `isBundleAbsent` BEFORE
+ * computing the verdict delta, so a `bundle_absent` row's outcome label was
+ * unconditionally overridden regardless of whether the delta was a real
+ * change — this comment used to say checking `bundle_absent` here "would
+ * flag a correct row as a false positive" on that basis. That is no longer
+ * true: post-fix, `processRow` only emits `bundle_absent` when the delta is
+ * `unchanged_clean`/`unchanged_quarantined`, so a `bundle_absent` row's own
+ * `prePortQuarantine`/`postPortQuarantine` must always agree — a real
+ * invariant, not a false-positive risk.
  */
 const VERDICT_DELTA_OUTCOMES: readonly SimRowOutcome[] = [
   'newly_quarantined',
@@ -202,6 +210,48 @@ export function assertRowOutcomeCoherence(rows: readonly SimRowResult[]): void {
         'are derived directly from the outcome label — a row whose label disagrees with its own ' +
         'quarantine fields would corrupt both without any coverage/count arithmetic ever detecting it. ' +
         'Refusing to merge a shard report containing an internally-inconsistent row.'
+    )
+  }
+}
+
+/**
+ * SMI-6436: assert every merged `bundle_absent` row's own quarantine
+ * booleans actually agree with a non-change — `prePortQuarantine ===
+ * postPortQuarantine`. Post-fix, `processRow` only ever emits
+ * `bundle_absent` when `classifyVerdictDelta` already resolved to
+ * `unchanged_clean`/`unchanged_quarantined`; a `bundle_absent` row whose
+ * booleans disagree would mean a real verdict flip got mislabeled and
+ * silently dropped from G-1's review set and G-3's `newly_quarantined`/
+ * `newly_cleared` counts — exactly the bug class SMI-6436 fixed. Mirrors
+ * {@link assertRowOutcomeCoherence}'s shape but for the one outcome that
+ * function deliberately excludes.
+ */
+export function assertBundleAbsentCoherence(rows: readonly SimRowResult[]): void {
+  const mismatches: string[] = []
+  for (const row of rows) {
+    if (row.outcome !== 'bundle_absent') continue
+    if (row.prePortQuarantine === undefined || row.postPortQuarantine === undefined) {
+      mismatches.push(
+        `${row.id} (outcome=bundle_absent but prePortQuarantine/postPortQuarantine is missing)`
+      )
+      continue
+    }
+    if (row.prePortQuarantine !== row.postPortQuarantine) {
+      mismatches.push(
+        `${row.id} (outcome=bundle_absent, but prePortQuarantine=${row.prePortQuarantine}/` +
+          `postPortQuarantine=${row.postPortQuarantine} is a real verdict change, not a non-change)`
+      )
+    }
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `SMI-6436: ${mismatches.length} row(s) are labeled bundle_absent but their own ` +
+        `prePortQuarantine/postPortQuarantine fields show a real verdict change: ` +
+        `${mismatches.slice(0, MAX_IDS_IN_ERROR).join('; ')}` +
+        `${mismatches.length > MAX_IDS_IN_ERROR ? ', ...' : ''}. bundle_absent must only be used for a ` +
+        'non-change (unchanged_clean/unchanged_quarantined) — a row like this would hide a real ' +
+        "newly_quarantined/newly_cleared delta from G-1's review set and G-3's counts. Refusing to " +
+        'merge a shard report containing an internally-inconsistent row.'
     )
   }
 }

--- a/scripts/indexer/smi5879-merge-shards.ts
+++ b/scripts/indexer/smi5879-merge-shards.ts
@@ -65,6 +65,7 @@ import {
   type ShardReportInput,
 } from './smi5879-merge-shards.merge-rules.ts'
 import {
+  assertBundleAbsentCoherence,
   assertRowOutcomeCoherence,
   assertRowOutcomeFieldPresence,
 } from './smi5879-merge-shards.outcome-coherence.ts'
@@ -208,6 +209,7 @@ export async function runMergeShards(
   // only needs to worry about the four outcomes it's scoped to.
   assertRowOutcomeFieldPresence(mergedRows)
   assertRowOutcomeCoherence(mergedRows)
+  assertBundleAbsentCoherence(mergedRows)
 
   const { population, summary } = await loadVerifiedPopulation(db, args.runId)
   assertReportsBindToGeneration(identity, args.runId, summary)

--- a/scripts/indexer/smi5879-simulate-full.helpers.ts
+++ b/scripts/indexer/smi5879-simulate-full.helpers.ts
@@ -384,7 +384,15 @@ export async function processRow(
   const preVerdict = effectiveVerdict(prePortResult)
   const postVerdict = effectiveVerdict(postPortResult)
 
-  if (isBundleAbsent(postPortResult)) {
+  // SMI-6436: classify the delta FIRST — bundle_absent only replaces a
+  // non-change (unchanged_clean/unchanged_quarantined), never a real delta.
+  // The pre-fix order (isBundleAbsent before this) masked real flips.
+  const delta = classifyVerdictDelta(preVerdict.quarantine, postVerdict.quarantine)
+
+  if (
+    (delta === 'unchanged_clean' || delta === 'unchanged_quarantined') &&
+    isBundleAbsent(postPortResult)
+  ) {
     return {
       ...base,
       outcome: 'bundle_absent',
@@ -398,7 +406,7 @@ export async function processRow(
 
   return {
     ...base,
-    outcome: classifyVerdictDelta(preVerdict.quarantine, postVerdict.quarantine),
+    outcome: delta,
     prePortQuarantine: preVerdict.quarantine,
     postPortQuarantine: postVerdict.quarantine,
     prePortRiskScore: preVerdict.riskScore,

--- a/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
@@ -207,6 +207,16 @@ describe('processRow — tier-2 outcome classification', () => {
     expect(result.postPortQuarantine).toBe(false)
   })
 
+  it('SMI-6436: bundle_absent still fires for a non-change when both scans are quarantined (not just both clean)', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const scanner = makeBundleAbsentScanner(DIRTY_RISK)
+    const result = await processRow(row, new Map(), baseDeps(scanner, scanner))
+    expect(result.outcome).toBe('bundle_absent')
+    expect(result.prePortQuarantine).toBe(true)
+    expect(result.postPortQuarantine).toBe(true)
+  })
+
   // SMI-6436 regression: empty sibling scope (bundle_absent-eligible) must
   // NOT mask a real verdict delta. Prior to the fix, `isBundleAbsent` was
   // checked before `classifyVerdictDelta`, so both of these rows would have

--- a/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
@@ -207,6 +207,33 @@ describe('processRow — tier-2 outcome classification', () => {
     expect(result.postPortQuarantine).toBe(false)
   })
 
+  // SMI-6436 regression: empty sibling scope (bundle_absent-eligible) must
+  // NOT mask a real verdict delta. Prior to the fix, `isBundleAbsent` was
+  // checked before `classifyVerdictDelta`, so both of these rows would have
+  // been misclassified `bundle_absent` instead of their real delta.
+
+  it('SMI-6436: newly_quarantined even with empty sibling scope (bundle_absent must not mask a real delta)', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const postPort = makeBundleAbsentScanner(DIRTY_RISK)
+    const prePort = makeBundleAbsentScanner(CLEAN_RISK)
+    const result = await processRow(row, new Map(), baseDeps(postPort, prePort))
+    expect(result.outcome).toBe('newly_quarantined')
+    expect(result.prePortQuarantine).toBe(false)
+    expect(result.postPortQuarantine).toBe(true)
+  })
+
+  it('SMI-6436: newly_cleared even with empty sibling scope (bundle_absent must not mask a real delta)', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const postPort = makeBundleAbsentScanner(CLEAN_RISK)
+    const prePort = makeBundleAbsentScanner(DIRTY_RISK)
+    const result = await processRow(row, new Map(), baseDeps(postPort, prePort))
+    expect(result.outcome).toBe('newly_cleared')
+    expect(result.prePortQuarantine).toBe(true)
+    expect(result.postPortQuarantine).toBe(false)
+  })
+
   it('newly_quarantined: pre-port clean, post-port quarantined', async () => {
     const row = makeRow()
     registerPrimary(row, [contentsApiResponse('# SKILL')])


### PR DESCRIPTION
## Business Summary

**What shipped:** The SMI-6015 census tool was undercounting real skill quarantine-status changes by about 20x — 83 rows that genuinely flipped quarantine status got bucketed into a harmless "no sibling files" category instead. Fixed the classification order so a real status change is never masked, and added a permanent check so this can't recur silently.

**Quality bar:** Plan reviewed through 4 rounds of adversarial review before implementation. Full test suite green (18,782 tests), typecheck/lint/audit:standards clean. A self-run governance pass on the finished diff found one test-coverage gap and fixed it in the same PR.

**Found along the way:** an unrelated pre-push tooling bug (the repo-wide Prettier check OOMs on this container's default heap) — filed separately as SMI-6439, not bundled into this PR.

**Net result:** Fully shipped. `pr-reviewer`'s 14-check gate still needs to run before merge.

---

## Technical detail

**Root cause**: `processRow` (`scripts/indexer/smi5879-simulate-full.helpers.ts`) checked `isBundleAbsent` before computing the verdict delta, so any row with empty sibling-file scope got labeled `bundle_absent` even when it had genuinely flipped quarantine status. Confirmed against the completed SMI-6015 decision-purpose census run (416,119 rows): 83 rows were affected, undercounting `newly_quarantined`/`newly_cleared` from 87 real deltas to 4 reported.

**Fix**: reorder so `classifyVerdictDelta` runs first; `bundle_absent` now only substitutes for a non-change delta (`unchanged_clean`/`unchanged_quarantined`), never a real one.

**New guard**: `assertBundleAbsentCoherence` (new export in `smi5879-merge-shards.outcome-coherence.ts`, wired into `smi5879-merge-shards.ts`) makes the invariant permanent — a merged `bundle_absent` row's own `prePortQuarantine`/`postPortQuarantine` must always agree.

**Tests**: three new cases in `smi5879-simulate-full.classification.test.ts` — a real delta in each direction surviving empty sibling scope, plus a governance-found gap (both scans quarantined + empty sibling scope must still report `bundle_absent`, not `unchanged_quarantined`).

**Adjacent fix**: corrected a stale line-number citation in `smi5879-gate-check.helpers.ts` in the same touched region.

**Behavior change reviewers should know about**: `R_OUTCOMES` (`gate-check.helpers.ts:208`) is `['newly_quarantined', 'newly_cleared']` only — `bundle_absent` rows were fully exempt from Gate G-1's hand-review set. After this fix, any future run's reclassified rows enter that review set and need an explicit disposition before G-1 can pass. This is the intended effect of the fix, not a defect.

**Plan doc**: `docs/internal/implementation/smi-6436-bundle-absent-classification-fix.md`

**Verification**: `docker exec` typecheck/lint/audit:standards all clean (7 pre-existing audit warnings, none touching this diff); full suite 18,782 passed / 0 failed; Prettier clean on the 5 touched files (the repo-wide `format:check` independently OOMs in this container regardless of diff content — see SMI-6439).

Linear: SMI-6436 (parented under SMI-6015).
