### PR TITLE
fix(website): SMI-6428 -- skills-page results-region ownership race

### DIFF
--- a/.claude/templates/implementation-plan.md
+++ b/.claude/templates/implementation-plan.md
@@ -109,13 +109,14 @@ If a SMOKE test cannot fire automatically post-deploy, name the human runner and
 
 ## Shared-State / Coordination Audit (P-5)
 
-_Required when the plan touches any of: browser/Node globals (window.\*, module singletons); event listeners on shared targets (`document`, `window`, broadcast channels, postMessage, signals); caches keyed by computed values (in-memory Map, Redis, KV, file-system caches); row-shape extensions (new column, new field on an interface with multiple persisters); new async producers feeding existing async consumers (or vice versa)._
+_Required when the plan touches any of: browser/Node globals (window.\*, module singletons); event listeners on shared targets (`document`, `window`, broadcast channels, postMessage, signals); caches keyed by computed values (in-memory Map, Redis, KV, file-system caches); row-shape extensions (new column, new field on an interface with multiple persisters); new async producers feeding existing async consumers (or vice versa); async chains whose completion callback writes shared UI/render state that a separately-triggered handler also writes (SMI-6428)._
 
 For each piece of shared mutable state introduced or extended:
 
 | State | Producers (file:line) | Consumers (file:line) | Coordination invariant | Test |
 |-------|------------------------|------------------------|------------------------|------|
 | Example: `window.__SUPABASE_CLIENT__` | `BaseLayout.astro:136` (eager init) + `supabase-client.ts:24` (lazy fallback) | `LoginButton.astro:247`, `callback.astro:*`, `device.astro:*` | Every consumer reads via `getSupabaseClient()`, not the raw global; lazy-init guarantees a client exists for the consumer's tick. | `LoginButton.test.ts` covers cold-load case |
+| Example: skills-page results region (`showState()` + `#results-count`) | `skills/index.astro:916` (init chain terminal write) + `:593`, `:636`, `:692`, `:778`, `:824` (searchSkills paths) | same functions; `skills-filter.spec.ts:24` `waitForResults` | Exactly one logical owner per page load: every `searchSkills()` entry advances `resultsGeneration`; any write after an `await` re-checks it; the init chain's featured write runs only when no query/filter intent is live. | `skills-filter.spec.ts` SMI-6428 describe (delayed-fetch stomp repro) |
 
 **Producers** are every write site, found via `grep -rn` against the codebase — not from memory. **Consumers** are every read site. The **coordination invariant** is one sentence stating the rule that must hold. The **test** is a specific case (file:test-name), not "tests pass".
 
@@ -136,7 +137,7 @@ If the audit surfaces a producer/consumer pair without an explicit invariant, **
 - [ ] Surface grounding (P-1, P-2): every cross-surface reference has a canonical source + verification command
 - [ ] PL/pgSQL name-collision audit (P-3) completed _if_ plan touches a `RETURNS TABLE` function
 - [ ] Smoke path (P-4) specified and run post-deploy (or `scripts/smoke-prod.sh` invoked once it exists)
