### PR TITLE
fix(indexer): SMI-6442 -- terminal primary_not_found outcome, honor Retry-After

### DIFF
--- a/scripts/indexer/smi5879-fetch-retry.ts
+++ b/scripts/indexer/smi5879-fetch-retry.ts
@@ -101,11 +101,20 @@ export async function withFetchRetry(
 
   for (let i = 0; i <= maxRetries; i++) {
     let result: RetryableFetchResult
+    // SMI-6442: track whether THIS iteration threw a RateLimitError, and its
+    // server-reported retryAfterSeconds if it had a usable one — needed below
+    // both to fix an adjacent bug (captureStatus overwriting a fresh
+    // RateLimitError's own status with a stale value) and to honor
+    // Retry-After.
+    let threwRateLimitError = false
+    let rateLimitRetryAfterSeconds: number | null = null
     try {
       result = await attempt()
     } catch (err) {
       if (err instanceof RateLimitError) {
         lastStatus = err.status
+        threwRateLimitError = true
+        rateLimitRetryAfterSeconds = err.retryAfterSeconds > 0 ? err.retryAfterSeconds : null
         result = null
       } else {
         // Not a retryable-shaped error — a genuine bug in the caller, not a
@@ -117,12 +126,25 @@ export async function withFetchRetry(
 
     if (result !== null) return result // { content } or { removed: true } — immediate, never retried
 
-    const captured = options.captureStatus?.()
-    if (captured !== undefined) lastStatus = captured
+    // Only consult captureStatus for a plain-null (non-RateLimitError)
+    // attempt — otherwise a stale status from an EARLIER null-returning
+    // attempt could silently overwrite the status THIS iteration's
+    // RateLimitError already set on `lastStatus` above.
+    if (!threwRateLimitError) {
+      const captured = options.captureStatus?.()
+      if (captured !== undefined) lastStatus = captured
+    }
 
     if (i === maxRetries) break
 
-    const waitMs = fullJitterWaitMs(i, baseMs, maxMs)
+    // A server-provided Retry-After acts as a FLOOR over local jitter — never
+    // truncated by maxMs. An authoritative delay must be honored in full, not
+    // silently shortened; maxMs only bounds our own guessed backoff.
+    const jitterWaitMs = fullJitterWaitMs(i, baseMs, maxMs)
+    const waitMs =
+      rateLimitRetryAfterSeconds !== null
+        ? Math.max(jitterWaitMs, rateLimitRetryAfterSeconds * 1000)
+        : jitterWaitMs
     options.onRetry?.(i + 1, waitMs)
     await sleep(waitMs)
   }

--- a/scripts/indexer/smi5879-gate-check.gates.ts
+++ b/scripts/indexer/smi5879-gate-check.gates.ts
@@ -79,7 +79,7 @@ export function evaluateG2(
       reason:
         'coverage is not full-and-zero-unevaluable for every cohort — ' +
         `partial: [${partial.join(', ') || 'none'}], unevaluable>0: [${unevaluableNonzero.join(', ') || 'none'}]. ` +
-        'unfetchable and bundle_absent rows do NOT block this gate.',
+        'unfetchable, primary_not_found, and bundle_absent rows do NOT block this gate.',
       detail: { partial, unevaluableNonzero },
     }
   }
@@ -302,6 +302,14 @@ export function evaluateG1(
     .filter((r) => ledger.validation.byId.get(r.id) !== 'exclude')
     .map((r) => r.id)
 
+  // SMI-6442: primary_not_found is terminal and coverage-neutral like
+  // unfetchable, and needs the identical exclusion requirement — without
+  // this, a confirmed-404 row would silently skip human review entirely.
+  const primaryNotFoundRows = simReport.rows.filter((r) => r.outcome === 'primary_not_found')
+  const missingPrimaryNotFoundExcludes = primaryNotFoundRows
+    .filter((r) => ledger.validation.byId.get(r.id) !== 'exclude')
+    .map((r) => r.id)
+
   const driftRequiringExclusion =
     mode === 'reconciliation'
       ? g2rDriftRows.filter((r) =>
@@ -315,6 +323,7 @@ export function evaluateG1(
   if (
     missingRDispositions.length > 0 ||
     missingUnfetchableExcludes.length > 0 ||
+    missingPrimaryNotFoundExcludes.length > 0 ||
     missingDriftExcludes.length > 0
   ) {
     const parts: string[] = []
@@ -330,6 +339,12 @@ export function evaluateG1(
           `${missingUnfetchableExcludes.slice(0, 10).join(', ')}${missingUnfetchableExcludes.length > 10 ? ', ...' : ''}`
       )
     }
+    if (missingPrimaryNotFoundExcludes.length > 0) {
+      parts.push(
+        `${missingPrimaryNotFoundExcludes.length} primary_not_found row(s) lack a recorded exclude: ` +
+          `${missingPrimaryNotFoundExcludes.slice(0, 10).join(', ')}${missingPrimaryNotFoundExcludes.length > 10 ? ', ...' : ''}`
+      )
+    }
     if (missingDriftExcludes.length > 0) {
       parts.push(
         `${missingDriftExcludes.length} G-2R drift row(s) (DR-1..DR-4) lack a recorded exclude: ` +
@@ -340,7 +355,12 @@ export function evaluateG1(
       id: 'G-1',
       outcome: 'INCONCLUSIVE',
       reason: parts.join('; '),
-      detail: { missingRDispositions, missingUnfetchableExcludes, missingDriftExcludes },
+      detail: {
+        missingRDispositions,
+        missingUnfetchableExcludes,
+        missingPrimaryNotFoundExcludes,
+        missingDriftExcludes,
+      },
     }
   }
 
@@ -348,7 +368,8 @@ export function evaluateG1(
     id: 'G-1',
     outcome: 'PASS',
     reason:
-      `every row in R (${R.length}), every unfetchable row (${unfetchableRows.length}), and every ` +
-      `G-2R drift row requiring exclusion (${driftRequiringExclusion.length}) has a recorded disposition`,
+      `every row in R (${R.length}), every unfetchable row (${unfetchableRows.length}), every ` +
+      `primary_not_found row (${primaryNotFoundRows.length}), and every G-2R drift row requiring ` +
+      `exclusion (${driftRequiringExclusion.length}) has a recorded disposition`,
   }
 }

--- a/scripts/indexer/smi5879-gate-check.helpers.ts
+++ b/scripts/indexer/smi5879-gate-check.helpers.ts
@@ -221,8 +221,9 @@ export function computeR(rows: readonly SimRowResult[]): SimRowResult[] {
  * `bundle_absent` (lines ~399-407) and the final `classifyVerdictDelta`
  * branch (unchanged_clean/unchanged_quarantined/newly_quarantined/
  * newly_cleared, ~410-417) are the ONLY paths that populate the score
- * fields. `unevaluable`/`unfetchable`/`content_drifted` all return early
- * before scoring and never carry them.
+ * fields. `unevaluable`/`unfetchable`/`content_drifted`/`primary_not_found`
+ * (SMI-6442 — no primary content to score) all return early before scoring
+ * and never carry them.
  */
 export const SCORED_OUTCOMES: readonly SimRowOutcome[] = [
   'bundle_absent',

--- a/scripts/indexer/smi5879-gate-check.io.ts
+++ b/scripts/indexer/smi5879-gate-check.io.ts
@@ -167,6 +167,7 @@ const VALID_OUTCOMES: readonly SimRowOutcome[] = [
   'bundle_absent',
   'unevaluable',
   'unfetchable',
+  'primary_not_found',
 ]
 
 function validateCoverage(
@@ -178,13 +179,21 @@ function validateCoverage(
   const total = value['total']
   const unevaluable = value['unevaluable']
   const unfetchable = value['unfetchable']
+  // SMI-6442: primaryNotFound is additive to the report schema. A report
+  // from before this fix landed has no such field at all — treat a genuinely
+  // ABSENT field as 0 (backward compatible with every pre-existing report),
+  // but still reject a PRESENT, non-number value as malformed.
+  const primaryNotFoundRaw = value['primaryNotFound']
+  const primaryNotFound = primaryNotFoundRaw === undefined ? 0 : primaryNotFoundRaw
   if (status !== 'full' && status !== 'partial')
     return { ok: false, reason: 'status must be full|partial' }
   if (typeof scanned !== 'number') return { ok: false, reason: 'scanned must be a number' }
   if (typeof total !== 'number') return { ok: false, reason: 'total must be a number' }
   if (typeof unevaluable !== 'number') return { ok: false, reason: 'unevaluable must be a number' }
   if (typeof unfetchable !== 'number') return { ok: false, reason: 'unfetchable must be a number' }
-  return { ok: true, value: { status, scanned, total, unevaluable, unfetchable } }
+  if (typeof primaryNotFound !== 'number')
+    return { ok: false, reason: 'primaryNotFound must be a number when present' }
+  return { ok: true, value: { status, scanned, total, unevaluable, unfetchable, primaryNotFound } }
 }
 
 function validateRow(
@@ -302,6 +311,16 @@ function validateSimulatorReportConsistency(
         reason:
           `coverage.${cohort}.unfetchable=${cov.unfetchable} does not equal the number of ` +
           `unfetchable cohort=${cohort} rows in report.rows (${actualUnfetchable})`,
+      }
+    }
+    // SMI-6442: same cross-validation for the new terminal outcome.
+    const actualPrimaryNotFound = cohortRows.filter((r) => r.outcome === 'primary_not_found').length
+    if (cov.primaryNotFound !== actualPrimaryNotFound) {
+      return {
+        ok: false,
+        reason:
+          `coverage.${cohort}.primaryNotFound=${cov.primaryNotFound} does not equal the number of ` +
+          `primary_not_found cohort=${cohort} rows in report.rows (${actualPrimaryNotFound})`,
       }
     }
   }

--- a/scripts/indexer/smi5879-merge-shards.merge-rules.ts
+++ b/scripts/indexer/smi5879-merge-shards.merge-rules.ts
@@ -120,6 +120,7 @@ export function assertShardReportNumericSanity(input: ShardReportInput): void {
     assertNonNegativeInteger(c.scanned, `coverage.${cohort}.scanned`, input.path)
     assertNonNegativeInteger(c.unevaluable, `coverage.${cohort}.unevaluable`, input.path)
     assertNonNegativeInteger(c.unfetchable, `coverage.${cohort}.unfetchable`, input.path)
+    assertNonNegativeInteger(c.primaryNotFound, `coverage.${cohort}.primaryNotFound`, input.path)
   }
   for (const outcome of SIM_ROW_OUTCOMES) {
     assertNonNegativeInteger(input.report.counts[outcome], `counts.${outcome}`, input.path)
@@ -263,21 +264,24 @@ export function mergeCoverage(
     let scanned = 0
     let unevaluable = 0
     let unfetchable = 0
+    let primaryNotFound = 0
     for (const input of inputs) {
       const c = input.report.coverage[cohort]
       scanned += c.scanned
       unevaluable += c.unevaluable
       unfetchable += c.unfetchable
+      primaryNotFound += c.primaryNotFound
     }
 
     const cohortRows = mergedRows.filter((r) => r.cohort === cohort)
-    const summed = { scanned, unevaluable, unfetchable }
+    const summed = { scanned, unevaluable, unfetchable, primaryNotFound }
     const recomputed = {
       scanned: cohortRows.length,
       unevaluable: cohortRows.filter((r) => r.outcome === 'unevaluable').length,
       unfetchable: cohortRows.filter((r) => r.outcome === 'unfetchable').length,
+      primaryNotFound: cohortRows.filter((r) => r.outcome === 'primary_not_found').length,
     }
-    for (const key of ['scanned', 'unevaluable', 'unfetchable'] as const) {
+    for (const key of ['scanned', 'unevaluable', 'unfetchable', 'primaryNotFound'] as const) {
       if (summed[key] !== recomputed[key]) {
         throw new Error(
           `SMI-6015: summed coverage.${cohort}.${key}=${summed[key]} across the shard reports does ` +
@@ -294,17 +298,17 @@ export function mergeCoverage(
           `${total} — the shards collectively reported more rows than the cohort contains.`
       )
     }
-    if (unevaluable > scanned || unfetchable > scanned) {
+    if (unevaluable > scanned || unfetchable > scanned || primaryNotFound > scanned) {
       throw new Error(
         `SMI-6015: merged coverage.${cohort} subset count(s) exceed scanned=${scanned} ` +
-          `(unevaluable=${unevaluable}, unfetchable=${unfetchable}). Both are SUBSETS of scanned, ` +
-          'never addends to it.'
+          `(unevaluable=${unevaluable}, unfetchable=${unfetchable}, primaryNotFound=${primaryNotFound}). ` +
+          'All three are SUBSETS of scanned, never addends to it.'
       )
     }
 
     const status: CohortCoverage['status'] =
       scanned === total && unevaluable === 0 ? 'full' : 'partial'
-    coverage[cohort] = { status, scanned, total, unevaluable, unfetchable }
+    coverage[cohort] = { status, scanned, total, unevaluable, unfetchable, primaryNotFound }
   }
   return coverage
 }

--- a/scripts/indexer/smi5879-simulate-full.helpers.ts
+++ b/scripts/indexer/smi5879-simulate-full.helpers.ts
@@ -325,17 +325,16 @@ export async function processRow(
     }
   }
   if ('removed' in primaryOutcome) {
-    // JUDGMENT CALL (documented in the implementation report): a primary
-    // SKILL.md 404 has no dedicated bucket in the plan's closed vocabulary —
-    // `unfetchable` is reserved for structurally-undecidable ROW SHAPES
-    // determined without any network attempt; `bundle_absent` requires
-    // "primary OK". Routed to `unevaluable` (the conservative, G-2-blocking
-    // choice) because the post-port verdict is categorically unknowable with
-    // no primary content to score, matching unevaluable's own definition.
+    // SMI-6442: a confirmed 404 is terminal (never retried), so it must
+    // never be `unevaluable`. Not `unfetchable` either (no-network-attempt
+    // ROW SHAPE). Coverage-neutral, still G-1-exclude-required.
     return {
       ...base,
-      outcome: 'unevaluable',
-      reason: 'primary SKILL.md confirmed absent (404) since the generation was sealed',
+      outcome: 'primary_not_found',
+      reason:
+        'primary SKILL.md not found at this path/ref (404) — repo resolved fine, but this ' +
+        'specific file returned 404; not retried, since repeating an identical request will not ' +
+        'change the answer',
     }
   }
   const primaryContent = primaryOutcome.content

--- a/scripts/indexer/smi5879-simulate-full.output.ts
+++ b/scripts/indexer/smi5879-simulate-full.output.ts
@@ -28,7 +28,7 @@ export function printSummary(report: Smi5879SimulateFullReport): void {
       `  sweep:             ${report.sweep.passes_run} pass(es), hard_stopped=${report.sweep.hard_stopped ?? 'none'}\n` +
       ALL_SIMULATED_COHORTS.map(
         (c) =>
-          `  coverage.${c}:       ${report.coverage[c].status} (${report.coverage[c].scanned}/${report.coverage[c].total}, unevaluable=${report.coverage[c].unevaluable}, unfetchable=${report.coverage[c].unfetchable})`
+          `  coverage.${c}:       ${report.coverage[c].status} (${report.coverage[c].scanned}/${report.coverage[c].total}, unevaluable=${report.coverage[c].unevaluable}, unfetchable=${report.coverage[c].unfetchable}, primaryNotFound=${report.coverage[c].primaryNotFound})`
       ).join('\n') +
       `\n  counts: ${JSON.stringify(report.counts)}\n`
   )

--- a/scripts/indexer/smi5879-simulate-full.sweep.ts
+++ b/scripts/indexer/smi5879-simulate-full.sweep.ts
@@ -53,16 +53,18 @@ export function computeCoverage(
     let scanned = 0
     let unevaluable = 0
     let unfetchable = 0
+    let primaryNotFound = 0
     for (const row of rows) {
       const result = results.get(row.id)
       if (!result) continue
       scanned++
       if (result.outcome === 'unevaluable') unevaluable++
       if (result.outcome === 'unfetchable') unfetchable++
+      if (result.outcome === 'primary_not_found') primaryNotFound++
     }
     const status: CohortCoverage['status'] =
       scanned === total && unevaluable === 0 ? 'full' : 'partial'
-    coverage[cohort] = { status, scanned, total, unevaluable, unfetchable }
+    coverage[cohort] = { status, scanned, total, unevaluable, unfetchable, primaryNotFound }
   }
   return coverage
 }
@@ -159,8 +161,9 @@ const defaultSleep = (ms: number): Promise<void> =>
 /**
  * Re-run ONLY the rows currently classified `unevaluable`, in repeated sweep
  * passes, until fixed point (`|R_k| = 0`) or a hard stop (plan §3b tier 3).
- * `unfetchable` rows are never included in `initialResidual` by the caller —
- * being terminal, they can never cause non-convergence.
+ * `unfetchable`/`primary_not_found` rows are never included in
+ * `initialResidual` by the caller — being terminal, they can never cause
+ * non-convergence.
  */
 export async function runTier3Sweep(
   initialResidual: SimRowResult[],

--- a/scripts/indexer/smi5879-simulate-full.types.ts
+++ b/scripts/indexer/smi5879-simulate-full.types.ts
@@ -37,6 +37,7 @@ export type SimRowOutcome =
   | 'bundle_absent'
   | 'unevaluable'
   | 'unfetchable'
+  | 'primary_not_found'
 
 /**
  * Single source of truth for the closed {@link SimRowOutcome} vocabulary at
@@ -57,6 +58,7 @@ export const EMPTY_OUTCOME_COUNTS: Record<SimRowOutcome, number> = {
   bundle_absent: 0,
   unevaluable: 0,
   unfetchable: 0,
+  primary_not_found: 0,
 }
 
 export const SIM_ROW_OUTCOMES: readonly SimRowOutcome[] = Object.keys(
@@ -113,6 +115,8 @@ export interface CohortCoverage {
   total: number
   unevaluable: number
   unfetchable: number
+  /** SMI-6442: confirmed file-level 404 on the primary SKILL.md — terminal, coverage-neutral. */
+  primaryNotFound: number
 }
 
 export type CoverageByCohort = Record<SimulatedCohort, CohortCoverage>

--- a/scripts/tests/indexer/smi5879-fetch-retry.test.ts
+++ b/scripts/tests/indexer/smi5879-fetch-retry.test.ts
@@ -14,7 +14,7 @@
 import { readFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { join } from 'node:path'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   withFetchRetry,
   fullJitterWaitMs,
@@ -110,6 +110,135 @@ describe('withFetchRetry', () => {
   it('honors overridden maxRetries/baseMs/maxMs defaults', () => {
     expect(DEFAULT_BASE_MS).toBe(1000)
     expect(DEFAULT_MAX_MS).toBe(60_000)
+  })
+
+  // SMI-6442: RateLimitError.retryAfterSeconds (parsed from the real
+  // Retry-After response header, _shared/rate-limit.ts) was previously
+  // discarded entirely in favor of blind full-jitter backoff. Fake timers
+  // throughout this block — a real Retry-After can be many seconds, and
+  // these tests must not actually wait that long.
+  describe('SMI-6442: honoring RateLimitError.retryAfterSeconds', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('a positive Retry-After is honored as a floor over local jitter', async () => {
+      const waits: number[] = []
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(new RateLimitError('rate limited', 429, 2))
+        .mockResolvedValueOnce({ content: 'ok' })
+      const resultPromise = withFetchRetry(attempt, {
+        baseMs: 1,
+        maxMs: 5,
+        onRetry: (_attempt, waitMs) => waits.push(waitMs),
+      })
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+      expect(result).toEqual({ content: 'ok' })
+      // Local jitter alone would be at most 5ms (maxMs) — the 2s Retry-After
+      // floor must win.
+      expect(waits[0]).toBe(2000)
+    })
+
+    it('missing/zero Retry-After falls back to jitter unchanged', async () => {
+      const waits: number[] = []
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(new RateLimitError('rate limited', 429, 0))
+        .mockResolvedValueOnce({ content: 'ok' })
+      const resultPromise = withFetchRetry(attempt, {
+        baseMs: 1,
+        maxMs: 5,
+        onRetry: (_attempt, waitMs) => waits.push(waitMs),
+      })
+      await vi.runAllTimersAsync()
+      await resultPromise
+      expect(waits[0]).toBeGreaterThanOrEqual(0)
+      expect(waits[0]).toBeLessThanOrEqual(5)
+    })
+
+    it('a Retry-After greater than maxMs is honored in full, never truncated', async () => {
+      const waits: number[] = []
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(new RateLimitError('rate limited', 429, 120))
+        .mockResolvedValueOnce({ content: 'ok' })
+      const resultPromise = withFetchRetry(attempt, {
+        baseMs: 1,
+        maxMs: 5, // far smaller than the 120s Retry-After
+        onRetry: (_attempt, waitMs) => waits.push(waitMs),
+      })
+      await vi.runAllTimersAsync()
+      await resultPromise
+      expect(waits[0]).toBe(120_000)
+    })
+
+    it('no sleep occurs after the final failed attempt, even with a positive Retry-After', async () => {
+      const attempt = vi.fn().mockRejectedValue(new RateLimitError('rate limited', 429, 5))
+      const resultPromise = withFetchRetry(attempt, { maxRetries: 1, baseMs: 1, maxMs: 5 })
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+      expect(result).toEqual({ exhausted: true, lastStatus: 429 })
+      // 1 initial attempt + 1 retry = 2 calls; no third attempt, no hang.
+      expect(attempt).toHaveBeenCalledTimes(2)
+    })
+
+    it('onRetry receives the actual post-floor wait value, not the raw jitter', async () => {
+      let observedWait: number | undefined
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(new RateLimitError('rate limited', 429, 3))
+        .mockResolvedValueOnce({ content: 'ok' })
+      const resultPromise = withFetchRetry(attempt, {
+        baseMs: 1,
+        maxMs: 5,
+        onRetry: (_attempt, waitMs) => {
+          observedWait = waitMs
+        },
+      })
+      await vi.runAllTimersAsync()
+      await resultPromise
+      expect(observedWait).toBe(3000)
+    })
+
+    it('a mixed null-then-RateLimitError sequence resolves lastStatus to the RateLimitError, not the stale null attempt', async () => {
+      const attempt = vi
+        .fn()
+        .mockResolvedValueOnce(null) // attempt 1: plain null, no status
+        .mockRejectedValueOnce(new RateLimitError('rate limited', 403, 1)) // attempt 2: real status
+      const resultPromise = withFetchRetry(attempt, {
+        maxRetries: 1,
+        baseMs: 1,
+        maxMs: 5,
+        captureStatus: () => 999, // would wrongly win if the ordering bug regressed
+      })
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+      expect(result).toEqual({ exhausted: true, lastStatus: 403 })
+    })
+
+    it('both 403 and 429 exercise the Retry-After path identically', async () => {
+      for (const status of [403, 429]) {
+        const attempt = vi
+          .fn()
+          .mockRejectedValueOnce(new RateLimitError('rate limited', status, 1))
+          .mockResolvedValueOnce({ content: 'ok' })
+        const waits: number[] = []
+        const resultPromise = withFetchRetry(attempt, {
+          baseMs: 1,
+          maxMs: 5,
+          onRetry: (_attempt, waitMs) => waits.push(waitMs),
+        })
+        await vi.runAllTimersAsync()
+        const result = await resultPromise
+        expect(result).toEqual({ content: 'ok' })
+        expect(waits[0]).toBe(1000)
+      }
+    })
   })
 })
 

--- a/scripts/tests/indexer/smi5879-gate-check.dispositions.test.ts
+++ b/scripts/tests/indexer/smi5879-gate-check.dispositions.test.ts
@@ -303,6 +303,23 @@ describe('smi5879-gate-check.ts — G-1 hand review', () => {
     expect(findGate(report.gates, 'G-1').reason).toMatch(/unfetchable row/)
   })
 
+  it('SMI-6442: is INCONCLUSIVE when a primary_not_found row has no recorded exclude', async () => {
+    const dir = makeScratchDir()
+    const rows = [makeSimRow({ id: 'r1', outcome: 'primary_not_found' })]
+    const dispositionsPath = writeFixtureFile(
+      dir,
+      'dispositions.json',
+      makeDispositionLedgerJson([])
+    )
+    const args = {
+      ...buildRequiredArgs(dir, { simulatorJson: makeSimulatorReportJson({ rows }) }),
+      dispositionsPath,
+    }
+    const report = await evaluateGateCheck({ db: makeFakeDb(), test: makeFakeTestDeps() }, args)
+    expect(findGate(report.gates, 'G-1').outcome).toBe('INCONCLUSIVE')
+    expect(findGate(report.gates, 'G-1').reason).toMatch(/primary_not_found row/)
+  })
+
   it('PASSes when every row in R and every unfetchable row has a recorded disposition', async () => {
     const dir = makeScratchDir()
     const rows = [

--- a/scripts/tests/indexer/smi5879-gate-check.fixtures.ts
+++ b/scripts/tests/indexer/smi5879-gate-check.fixtures.ts
@@ -128,10 +128,19 @@ const ALL_OUTCOMES = [
   'bundle_absent',
   'unevaluable',
   'unfetchable',
+  'primary_not_found',
 ] as const
 
 export function makeCoverage(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return { status: 'full', scanned: 0, total: 0, unevaluable: 0, unfetchable: 0, ...overrides }
+  return {
+    status: 'full',
+    scanned: 0,
+    total: 0,
+    unevaluable: 0,
+    unfetchable: 0,
+    primaryNotFound: 0,
+    ...overrides,
+  }
 }
 
 export function makeFullCoverageAllCohorts(): Record<string, unknown> {
@@ -178,11 +187,13 @@ function deriveCoverageFromRows(rows: readonly Record<string, unknown>[]): Recor
     const cohortRows = rows.filter((r) => r['cohort'] === cohort)
     const unevaluable = cohortRows.filter((r) => r['outcome'] === 'unevaluable').length
     const unfetchable = cohortRows.filter((r) => r['outcome'] === 'unfetchable').length
+    const primaryNotFound = cohortRows.filter((r) => r['outcome'] === 'primary_not_found').length
     coverage[cohort] = makeCoverage({
       scanned: cohortRows.length,
       total: cohortRows.length,
       unevaluable,
       unfetchable,
+      primaryNotFound,
     })
   }
   return coverage

--- a/scripts/tests/indexer/smi5879-gate-check.io.test.ts
+++ b/scripts/tests/indexer/smi5879-gate-check.io.test.ts
@@ -200,6 +200,77 @@ describe('smi5879-gate-check.io.ts — finding #7: simulator report internal con
     }
   })
 
+  it('coverage.<cohort>.primaryNotFound disagreeing with the actual primary_not_found row count is malformed', () => {
+    const dir = makeScratchDir()
+    const rows = [makeSimRow({ id: 'r1', cohort: 'C4', outcome: 'primary_not_found' })]
+    const coverage = {
+      C1: makeCoverage(),
+      C2: makeCoverage(),
+      C3: makeCoverage(),
+      // Claims 0 primaryNotFound even though the one C4 row IS primary_not_found.
+      C4: makeCoverage({ scanned: 1, total: 1, primaryNotFound: 0 }),
+    }
+    const path = writeFixtureFile(
+      dir,
+      'simulator.json',
+      makeSimulatorReportJson({ rows, coverage })
+    )
+    const result = loadSimulatorReport(path, 'simulator-report')
+    expect(result.status).toBe('malformed')
+    if (result.status === 'malformed') {
+      expect(result.reason).toMatch(/coverage\.C4\.primaryNotFound=0 does not equal/)
+    }
+  })
+
+  it('a report predating SMI-6442 (coverage.<cohort> genuinely missing primaryNotFound) still loads ok — treated as 0', () => {
+    const dir = makeScratchDir()
+    const rows = [makeSimRow({ id: 'r1', cohort: 'C1', outcome: 'unchanged_clean' })]
+    const legacyCoverage = {
+      C1: { status: 'full', scanned: 1, total: 1, unevaluable: 0, unfetchable: 0 },
+      C2: { status: 'full', scanned: 0, total: 0, unevaluable: 0, unfetchable: 0 },
+      C3: { status: 'full', scanned: 0, total: 0, unevaluable: 0, unfetchable: 0 },
+      C4: { status: 'full', scanned: 0, total: 0, unevaluable: 0, unfetchable: 0 },
+    }
+    const path = writeFixtureFile(
+      dir,
+      'simulator.json',
+      makeSimulatorReportJson({ rows, coverage: legacyCoverage })
+    )
+    const result = loadSimulatorReport(path, 'simulator-report')
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.value.coverage.C1.primaryNotFound).toBe(0)
+    }
+  })
+
+  it('coverage.<cohort>.primaryNotFound PRESENT but not a number is malformed, not silently defaulted', () => {
+    const dir = makeScratchDir()
+    const rows = [makeSimRow({ id: 'r1', cohort: 'C1', outcome: 'unchanged_clean' })]
+    const coverage = {
+      C1: {
+        status: 'full',
+        scanned: 1,
+        total: 1,
+        unevaluable: 0,
+        unfetchable: 0,
+        primaryNotFound: 'zero',
+      },
+      C2: makeCoverage(),
+      C3: makeCoverage(),
+      C4: makeCoverage(),
+    }
+    const path = writeFixtureFile(
+      dir,
+      'simulator.json',
+      makeSimulatorReportJson({ rows, coverage })
+    )
+    const result = loadSimulatorReport(path, 'simulator-report')
+    expect(result.status).toBe('malformed')
+    if (result.status === 'malformed') {
+      expect(result.reason).toMatch(/primaryNotFound must be a number/)
+    }
+  })
+
   it('a truncated rows array with unmodified coverage/counts (the exact tamper shape G-2/G-3 alone would miss) is malformed', () => {
     const dir = makeScratchDir()
     // Report CLAIMS full coverage over 100 C1 rows via `coverage`, and

--- a/scripts/tests/indexer/smi5879-merge-shards.fixtures.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.fixtures.ts
@@ -107,12 +107,14 @@ export function coverageForShard(
     const cohortRows = reportRows.filter((r) => r['cohort'] === cohort)
     const unevaluable = cohortRows.filter((r) => r['outcome'] === 'unevaluable').length
     const unfetchable = cohortRows.filter((r) => r['outcome'] === 'unfetchable').length
+    const primaryNotFound = cohortRows.filter((r) => r['outcome'] === 'primary_not_found').length
     const total = totals[cohort]
     coverage[cohort] = makeCoverage({
       scanned: cohortRows.length,
       total,
       unevaluable,
       unfetchable,
+      primaryNotFound,
       status: cohortRows.length === total && unevaluable === 0 ? 'full' : 'partial',
     })
   }

--- a/scripts/tests/indexer/smi5879-merge-shards.test.ts
+++ b/scripts/tests/indexer/smi5879-merge-shards.test.ts
@@ -23,10 +23,13 @@ import { parseArgs, runMergeShards, writeMergedReport } from '../../indexer/smi5
 import {
   MERGE_RUN_ID,
   buildThreeShardFixture,
+  fixtureRow,
   makeMergeShardsDb,
   makeScratchDir,
   mergeArgs,
+  totalsFor,
   writeShardReport,
+  type FixtureRowPair,
 } from './smi5879-merge-shards.fixtures.ts'
 
 // ---------------------------------------------------------------------------
@@ -133,6 +136,7 @@ describe('runMergeShards — N=3 happy path', () => {
       total: 3,
       unevaluable: 0,
       unfetchable: 0,
+      primaryNotFound: 0,
     })
     expect(report.coverage.C3).toEqual({
       status: 'full',
@@ -140,6 +144,7 @@ describe('runMergeShards — N=3 happy path', () => {
       total: 3,
       unevaluable: 0,
       unfetchable: 0,
+      primaryNotFound: 0,
     })
     expect(report.coverage.C1).toEqual({
       status: 'full',
@@ -147,6 +152,7 @@ describe('runMergeShards — N=3 happy path', () => {
       total: 0,
       unevaluable: 0,
       unfetchable: 0,
+      primaryNotFound: 0,
     })
     expect(report.coverage.C4).toEqual({
       status: 'full',
@@ -154,6 +160,7 @@ describe('runMergeShards — N=3 happy path', () => {
       total: 0,
       unevaluable: 0,
       unfetchable: 0,
+      primaryNotFound: 0,
     })
 
     // counts: recomputed from the merged rows, sum(counts) === rows.length.
@@ -164,6 +171,49 @@ describe('runMergeShards — N=3 happy path', () => {
     // sweep: no shard hard-stopped, passes_run is the max across shards
     // (every shard defaults to `makeSimulatorReportJson`'s passes_run: 1).
     expect(report.sweep).toEqual({ passes_run: 1, hard_stopped: null })
+  })
+
+  it('SMI-6442: primaryNotFound sums correctly across shards and stays coverage-neutral', async () => {
+    const dir = scratch()
+    // primary_not_found is NOT a scored outcome (no primary content was ever
+    // fetched successfully) — the real simulator never attaches
+    // quarantine/risk-score fields to it, so build these rows by hand rather
+    // than via fixtureRow, which always attaches them.
+    const pnf1 = fixtureRow('row-pnf-1', 'C2')
+    const pnf2 = fixtureRow('row-pnf-2', 'C2')
+    const c2c = fixtureRow('row-pnf-3', 'C2')
+    const asPrimaryNotFound = (row: FixtureRowPair): FixtureRowPair => ({
+      population: row.population,
+      reportRow: {
+        id: row.reportRow['id'],
+        cohort: row.reportRow['cohort'],
+        author: row.reportRow['author'],
+        name: row.reportRow['name'],
+        outcome: 'primary_not_found',
+        reason: 'primary SKILL.md not found at this path/ref (404)',
+      },
+    })
+    const c2a = asPrimaryNotFound(pnf1)
+    const c2b = asPrimaryNotFound(pnf2)
+    const population = [c2a.population, c2b.population, c2c.population]
+    const totals = totalsFor(population)
+    // Split across two shards so the merge tool must SUM, not just pass through.
+    const path0 = writeShardReport(dir, 0, [c2a.reportRow], totals)
+    const path1 = writeShardReport(dir, 1, [c2b.reportRow, c2c.reportRow], totals)
+    const db = makeMergeShardsDb(population)
+    const args = mergeArgs([path0, path1], join(dir, 'merged.json'))
+
+    const report = await runMergeShards(db, args)
+
+    expect(report.coverage.C2).toEqual({
+      status: 'full',
+      scanned: 3,
+      total: 3,
+      unevaluable: 0,
+      unfetchable: 0,
+      primaryNotFound: 2,
+    })
+    expect(report.counts.primary_not_found).toBe(2)
   })
 })
 

--- a/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
@@ -125,15 +125,15 @@ describe('processRow — tier-2 outcome classification', () => {
     expect(result.reason).toMatch(/unparseable/)
   })
 
-  it('unevaluable: repo_url embeds a ref, census resolved the repo fine, but SKILL.md itself still 404s (file-level absence is NOT reclassified by this fix)', async () => {
+  it('primary_not_found: repo_url embeds a ref, census resolved the repo fine, but SKILL.md itself still 404s (a genuine live fetch, distinct from the embedded-ref repo-level bypass above — SMI-6442 routes this to primary_not_found, not unevaluable)', async () => {
     const row = makeRow()
     const branchMap: BranchMap = new Map([
       [`acme/${row.id}`, { resolution: 'resolved', default_branch: 'main' }],
     ])
     registerPrimary(row, [new Response('Not Found', { status: 404 })])
     const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
-    expect(result.outcome).toBe('unevaluable')
-    expect(result.reason).toMatch(/confirmed absent/)
+    expect(result.outcome).toBe('primary_not_found')
+    expect(result.reason).toMatch(/not found/)
   })
 
   it('unchanged_clean: repo_url embeds a ref and census reports transient — transient does not block an embedded-ref row (it never needed default_branch)', async () => {
@@ -168,12 +168,12 @@ describe('processRow — tier-2 outcome classification', () => {
     expect(result.reason).toMatch(/primary fetch exhausted/)
   })
 
-  it('unevaluable: primary SKILL.md confirmed absent (404) since the snapshot (judgment call)', async () => {
+  it('primary_not_found: primary SKILL.md 404s (SMI-6442 — terminal, not retry-eligible)', async () => {
     const row = makeRow()
     registerPrimary(row, [new Response('Not Found', { status: 404 })])
     const result = await processRow(row, new Map(), baseDeps(cleanScanner, cleanScanner))
-    expect(result.outcome).toBe('unevaluable')
-    expect(result.reason).toMatch(/confirmed absent/)
+    expect(result.outcome).toBe('primary_not_found')
+    expect(result.reason).toMatch(/not found/)
   })
 
   it('unevaluable: a sibling exhausts retries', async () => {
@@ -367,6 +367,27 @@ describe('computeCoverage — unfetchable does NOT block full coverage, unevalua
     const coverage = computeCoverage({ C1: [], C2: rows, C3: [], C4: [] }, results)
     expect(coverage.C2.status).toBe('full')
     expect(coverage.C2.unfetchable).toBe(1)
+    expect(coverage.C2.unevaluable).toBe(0)
+  })
+
+  it('SMI-6442: a cohort where every row is primary_not_found or a resolved verdict reports full', () => {
+    const rows: [SimSnapshotRow, SimSnapshotRow] = [
+      makeRow({ cohort: 'C2' }),
+      makeRow({ cohort: 'C2' }),
+    ]
+    const results = new Map<string, SimRowResult>([
+      [
+        rows[0].id,
+        { id: rows[0].id, cohort: 'C2', author: null, name: null, outcome: 'primary_not_found' },
+      ],
+      [
+        rows[1].id,
+        { id: rows[1].id, cohort: 'C2', author: null, name: null, outcome: 'unchanged_clean' },
+      ],
+    ])
+    const coverage = computeCoverage({ C1: [], C2: rows, C3: [], C4: [] }, results)
+    expect(coverage.C2.status).toBe('full')
+    expect(coverage.C2.primaryNotFound).toBe(1)
     expect(coverage.C2.unevaluable).toBe(0)
   })
 


### PR DESCRIPTION
## Business Summary

**What shipped:** The census tool's coverage gate could never pass. A skill whose file was confirmed deleted got treated the same as a network hiccup worth retrying — so the tool kept re-checking already-deleted files forever, never finishing. Fixed the classification so a confirmed deletion is recorded once and never re-checked, and fixed a separate bug where the retry logic was ignoring GitHub's own "wait this long" signal in favor of a blind guess.

**Quality bar:** Plan reviewed twice by GPT-5.6-Sol (cross-model) — the first pass found 12 real gaps (missing places the new classification needed to be wired in, an old-report compatibility problem, an overclaimed root-cause), all fixed before implementation. Full suite green (18,795 tests), typecheck/lint/audit:standards clean.

**Found along the way:** filing a follow-up issue for a separate, larger problem this investigation surfaced — even after this fix, the next gate down the line has no way to process the volume of confirmed-deletions this change surfaces. Not solved here; tracked separately under SMI-6015 (issue filing currently blocked by an intermittent Linear auth failure this session hit twice, being retried).

**Net result:** This fix is complete and correct on its own, but does **not** by itself unblock the PR it exists to gate (#2192) — see Technical detail. `pr-reviewer`'s 14-check gate still needs to run before merge.

---

## Technical detail

**Root cause**: `processRow` (`scripts/indexer/smi5879-simulate-full.helpers.ts`) classified a confirmed 404 on the primary `SKILL.md` as `unevaluable` — a bucket the tier-3 sweep re-checks every pass, forever. A 404 is immediate and non-retryable at the fetch layer itself (`smi5879-fetch-retry.ts`'s own documented contract: "a 404 is a positive absence signal, not a failure"), so this could never converge for any real-world census containing deleted skills. Confirmed against the completed decision-purpose census (416,119 rows): 83% of the ~28K residual rows blocking coverage were this exact case.

**Fix**: added a new terminal, coverage-neutral outcome `primary_not_found`, mirroring how the existing `unfetchable` outcome is already handled — never re-checked, but still requires an explicit human-reviewed exclusion before the downstream review gate (G-1) can pass. Wired through every consumer: coverage aggregation, the review-gate's exclusion set, the report loader/validator (with backward-compatible handling of reports written before this fix), and the multi-shard merge tool's cross-validation logic.

**Separate, smaller fix**: the retry logic for rate-limited requests was discarding GitHub's own `Retry-After` response header in favor of a blind guessed wait time — now honored as a floor. A second bug found during review (a stale status value could silently overwrite a fresh one) was fixed alongside it.

**Scope note reviewers should know**: this fix makes the coverage gate passable in principle, but does not make the PR it gates mergeable by itself. The next gate down the line (G-1, human review sign-off) requires an individual disposition for every one of the ~23,597 rows this fix reclassifies, and that gate's ledger has no bulk-processing mechanism today — it's entirely hand-authored. That's a separate, substantial piece of work, tracked as its own follow-up rather than solved here.

**Plan doc**: `docs/internal/implementation/smi-6442-g2-coverage-terminal-outcome-plan.md` (two review rounds, GPT-5.6-Sol/NEEDLE, ADR-128)

**Verification**: typecheck/lint/audit:standards all clean (7 pre-existing warnings, none touching this diff); full suite 18,795 passed / 0 failed.

Linear: SMI-6442 (parented under SMI-6015).