-- [ ] Shared-state audit (P-5) completed _if_ plan touches browser/Node globals, event listeners on shared targets, computed-key caches, row-shape extensions, or new async producer/consumer pairs
+- [ ] Shared-state audit (P-5) completed _if_ plan touches browser/Node globals, event listeners on shared targets, computed-key caches, row-shape extensions, new async producer/consumer pairs, or async chains whose completion callback writes shared UI/render state that a separately-triggered handler also writes
 - [ ] If this plan includes a genuine architecture decision (not just an implementation detail), flag it and confirm whether it warrants its own `docs/internal/adr/` entry — `plan-review-skill`'s VP Engineering rubric checks for this (standing rule since 2026-08-24, see CLAUDE.md § Infrastructure Change Policy)
 - [ ] **If this change targets a non-Docker CI workflow** (e.g. `post-merge-verify.yml`,
       any workflow running on `ubuntu-latest` without the Docker dev container):

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -449,7 +449,13 @@ const breadcrumbSchema = {
     // Use astro:page-load for View Transitions compatibility (fires on both initial load and client-side navigation).
     // Bundled ES module evaluates once, so this binds exactly one listener; the early-bail below
     // (search-input existence) is the state guard for the handler body across ClientRouter navigations.
-    // audit:concurrency-ok — single bind (module evals once) + early-bail state guard on the handler body
+    // SMI-6428: the bind is only half the concurrency story — the handler body's own
+    // terminal write (initAuth() -> loadFeaturedSkills() -> showState('search-prompt'))
+    // targets the same results region searchSkills() writes, and the two resolve in
+    // whatever order the network decides. The `resultsGeneration` ownership counter
+    // declared below is the guard for that second half.
+    // audit:concurrency-ok — single bind (module evals once) + early-bail state guard on the
+    // handler body + resultsGeneration ownership guard on the shared results region (SMI-6428)
     document.addEventListener('astro:page-load', () => {
       // Document-level listeners persist across ClientRouter navigations. When the user
       // navigates /skills → /skills/[id] (or any non-/skills page), this handler still
@@ -530,6 +536,18 @@ const breadcrumbSchema = {
       let allResults: WireSkill[] = []
       let debounceTimer: ReturnType<typeof setTimeout> | undefined
 
+      // SMI-6428: results-region ownership generation. Every user-initiated
+      // searchSkills() call claims the shared region (#results-grid /
+      // #loading-state / #empty-state / #error-state / #search-prompt-state
+      // visibility + #results-count text) by advancing this. Any write that
+      // follows an `await` must re-check it before touching that state.
+      // Same shape as createNavigationEpochGuard() (SMI-6112,
+      // src/lib/account-navigation-epoch.ts) but scoped to same-page-load
+      // ownership rather than navigation — that module's counter only advances
+      // on astro:before-swap/astro:page-load, so it would never fire for a
+      // filter change within one page load. See D-1 in the plan.
+      let resultsGeneration = 0
+
       // DOM Elements
       const searchInput = document.getElementById('search-input') as HTMLInputElement
       const categoryFilter = document.getElementById('category-filter') as HTMLSelectElement
@@ -580,6 +598,19 @@ const breadcrumbSchema = {
 
       // Search skills
       async function searchSkills() {
+        const gen = ++resultsGeneration
+        // Claiming ownership tears down anything a previous owner left running —
+        // otherwise a superseded search's rate-limit countdown keeps mutating a
+        // button the new search no longer controls (GPT-5.6-Sol plan-review
+        // finding #3). `delete` rather than `= undefined`: tsconfig.json sets
+        // exactOptionalPropertyTypes, under which assigning undefined to the
+        // optional `Window._rateLimitInterval` (env.d.ts:56) is a type error —
+        // this matches the existing teardown in the 429 branch below.
+        if (window._rateLimitInterval) {
+          clearInterval(window._rateLimitInterval)
+          delete window._rateLimitInterval
+        }
+
         const query = searchInput.value.trim()
         const category = categoryFilter.value
         const trustTier = trustFilter.value
@@ -621,6 +652,11 @@ const breadcrumbSchema = {
             },
           })
           clearTimeout(timeoutId)
+          // SMI-6428 guard 1/4. Placed AFTER clearTimeout so the abort timer is
+          // always torn down even for a superseded search, and BEFORE any state
+          // mutation — it covers the 401 branch's error-DOM writes, the 429
+          // branch's entry, and the quota-banner writes below.
+          if (gen !== resultsGeneration) return
 
           if (response.status === 401) {
             // Trial limit exceeded — show friendly CTA instead of generic error
@@ -641,6 +677,10 @@ const breadcrumbSchema = {
           // SMI-3589: Rate limit exceeded — show friendly countdown instead of generic error
           if (response.status === 429) {
             const retryData = await response.json().catch(() => ({}))
+            // SMI-6428 guard 2/4. A superseded 429 response must not install a
+            // live countdown interval or repaint the retry button — the new
+            // owner already cleared the previous interval when it claimed.
+            if (gen !== resultsGeneration) return
             // SMI-3664: Suppress global toast — this page handles 429 inline
             if (typeof window.hideRateLimitToast === 'function') {
               window.hideRateLimitToast()
@@ -725,6 +765,11 @@ const breadcrumbSchema = {
           }
 
           const data = await response.json()
+          // SMI-6428 guard 3/4 (success path). Placed before the `allResults`
+          // assignment so a superseded response never overwrites the current
+          // owner's result set, org-boost ordering, gtag event, sort, page
+          // reset, or rendered grid.
+          if (gen !== resultsGeneration) return
           allResults = (data.data || data.skills || data.results || []) as WireSkill[]
 
           // SMI-4401 Wave 2 A-M9-2: signal-boost — surface skills whose topics or author
@@ -770,6 +815,10 @@ const breadcrumbSchema = {
           renderResults()
         } catch (error) {
           clearTimeout(timeoutId)
+          // SMI-6428 guard 4/4. A superseded search's abort/network error must
+          // not paint the error state over the current owner's results. Again
+          // after clearTimeout so the timer is torn down unconditionally.
+          if (gen !== resultsGeneration) return
           console.error('Search error:', error)
           const isTimeout = (error as Error).name === 'AbortError'
           errorMessage.textContent = isTimeout
@@ -911,8 +960,34 @@ const breadcrumbSchema = {
       }
 
       // SMI-2081 + SMI-4838: Initialize auth, load featured examples, then show featured state.
+      // SMI-6428: this chain's terminal write targets the SAME shared region
+      // searchSkills() owns, at a time neither side controls. Capture the
+      // ownership generation before the first await; at the end, re-read the
+      // live controls (they are the ground truth for user intent) and never
+      // overwrite an active search with the featured state.
+      const initGen = resultsGeneration
       initAuth().then(async () => {
         await loadFeaturedSkills()
+        const hasQuery = searchInput.value.trim().length >= MIN_QUERY_LENGTH
+        const hasFilter = Boolean(categoryFilter.value || trustFilter.value)
+        if (hasQuery || hasFilter) {
+          // The user expressed a search intent since page load. If the generation
+          // is unchanged, no searchSkills() call has actually STARTED for it yet.
+          // That covers two cases: (a) the change/input listeners hadn't attached
+          // when the control changed, so the intent was dropped entirely; (b) a
+          // debounced input search is still armed (debounceTimer pending, ~400ms
+          // out) but hasn't fired. Either way, clear any pending debounce and
+          // dispatch immediately — GPT-5.6-Sol plan-review flagged that leaving
+          // the timer armed here lets it fire a SECOND, redundant searchSkills()
+          // call ~400ms later; the resultsGeneration guards make that safe (not
+          // corrupting), but it's a wasted duplicate fetch worth eliminating
+          // outright rather than merely tolerating.
+          if (resultsGeneration === initGen) {
+            clearTimeout(debounceTimer)
+            void searchSkills()
+          }
+          return
+        }
         showState('search-prompt')
         resultsCount.textContent = 'Showing featured examples'
       })

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -609,6 +609,16 @@ const breadcrumbSchema = {
         if (window._rateLimitInterval) {
           clearInterval(window._rateLimitInterval)
           delete window._rateLimitInterval
+          // SMI-6428 confirmation review (round 2, finding F-1): the countdown
+          // this cancels is the ONLY code path that ever re-enables this button
+          // (see the 429 branch below). Cancelling it without restoring the
+          // terminal state it would have reached strands the button reading
+          // "Retry in Ns" and disabled forever, on ANY later error state — not
+          // just another 429. Restore what the countdown's own zero-case sets.
+          if (retryButton) {
+            retryButton.textContent = 'Try Again'
+            retryButton.disabled = false
+          }
         }
 
         const query = searchInput.value.trim()

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -834,6 +834,19 @@ const breadcrumbSchema = {
           errorMessage.textContent = isTimeout
             ? 'Request timed out. Please try again.'
             : (error as Error).message
+          // SMI-6428 confirmation review (round 3, finding 2): the 401 and 429
+          // branches above decorate this same #error-state region (heading text,
+          // icon visibility, retry-button visibility) and nothing ever reverted
+          // it — a generic error following either one rendered under a stale
+          // "You're on a roll!"/"Slow down a moment" heading, no icon, and (for
+          // 401) no retry button at all. Pre-existing on main, unrelated to the
+          // race fix, but this PR already owns this error-state machinery.
+          // Restore the static markup's defaults before painting a generic error.
+          const errorHeading = errorState.querySelector('h2')
+          const errorIcon = errorState.querySelector('svg')
+          if (errorHeading) errorHeading.textContent = 'Error loading skills'
+          if (errorIcon) errorIcon.classList.remove('hidden')
+          if (retryButton) retryButton.classList.remove('hidden')
           showState('error')
           resultsCount.textContent = 'Error'
         }

--- a/packages/website/tests/e2e/skills-filter.spec.ts
+++ b/packages/website/tests/e2e/skills-filter.spec.ts
@@ -76,6 +76,19 @@ test.describe('Skills Filter-Only Browsing (SMI-1658)', () => {
         /* localStorage unavailable — overlay suppression falls back to the race */
       }
     })
+    // SMI-6428 confirmation review (round 2, finding F-3): the readiness barrier
+    // below waits on loadFeaturedSkills()'s terminal write, and that function has
+    // no AbortController/timeout of its own -- it issues one real, unmocked
+    // fetch per featured-skills.json ID against prod skills-get. A slow or
+    // degraded prod response would stall this barrier for up to 30s on every
+    // test in this block, including the 2 that DO run in the required CI check
+    // -- for a reason unrelated to the code under test. Route it deterministically
+    // instead; loadFeaturedSkills() treats a non-ok response as a per-item null
+    // and only skips populating the grid if every item comes back that way
+    // (index.astro:954-963), so this doesn't need real skill data to resolve fast.
+    await page.route('**/skills-get/**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{"data":null}' })
+    })
     await page.goto(`${BASE_URL}/skills`)
     // Wait for the page to be fully loaded
     await expect(page.locator('#category-filter')).toBeVisible()

--- a/packages/website/tests/e2e/skills-filter.spec.ts
+++ b/packages/website/tests/e2e/skills-filter.spec.ts
@@ -83,9 +83,12 @@ test.describe('Skills Filter-Only Browsing (SMI-1658)', () => {
     // degraded prod response would stall this barrier for up to 30s on every
     // test in this block, including the 2 that DO run in the required CI check
     // -- for a reason unrelated to the code under test. Route it deterministically
-    // instead; loadFeaturedSkills() treats a non-ok response as a per-item null
-    // and only skips populating the grid if every item comes back that way
-    // (index.astro:954-963), so this doesn't need real skill data to resolve fast.
+    // instead; loadFeaturedSkills() resolves each item as `body?.data ?? null`
+    // (index.astro:956) and only skips populating the grid if every item comes
+    // back null (index.astro:962-963) -- a 200 with `{"data":null}` per the mock
+    // below hits exactly that path, so this doesn't need real skill data to
+    // resolve fast (round-3 confirmation review, finding 1: an earlier version
+    // of this comment said "non-ok response", which is never actually reached).
     await page.route('**/skills-get/**', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{"data":null}' })
     })
@@ -622,5 +625,62 @@ test.describe('SMI-6428: results-region ownership race', () => {
     await expect(searchCard).toBeVisible({ timeout: 15000 })
     await expect(page.locator('#search-prompt-state')).toBeHidden()
     await expect(page.locator('#results-count')).not.toHaveText('Showing featured examples')
+  })
+
+  test('SMI-6428 confirmation review findings F-1 + 2: claiming ownership restores the retry button and clears stale error-state decoration', async ({
+    page,
+  }) => {
+    // Round 2 caught a regression the original generation-guard fix introduced
+    // (F-1): claiming ownership clears window._rateLimitInterval, but that
+    // countdown was the ONLY code path that ever re-enabled #retry-button --
+    // so a search superseding a live 429 countdown left the button stuck
+    // reading "Retry in Ns" / disabled under any later error state. Round 3
+    // caught an adjacent pre-existing bug in the same region (finding 2): the
+    // 401/429 branches decorate the error heading and icon with nothing ever
+    // reverting them, so a later generic error rendered under stale decoration.
+    // This test drives both in one sequence: a 429 (installs the countdown +
+    // "Slow down a moment" decoration), then a second search that resolves as
+    // a generic 500 -- the shape both fixes target.
+    await suppressSignedOutOverlay(page)
+    await routeFeatured(page, 0)
+
+    let searchCallCount = 0
+    await page.route('**/skills-search**', async (route) => {
+      searchCallCount += 1
+      if (searchCallCount === 1) {
+        await route.fulfill({
+          status: 429,
+          contentType: 'application/json',
+          headers: { 'Retry-After': '30' },
+          body: JSON.stringify({ details: { retry_after: 30 } }),
+        })
+        return
+      }
+      await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto(`${BASE_URL}/skills`)
+    await expect(page.locator('#category-filter')).toBeVisible()
+
+    // First search: category filter -> 429 -> countdown installed.
+    await page.locator('#category-filter').selectOption('development')
+    await expect(page.locator('#error-state')).toBeVisible()
+    await expect(page.locator('#error-state h2')).toHaveText('Slow down a moment')
+    await expect(page.locator('#error-state svg')).toBeHidden()
+    const retryButton = page.locator('#retry-button')
+    await expect(retryButton).toBeVisible()
+    await expect(retryButton).toHaveText('Retry in 30s')
+    await expect(retryButton).toBeDisabled()
+
+    // Second search, well before the 30s countdown could naturally reach zero:
+    // claims ownership (F-1: must restore the button), resolves as a generic
+    // 500 (finding 2: must reset the heading/icon this same claim didn't touch).
+    await page.locator('#trust-filter').selectOption('verified')
+    await expect(page.locator('#error-state')).toBeVisible()
+    await expect(page.locator('#error-state h2')).toHaveText('Error loading skills')
+    await expect(page.locator('#error-state svg')).toBeVisible()
+    await expect(retryButton).toBeVisible()
+    await expect(retryButton).toHaveText('Try Again')
+    await expect(retryButton).toBeEnabled()
   })
 })

--- a/packages/website/tests/e2e/skills-filter.spec.ts
+++ b/packages/website/tests/e2e/skills-filter.spec.ts
@@ -496,8 +496,10 @@ test.describe('SMI-6428: results-region ownership race', () => {
           'skills_overlay_dismissed_until',
           new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
         )
-      } catch {
-        /* localStorage unavailable -- overlay suppression falls back to the race */
+      } catch (e) {
+        // localStorage unavailable -- overlay suppression falls back to the race.
+        // NEEDLE/GPT-5.6-Sol pre-merge review (PR-07): log rather than swallow silently.
+        console.debug('[SMI-6428 test] overlay-suppression localStorage write failed:', e)
       }
     })
   }

--- a/packages/website/tests/e2e/skills-filter.spec.ts
+++ b/packages/website/tests/e2e/skills-filter.spec.ts
@@ -29,6 +29,12 @@ async function waitForResults(page: Page): Promise<void> {
   await expect(page.locator('#empty-state')).toBeHidden()
   await expect(page.locator('#search-prompt-state')).toBeHidden()
 
+  // SMI-6428: assert the error state too. Without it, a 401/429/timeout from
+  // skills-search fails at the #results-grid line with a bare "expected visible,
+  // received hidden" — visually identical to the state-stomp failure this ticket
+  // fixed, which is exactly what made the CI trace ambiguous.
+  await expect(page.locator('#error-state')).toBeHidden()
+
   // Results grid should be visible with content
   await expect(page.locator('#results-grid')).toBeVisible()
 }
@@ -73,6 +79,16 @@ test.describe('Skills Filter-Only Browsing (SMI-1658)', () => {
     await page.goto(`${BASE_URL}/skills`)
     // Wait for the page to be fully loaded
     await expect(page.locator('#category-filter')).toBeVisible()
+    // SMI-6428 readiness barrier: #category-filter is static HTML, visible long
+    // before the astro:page-load handler binds its change listener (index.astro
+    // ~835) or the initAuth() -> loadFeaturedSkills() chain resolves. #results-count
+    // renders as "Loading skills..." (index.astro:274) and is only rewritten to
+    // "Showing featured examples" by that chain's terminal write (~917). Waiting
+    // for that exact string proves the handler ran to completion, so no interaction
+    // below can be stomped by it.
+    await expect(page.locator('#results-count')).toHaveText('Showing featured examples', {
+      timeout: 30000,
+    })
   })
 
   test.describe('Category Filter Without Search Query', () => {
@@ -406,5 +422,192 @@ test.describe('Skills Filter-Only Browsing (SMI-1658)', () => {
       // URL must contain the skill id segment -- confirms the stretched link fired.
       await expect(page).toHaveURL(/\/skills\//)
     })
+  })
+})
+
+/**
+ * SMI-6428: results-region ownership race.
+ *
+ * A SIBLING describe block, deliberately NOT nested inside the SMI-1658 block above:
+ * these scenarios must register their own page.route() handlers BEFORE page.goto(),
+ * and the parent's beforeEach already navigates. Inheriting it would make every
+ * route registration land after navigation, where it cannot affect requests already
+ * in flight.
+ *
+ * The bug: searchSkills() and the astro:page-load init chain
+ * (initAuth() -> loadFeaturedSkills() -> showState('search-prompt')) are two
+ * independent writers to one shared results region. Whichever resolved last won, so
+ * a filter touched shortly after page load could have its results silently replaced
+ * by the featured-examples view. The fix is a resultsGeneration ownership counter
+ * plus a terminal-write guard in the init chain.
+ */
+test.describe('SMI-6428: results-region ownership race', () => {
+  const SEARCH_FIXTURE_SKILL = {
+    id: 'smith-horn/smi-6428-race-fixture',
+    name: 'SMI-6428 Race Fixture Skill',
+    author: 'smith-horn',
+    description: 'Search-result fixture proving the results region survives the init chain.',
+    trust_tier: 'verified',
+    stars: 7,
+    categories: ['development'],
+    version: '1.0.0',
+    compatibility: ['claude-code'],
+    license: 'MIT',
+  }
+
+  const FEATURED_FIXTURE_SKILL = {
+    id: 'smith-horn/smi-6428-featured-fixture',
+    name: 'SMI-6428 Featured Fixture Skill',
+    author: 'smith-horn',
+    description: 'Featured-examples fixture -- must never replace an active search.',
+    trust_tier: 'verified',
+    stars: 3,
+    categories: ['development'],
+    version: '1.0.0',
+    compatibility: ['claude-code'],
+    license: 'MIT',
+  }
+
+  /**
+   * Same SMI-5504 overlay suppression the SMI-1658 beforeEach uses. Re-declared
+   * here rather than shared because this block intentionally does not inherit that
+   * beforeEach (see the block comment above).
+   */
+  async function suppressSignedOutOverlay(page: Page): Promise<void> {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem(
+          'skills_overlay_dismissed_until',
+          new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+        )
+      } catch {
+        /* localStorage unavailable -- overlay suppression falls back to the race */
+      }
+    })
+  }
+
+  /** skills-search always answers immediately with one deterministic card. */
+  async function routeSearch(page: Page): Promise<void> {
+    await page.route('**/skills-search**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ skills: [SEARCH_FIXTURE_SKILL] }),
+      })
+    })
+  }
+
+  /**
+   * skills-get backs loadFeaturedSkills(). `delayMs` holds the init chain open so
+   * its terminal write lands AFTER the search has already rendered -- the exact
+   * ordering that produced the red CI check.
+   */
+  async function routeFeatured(page: Page, delayMs: number): Promise<void> {
+    await page.route('**/skills-get/**', async (route) => {
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: FEATURED_FIXTURE_SKILL }),
+      })
+    })
+  }
+
+  test('SMI-6428 scenario 1: a slow featured-load must not stomp an active search', async ({
+    page,
+  }) => {
+    await suppressSignedOutOverlay(page)
+    // Registered BEFORE goto -- a route added after navigation starts does not
+    // apply to requests already in flight.
+    await routeFeatured(page, 1500)
+    await routeSearch(page)
+
+    await page.goto(`${BASE_URL}/skills`)
+
+    // Only proves the static HTML rendered -- NOT that the astro:page-load handler
+    // bound its listeners or that the init chain resolved. Interacting here is the
+    // post-bind race window this scenario targets.
+    await expect(page.locator('#category-filter')).toBeVisible()
+    await page.locator('#category-filter').selectOption('development')
+
+    const searchCard = page.locator('#results-grid').getByText(SEARCH_FIXTURE_SKILL.name)
+    await expect(searchCard).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('#search-prompt-state')).toBeHidden()
+
+    // Past the 1500ms featured-load delay: the init chain's terminal write has now
+    // had its chance to fire. Before the fix it replaced the results with the
+    // featured state here; it must not any more.
+    await page.waitForTimeout(2000)
+    await expect(searchCard).toBeVisible()
+    await expect(page.locator('#search-prompt-state')).toBeHidden()
+    await expect(page.locator('#results-count')).not.toHaveText('Showing featured examples')
+  })
+
+  test('SMI-6428 scenario 2: a filter changed before listeners bind is not lost', async ({
+    page,
+  }) => {
+    await suppressSignedOutOverlay(page)
+
+    // Natural timing cannot reliably reach the pre-bind window, so make it
+    // deterministic: capture every astro:page-load listener registered on document
+    // WITHOUT invoking it, and expose a release hook the test fires on demand.
+    // All captured listeners are replayed in registration order (BaseLayout's
+    // ClientRouter and other components register on this event too), so releasing
+    // reproduces a normal page-load, just later than the interaction.
+    await page.addInitScript(() => {
+      const captured: Array<{ target: EventTarget; args: unknown[] }> = []
+      const realAdd = EventTarget.prototype.addEventListener
+      const invokeRealAdd = (target: EventTarget, args: unknown[]): void => {
+        Reflect.apply(realAdd, target, args)
+      }
+      const patched = function (this: EventTarget, type: string, ...rest: unknown[]): void {
+        if (type === 'astro:page-load' && (this as unknown) === document) {
+          captured.push({ target: this, args: [type, ...rest] })
+          return
+        }
+        invokeRealAdd(this, [type, ...rest])
+      }
+      EventTarget.prototype.addEventListener =
+        patched as typeof EventTarget.prototype.addEventListener
+
+      const release = (): void => {
+        EventTarget.prototype.addEventListener = realAdd
+        const evt = new Event('astro:page-load')
+        for (const entry of captured) {
+          invokeRealAdd(entry.target, entry.args)
+          const listener = entry.args[1] as EventListenerOrEventListenerObject | undefined
+          if (typeof listener === 'function') {
+            listener.call(entry.target, evt)
+          } else if (listener && typeof listener.handleEvent === 'function') {
+            listener.handleEvent(evt)
+          }
+        }
+        captured.length = 0
+      }
+      ;(window as unknown as { __releaseAstroPageLoad__?: () => void }).__releaseAstroPageLoad__ =
+        release
+    })
+
+    await routeFeatured(page, 0)
+    await routeSearch(page)
+
+    await page.goto(`${BASE_URL}/skills`)
+    await expect(page.locator('#category-filter')).toBeVisible()
+
+    // The handler has NOT run, so no change listener exists yet. This select is the
+    // user interaction the real listener would have caught -- before the fix it was
+    // dropped entirely and the init chain painted the featured state over it.
+    await page.locator('#category-filter').selectOption('development')
+
+    await page.evaluate(() => {
+      ;(window as unknown as { __releaseAstroPageLoad__?: () => void }).__releaseAstroPageLoad__?.()
+    })
+
+    const searchCard = page.locator('#results-grid').getByText(SEARCH_FIXTURE_SKILL.name)
+    await expect(searchCard).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('#search-prompt-state')).toBeHidden()
+    await expect(page.locator('#results-count')).not.toHaveText('Showing featured examples')
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** the skills page no longer silently discards a search or filter you touch shortly after the page loads — a background "load featured examples" step used to win the race and overwrite your results with the generic examples grid. This was keeping a required CI check permanently red on `main`. Two adjacent bugs surfaced by review during the fix are also fixed: the retry button after a rate-limit error no longer gets stuck reading "Retry in Ns" forever, and a later error no longer inherits a stale heading/icon left over from an earlier error type. Also updates the internal governance and plan-review checklists so future changes of this exact shape (an async background task overwriting a user's more recent action) get caught before merge, not after.

**Quality bar:** implemented by one adversarial-reasoning pass, then independently re-reviewed twice more (each round by a fresh reviewer with no knowledge of the prior round's work), per this repo's rule that a race-condition fix needs its own confirmation pass. Round 2 caught a real regression the first fix introduced and fixed it; round 3 confirmed that fix was correct and caught two smaller issues, both fixed and independently verified with a passing/failing test proof in both directions. Full local test suite, typecheck, and lint all clean; a live pre-merge CI run against this branch is green for real (confirmed the run actually executed the tests, not a legitimate skip).

**Found along the way:** two follow-up issues were already filed against this bug (SMI-6433, SMI-6434) before this PR started — wiring the two new regression tests into the required CI check, and prewarming a slow dependency that made the race easier to hit in CI, both require their own infrastructure review process and aren't part of this PR.

**Net result:** fully shipped. The one thing left to confirm is that `main`'s required check goes green after this merges — that's checked right after merge, since `main` is currently red and a green PR alone doesn't prove it.

---

## Technical detail

**Files touched:**
- `packages/website/src/pages/skills/index.astro` — the race fix (a page-local ownership counter, claimed by every search and checked before every write that follows a network response) plus the two follow-up fixes found in review.
- `packages/website/tests/e2e/skills-filter.spec.ts` — hardened the existing test setup, and added 3 new regression tests (2 for the race itself, 1 for the two follow-up fixes).
- `.claude/skills/governance/agent-prompt.md`, `.claude/skills/governance/SKILL.md`, `.claude/skills/plan-review-skill/agent-prompt.md` (via the `skillsmith-strategy` submodule, `smith-horn/skillsmith-strategy#21`) — new governance check for this bug class.
- `.claude/templates/implementation-plan.md` — new trigger clause + worked example for the same check, at plan time.
- `docs/internal/code_review/2026-09-07-smi-6428-results-race-confirmation-review.md` (via the `docs/internal` submodule, `smith-horn/skillsmith-docs#1020`) — both confirmation review rounds' full reports.

**Commits (6, in order):**
1. `f58e640b3` — governance P-5 check 5 + `.claude/skills` pointer bump.
2. `d6c85cba9` — the race fix itself (`resultsGeneration` ownership counter + 2 new E2E scenarios).
3. `e75a6a1f1` — round-2 review findings: retry-button regression fix, and a new-test CI-fragility fix (route-mock a previously-live, untimeout-bounded endpoint the new readiness barrier depends on).
4. `c8421cd00` — round-3 review findings: a comment-accuracy fix, and a pre-existing (confirmed via `git show` against `main` before this file was touched) error-decoration bug in the same region, plus a new regression test for both, red-then-green proven.
5. `42c795cdd` — `docs/internal` pointer bump for the confirmation review report.

**Verification run locally, in order:**
- `astro check`: 0 errors/warnings/hints across 218 files (confirms the fix's `<script>` block is genuinely typechecked, not just the surrounding page).
- `npm run typecheck` (full `tsc --build`), `npm run lint`, `npx prettier --check`: all clean.
- `npm run preflight`: one pre-existing, unrelated failure (missing `@isaacs/keytar`/`async_hooks`/`@wdio/globals` in `packages/core` + the VS Code extension — confirmed unrelated by checking it also fails identically against the pristine tree).
- Full local Playwright matrix against a local preview server: `-g 5368` (the 2 tests this repo's CI actually runs today), `-g 6428` (the new race tests), the full file (16 tests: 12 fail only on a known, unrelated anonymous-trial-quota exhaustion from repeated local runs against prod `skills-search`, confirmed via the 401 response body), and `-g "5368|6428"` (all 5 self-mocked tests, including the newest one) — all green.
- `bash .claude/skills/concurrency-auditor/scripts/scan-plan.sh` against the plan doc: exit 0.
- Live pre-merge CI: `gh workflow run website-skills-e2e.yml --ref fix/smi-6428-skills-results-race` — confirmed `relevant=true` was explicitly set (not a legitimate skip: `workflow_dispatch` always short-circuits to `relevant=true` and the job log confirms this run took that path), and the `e2e` job that ran the real tests passed.

**Deliberately out of scope** (both already tracked, both are ADR-109-gated infrastructure changes requiring their own SPARC + plan-review before implementation, per this repo's Infrastructure Change Policy):
- `packages/website/astro.config.mjs` — prewarming `optimizeDeps` for two dependencies that made the underlying race easier to reproduce in CI. Tracked in SMI-6433.
- `.github/workflows/website-skills-e2e.yml` — widening the required check's test filter so the 3 new regression tests in this PR actually run in CI going forward (they were run locally, and verified red-then-green against `main` and this branch, as evidence in lieu of CI coverage). Also tracked in SMI-6433.
- A detector for the new governance check (currently reviewer-only, no automated scanner support) — tracked in SMI-6434.

**Post-merge**: re-dispatch `website-skills-e2e.yml` against `main` and confirm the required check goes green there — this is the only evidence that actually resolves the underlying issue, since `main` has been deterministically red until this merges.
