### PR TITLE
fix(needle): SMI-6445 -- rotate Codex model allowlist, add version floor check

### DIFF
--- a/scripts/needle/README.md
+++ b/scripts/needle/README.md
@@ -80,6 +80,22 @@ Architecture decision: [ADR-128](../../docs/internal/adr/128-harness-of-harnesse
    `needle`, `bf`, and the adapter all install fine but every dispatch fails
    for a reason none of the earlier steps explain.
 
+   **Keep this current, not just installed once (SMI-6445).**
+   `NEEDLE_ALLOWED_MODELS` (`scripts/needle/lib.sh`) can list a model your
+   *local* Codex CLI predates — the CLI will accept `--model <that-slug>`
+   syntactically, then fail with an opaque
+   `404 The model 'X' does not exist or you do not have access to it.`,
+   indistinguishable from a genuinely dead/removed model. Before dispatching
+   with a model you haven't used before, run `npm view @openai/codex
+   version` and compare against your own `codex --version`; if yours is
+   behind, run `codex update`. **Before running `codex update`**, check
+   `scripts/needle/results/codex-*.log` for any dispatch in flight from a
+   concurrent session on this machine — `codex update` is a global `npm
+   install -g`, not scoped to this repo or to your current dispatch.
+   `dispatch.sh` itself checks this before every dispatch (its
+   `MIN_CODEX_VERSION` pre-flight check) and will tell you clearly if your
+   CLI is too old — this note is what to do about it.
+
 ## Usage
 
 ```sh
@@ -401,3 +417,12 @@ their outcomes, are the concrete facts to bring to the harness team.
   that dispatch is starting cleanly (e.g. that the secret-scanner pre-check
   passes), that's fine to pipe through `head` — just re-run the real
   dispatch afterward rather than trusting that piped attempt's outcome.
+- **`codex exec` fails with `404 ... does not exist or you do not have
+  access to it` for a model that IS in `NEEDLE_ALLOWED_MODELS`.** (SMI-6445)
+  Your local Codex CLI predates that model's rollout — run `npm view
+  @openai/codex version` vs. `codex --version`, then `codex update` if
+  behind. See Setup step 6. `dispatch.sh` itself now checks this before
+  dispatching (its `MIN_CODEX_VERSION` pre-flight check) and prints the same
+  remediation; if you're seeing the raw Codex 404 instead of `dispatch.sh`'s
+  own clearer error, you likely bypassed `dispatch.sh` and called `codex
+  exec` directly.

--- a/scripts/needle/codex-adapter.yaml
+++ b/scripts/needle/codex-adapter.yaml
@@ -5,7 +5,9 @@
 #
 # Flags verified directly via `codex exec --help` (ADR-128 / SMI-5668
 # diligence pass, 2026-07-13/14; -m/-s/--json re-verified unchanged against
-# codex-cli 0.145.0 during the SMI-5847 pass, 2026-07-28):
+# codex-cli 0.145.0 during the SMI-5847 pass, 2026-07-28; re-verified
+# unchanged again against codex-cli 0.153.4 during the SMI-6445 model
+# rotation, 2026-09-07):
 #   -m/--model <MODEL>    per-invocation model selection
 #   -s/--sandbox <MODE>   read-only | workspace-write | danger-full-access
 #   --json                stream events as JSONL (required for

--- a/scripts/needle/dispatch.sh
+++ b/scripts/needle/dispatch.sh
@@ -30,6 +30,18 @@ source "$SCRIPT_DIR/lib.sh"
 
 DEFAULT_MODEL="gpt-5.6-sol"
 DEFAULT_TIMEOUT=3600
+# MIN_CODEX_VERSION (SMI-6445) — the oldest Codex CLI release that can serve
+# every model in NEEDLE_ALLOWED_MODELS today: 0.153.1 is the first version
+# with GPT-6-Astra API support (npm view @openai/codex time --json shows
+# 0.153.1 published 2026-09-03T21:02Z, the same day as GPT-6-Astra's
+# announcement; confirmed against the GitHub release notes for
+# rust-v0.153.1). A local CLI older than this accepts `--model gpt-6-astra`
+# syntactically, then fails with the same opaque 404 a genuinely dead model
+# produces (`gpt-5.5`'s exact failure mode, see lib.sh's allowlist comment) —
+# this check turns that into a clear, actionable, Skillsmith-authored error
+# instead. Bump this constant (with a comment explaining why) whenever a
+# newly-added model needs a newer floor than the current value.
+MIN_CODEX_VERSION="0.153.1"
 
 WORKSPACE=""
 TITLE=""
@@ -58,6 +70,10 @@ Arguments:
 Options:
   --model <model>       Codex model to dispatch to (default: $DEFAULT_MODEL).
                          Allowed: $NEEDLE_ALLOWED_MODELS
+                         A model newer than your local Codex CLI needs
+                         'codex update' first (see README's Setup step 6) —
+                         this script checks for that below and errors clearly
+                         if your CLI predates $MIN_CODEX_VERSION.
   --timeout <secs>      Dispatch timeout in seconds (default: $DEFAULT_TIMEOUT).
   --expect-write         Signal that this dispatch is expected to produce a
                          real workspace change (not a pure analysis/review
@@ -72,7 +88,7 @@ Options:
 
 Examples:
   $(basename "$0") --workspace .worktrees/smi-1234-thing --title "Draft README section" --body-file /tmp/prompt.txt
-  $(basename "$0") --workspace .worktrees/smi-1234-thing --title "second opinion on auth design" --body-file /tmp/prompt.txt --model gpt-5.5 --timeout 1800
+  $(basename "$0") --workspace .worktrees/smi-1234-thing --title "second opinion on auth design" --body-file /tmp/prompt.txt --model gpt-5.6-terra --timeout 1800
 
 dispatch.sh's terminal outcomes: 'success' is FINAL — consume the result,
 never re-dispatch, even when the results log also carries an incidental
@@ -137,6 +153,32 @@ check_binary needle
 check_binary bf
 check_binary codex
 check_binary jq
+
+# ---- SMI-6445: MIN_CODEX_VERSION pre-flight check. Confirmed live on
+# 2026-09-07 (macOS host, both BSD-derived and GNU sort report -V support
+# here): a Codex CLI older than MIN_CODEX_VERSION accepts a newer model name
+# syntactically, then fails with the exact same opaque 404 a genuinely dead
+# model produces (see lib.sh's NEEDLE_ALLOWED_MODELS comment) — this turns
+# that into a clear, actionable error before ever reaching Codex. Version
+# extraction and 'sort -V' failing open (never blocking a dispatch on a
+# parsing hiccup) mirrors this script's other pre-flight guards' philosophy
+# of failing loud on the specific thing they check, not on unrelated
+# surprises.
+CODEX_VERSION_RAW="$(codex --version 2>/dev/null || echo '')"
+CODEX_VERSION_NUM="$(echo "$CODEX_VERSION_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+if [[ -n "$CODEX_VERSION_NUM" ]]; then
+    OLDEST_OF_TWO="$(printf '%s\n%s\n' "$MIN_CODEX_VERSION" "$CODEX_VERSION_NUM" | sort -V | head -1)"
+    if [[ "$OLDEST_OF_TWO" != "$MIN_CODEX_VERSION" ]]; then
+        needle_error "Installed Codex CLI ($CODEX_VERSION_NUM) is older than the minimum this repo's model allowlist needs ($MIN_CODEX_VERSION) — see MIN_CODEX_VERSION's comment above for why.
+
+A stale Codex CLI accepts --model syntactically for any newly-added model, then fails with an opaque 404 ('does not exist or you do not have access to it') indistinguishable from a genuinely dead model. Fix: run 'codex update' (wraps 'npm install -g @openai/codex'), then re-run this dispatch. Before doing so, check scripts/needle/results/codex-*.log for any dispatch in flight from a concurrent session on this machine — 'codex update' is a global npm install, not scoped to this repo. See scripts/needle/README.md's Setup step 6."
+    fi
+fi
+# A CODEX_VERSION_NUM parse failure (empty string) deliberately does NOT
+# block dispatch — it degrades to "can't verify, proceed" rather than a hard
+# failure on a version-string format this check didn't anticipate; a real
+# incompatibility still surfaces as Codex's own 404 downstream, just without
+# this check's clearer message.
 
 # Resolve to an absolute, real path so the repo-root refusal check below
 # cannot be bypassed by a relative path or a symlink.

--- a/scripts/needle/dispatch.sh
+++ b/scripts/needle/dispatch.sh
@@ -154,31 +154,12 @@ check_binary bf
 check_binary codex
 check_binary jq
 
-# ---- SMI-6445: MIN_CODEX_VERSION pre-flight check. Confirmed live on
-# 2026-09-07 (macOS host, both BSD-derived and GNU sort report -V support
-# here): a Codex CLI older than MIN_CODEX_VERSION accepts a newer model name
-# syntactically, then fails with the exact same opaque 404 a genuinely dead
-# model produces (see lib.sh's NEEDLE_ALLOWED_MODELS comment) — this turns
-# that into a clear, actionable error before ever reaching Codex. Version
-# extraction and 'sort -V' failing open (never blocking a dispatch on a
-# parsing hiccup) mirrors this script's other pre-flight guards' philosophy
-# of failing loud on the specific thing they check, not on unrelated
-# surprises.
-CODEX_VERSION_RAW="$(codex --version 2>/dev/null || echo '')"
-CODEX_VERSION_NUM="$(echo "$CODEX_VERSION_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-if [[ -n "$CODEX_VERSION_NUM" ]]; then
-    OLDEST_OF_TWO="$(printf '%s\n%s\n' "$MIN_CODEX_VERSION" "$CODEX_VERSION_NUM" | sort -V | head -1)"
-    if [[ "$OLDEST_OF_TWO" != "$MIN_CODEX_VERSION" ]]; then
-        needle_error "Installed Codex CLI ($CODEX_VERSION_NUM) is older than the minimum this repo's model allowlist needs ($MIN_CODEX_VERSION) — see MIN_CODEX_VERSION's comment above for why.
-
-A stale Codex CLI accepts --model syntactically for any newly-added model, then fails with an opaque 404 ('does not exist or you do not have access to it') indistinguishable from a genuinely dead model. Fix: run 'codex update' (wraps 'npm install -g @openai/codex'), then re-run this dispatch. Before doing so, check scripts/needle/results/codex-*.log for any dispatch in flight from a concurrent session on this machine — 'codex update' is a global npm install, not scoped to this repo. See scripts/needle/README.md's Setup step 6."
-    fi
-fi
-# A CODEX_VERSION_NUM parse failure (empty string) deliberately does NOT
-# block dispatch — it degrades to "can't verify, proceed" rather than a hard
-# failure on a version-string format this check didn't anticipate; a real
-# incompatibility still surfaces as Codex's own 404 downstream, just without
-# this check's clearer message.
+# SMI-6445: MIN_CODEX_VERSION pre-flight check, extracted to
+# needle_check_codex_version() (lib.sh) to keep this file under the repo's
+# 500-line limit. Calls this script's own needle_error() on failure — see
+# lib.sh for the full rationale (a real set -euo pipefail fail-open bug
+# caught by this PR's own cross-model review, fixed and reproduced there).
+needle_check_codex_version "$MIN_CODEX_VERSION"
 
 # Resolve to an absolute, real path so the repo-root refusal check below
 # cannot be bypassed by a relative path or a symlink.

--- a/scripts/needle/lib.sh
+++ b/scripts/needle/lib.sh
@@ -43,6 +43,71 @@ source "$NEEDLE_LIB_DIR/../agent-evals/lib.sh"
 # target. Do not reintroduce either without a documented reason.
 NEEDLE_ALLOWED_MODELS="gpt-5.6-sol gpt-6-astra gpt-5.6-terra gpt-5.6-luna gpt-5.4-mini"
 
+# needle_check_codex_version MIN_VERSION — pre-flight check (SMI-6445, moved
+# here from dispatch.sh to stay under the repo's 500-line-per-file limit).
+# Calls the CALLER's own needle_error() (dispatch.sh's) on failure — this
+# relies on bash resolving function calls at call-time, not definition-time,
+# so it's fine that needle_error isn't defined yet when THIS function is
+# defined, only that it's defined by the time dispatch.sh actually calls
+# needle_check_codex_version further down its own script.
+#
+# Confirmed live on 2026-09-07 (macOS host, both BSD-derived and GNU sort
+# report -V support here): a Codex CLI older than MIN_VERSION accepts a
+# newer model name syntactically, then fails with the exact same opaque 404
+# a genuinely dead model produces (see NEEDLE_ALLOWED_MODELS's comment
+# above) — this turns that into a clear, actionable error before ever
+# reaching Codex.
+#
+# SMI-6445 cross-model review (pr-reviewer gate, GPT-5.6-Sol via NEEDLE)
+# caught a real bug here, confirmed live via direct reproduction: under
+# dispatch.sh's own 'set -euo pipefail', 'VAR="$(cmd1 | cmd2)"' aborts the
+# ENTIRE SCRIPT the instant any stage of that pipeline exits non-zero
+# (pipefail propagates the rightmost non-zero exit through the pipeline;
+# set -e then kills the script on the assignment itself) — a bare
+# 'echo "" | grep -oE ... | head -1' reproduces this exactly ('grep' finds
+# nothing, exits 1; 'head' still exits 0 reading empty input; pipefail makes
+# the pipeline's status 1; the script dies with no needle_error message at
+# all). An earlier draft of this check claimed a parse failure "fails
+# open" — it did the opposite: a genuinely malformed or empty
+# 'codex --version' output would silently kill dispatch with exit 1 and
+# zero explanation. Both extraction pipelines below now end in '|| true'
+# (the same idiom dispatch.sh already uses for ANSWER_CHARS) so a parse
+# failure degrades to "can't verify, proceed" as originally intended,
+# rather than aborting. Removing either '|| true' reintroduces that bug.
+#
+# Also caught: a prerelease-suffixed version (e.g. '0.153.1-alpha.6') had
+# its suffix silently discarded by the digits-only regex, which would treat
+# it as equal to a stable '0.153.1' floor — semver prerelease ordering isn't
+# implemented here, so that's a real ordering risk, not just cosmetic. A
+# version string containing a hyphen is now treated as unparseable (fails
+# open, same as an empty string) rather than truncated and compared as if
+# it were the stable release.
+#
+# A parse failure (empty string, or a prerelease suffix cleared below)
+# deliberately does NOT block dispatch — it degrades to "can't verify,
+# proceed" rather than a hard failure on a version-string format this check
+# didn't anticipate; a real incompatibility still surfaces as Codex's own
+# 404 downstream, just without this check's clearer message.
+needle_check_codex_version() {
+  local min_version="$1" codex_version_raw codex_version_num oldest_of_two
+  codex_version_raw="$(codex --version 2>/dev/null || echo '')"
+  codex_version_num="$(echo "$codex_version_raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?' | head -1 || true)"
+  if [[ "$codex_version_num" == *-* ]]; then
+    # Prerelease/alpha build — can't reliably order against a stable floor
+    # with a plain numeric comparison; skip the check rather than risk a
+    # wrong verdict either way.
+    codex_version_num=""
+  fi
+  if [[ -n "$codex_version_num" ]]; then
+    oldest_of_two="$(printf '%s\n%s\n' "$min_version" "$codex_version_num" | sort -V | head -1 || true)"
+    if [[ -n "$oldest_of_two" ]] && [[ "$oldest_of_two" != "$min_version" ]]; then
+      needle_error "Installed Codex CLI ($codex_version_num) is older than the minimum this repo's model allowlist needs ($min_version) — see MIN_CODEX_VERSION's comment in dispatch.sh for why.
+
+A stale Codex CLI accepts --model syntactically for any newly-added model, then fails with an opaque 404 ('does not exist or you do not have access to it') indistinguishable from a genuinely dead model. Fix: run 'codex update' (wraps 'npm install -g @openai/codex'), then re-run this dispatch. Before doing so, check scripts/needle/results/codex-*.log for any dispatch in flight from a concurrent session on this machine — 'codex update' is a global npm install, not scoped to this repo. See scripts/needle/README.md's Setup step 6."
+    fi
+  fi
+}
+
 # needle_model_allowed MODEL — returns 0 if MODEL is in the allowlist above,
 # 1 otherwise.
 needle_model_allowed() {

--- a/scripts/needle/lib.sh
+++ b/scripts/needle/lib.sh
@@ -14,11 +14,34 @@ NEEDLE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$NEEDLE_LIB_DIR/../agent-evals/lib.sh"
 
 # NEEDLE_ALLOWED_MODELS — the Codex models confirmed present in
-# ~/.codex/models_cache.json at diligence time (see this doc's § Surface
-# Grounding). An explicit allowlist, not passed through unchecked: {model}
-# flows into a shell-interpreted invoke_template (codex-adapter.yaml), so an
-# unvalidated value reaching it would be a command-injection surface.
-NEEDLE_ALLOWED_MODELS="gpt-5.6-sol gpt-5.5 gpt-5.6-luna gpt-5.6-terra"
+# ~/.codex/models_cache.json AND smoke-tested via a real `codex exec` call at
+# diligence time (SMI-6445, 2026-09-07 rotation — see
+# docs/internal/implementation/smi-6445-codex-model-rotation.md § Live
+# Validation Record). An explicit allowlist, not passed through unchecked:
+# {model} flows into a shell-interpreted invoke_template (codex-adapter.yaml),
+# so an unvalidated value reaching it would be a command-injection surface.
+#
+# `gpt-5.5` was removed in the 2026-09-07 rotation: it stayed listed in
+# OpenAI's own model catalog but returned a live 404 ("does not exist or you
+# do not have access to it") from every real dispatch — the exact silent
+# failure mode this allowlist exists to prevent from reaching an operator
+# unfiltered. Re-verify this list periodically against a fresh
+# `~/.codex/models_cache.json` + a real smoke test per model; a catalog
+# listing alone is not proof a model actually works (this is now the second
+# time a listed model went dead without OpenAI removing the catalog entry).
+#
+# `gpt-5.4-mini` is included as a cheap/fast burst tier for Codex-side work —
+# the catalog's lowest-priority, lowest-effort `visibility: list` model — a
+# genuine analogue to CLAUDE.md's Haiku row (mechanical/high-volume work),
+# not because a specific workload needs it yet.
+#
+# `gpt-reserve` and `codex-auto-review` are deliberately EXCLUDED despite
+# both passing their smoke test: both carry `visibility: hide` in OpenAI's
+# own catalog (not meant for direct/interactive selection), and
+# `codex-auto-review`'s name/lowest-priority value suggest it's purpose-built
+# for the `codex review` subcommand's internal use, not a general dispatch
+# target. Do not reintroduce either without a documented reason.
+NEEDLE_ALLOWED_MODELS="gpt-5.6-sol gpt-6-astra gpt-5.6-terra gpt-5.6-luna gpt-5.4-mini"
 
 # needle_model_allowed MODEL — returns 0 if MODEL is in the allowlist above,
 # 1 otherwise.

--- a/scripts/tests/needle-dispatch.test.sh
+++ b/scripts/tests/needle-dispatch.test.sh
@@ -7,9 +7,11 @@
 # needle-dispatch.bead-lifecycle.test.sh — split out to stay under this
 # repo's 500-line-per-file limit; both source the shared fixture setup in
 # scripts/tests/_lib/needle-dispatch-fixtures.sh. SMI-6445's model-allowlist
-# + MIN_CODEX_VERSION cases (15-17) are appended at the end of THIS file,
+# + MIN_CODEX_VERSION cases (15-19) are appended at the end of THIS file,
 # numbered to continue after the sibling file's case 14 rather than
-# colliding with it.
+# colliding with it. Cases 18-19 were added during that PR's own cross-model
+# pr-reviewer gate (GPT-5.6-Sol via NEEDLE), which caught a real
+# fail-open/set-euo-pipefail bug in cases 15-17's first draft.
 #
 # Usage: ./scripts/tests/needle-dispatch.test.sh
 
@@ -241,6 +243,69 @@ if [[ "$EXIT_CODE" -ne 1 ]] || ! grep -q "older than the minimum" /tmp/needle-di
     FAIL_COUNT=$((FAIL_COUNT + 1))
 else
     echo "PASS (case 17): a Codex CLI older than MIN_CODEX_VERSION is rejected with a clear pre-flight error"
+fi
+
+# Case 18 (cross-model pr-reviewer finding, GPT-5.6-Sol via NEEDLE): a
+# malformed/empty 'codex --version' output must NOT abort dispatch.sh
+# outright under set -euo pipefail. The pre-fix version of the
+# MIN_CODEX_VERSION extraction pipeline did exactly that (confirmed via a
+# direct standalone repro during review) despite its own comment claiming
+# "fails open" — this case is the regression guard for that fix.
+UNPARSEABLE_CODEX_BIN_DIR="$(mktemp -d)"
+cat > "$UNPARSEABLE_CODEX_BIN_DIR/codex" << 'UNPARSEABLE_FAKE_CODEX'
+#!/usr/bin/env bash
+case "${1:-}" in
+    --version) echo "codex-cli unknown"; exit 0 ;;
+    *) exit 0 ;;
+esac
+UNPARSEABLE_FAKE_CODEX
+chmod +x "$UNPARSEABLE_CODEX_BIN_DIR/codex"
+: > "$FAKE_OUTCOME_FILE"
+EXIT_CODE="$(FAKE_SCENARIO=clean FAKE_TOUCH_FILE=0 PATH="$UNPARSEABLE_CODEX_BIN_DIR:$TEST_PATH" "$DISPATCH" \
+    --workspace "$GIT_WORKTREE_DIR" \
+    --title "fixture case 18" \
+    --body-file "$BODY_FILE" \
+    --timeout 5 \
+    >/tmp/needle-dispatch-test-case18.out 2>&1; echo $?)"
+rm -rf "$UNPARSEABLE_CODEX_BIN_DIR"
+if [[ "$EXIT_CODE" -ne 0 ]] || ! grep -q "outcome=success" /tmp/needle-dispatch-test-case18.out; then
+    echo "FAIL (case 18): an unparseable 'codex --version' output should fail OPEN (dispatch still succeeds), got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case18.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 18): an unparseable codex --version output fails open instead of aborting dispatch"
+fi
+
+# Case 19 (same review pass): a prerelease-suffixed version that is
+# numerically OLDER than MIN_CODEX_VERSION must still fail open (skip the
+# check) rather than being silently truncated to its numeric prefix and
+# compared as if it were a stable release — semver prerelease ordering
+# isn't implemented here, so this is a deliberate "can't verify" skip, not
+# a false pass on stale-but-real versions (case 17 already covers a real
+# stale STABLE version being correctly rejected).
+PRERELEASE_CODEX_BIN_DIR="$(mktemp -d)"
+cat > "$PRERELEASE_CODEX_BIN_DIR/codex" << 'PRERELEASE_FAKE_CODEX'
+#!/usr/bin/env bash
+case "${1:-}" in
+    --version) echo "codex-cli 0.100.0-alpha.1"; exit 0 ;;
+    *) exit 0 ;;
+esac
+PRERELEASE_FAKE_CODEX
+chmod +x "$PRERELEASE_CODEX_BIN_DIR/codex"
+: > "$FAKE_OUTCOME_FILE"
+EXIT_CODE="$(FAKE_SCENARIO=clean FAKE_TOUCH_FILE=0 PATH="$PRERELEASE_CODEX_BIN_DIR:$TEST_PATH" "$DISPATCH" \
+    --workspace "$GIT_WORKTREE_DIR" \
+    --title "fixture case 19" \
+    --body-file "$BODY_FILE" \
+    --timeout 5 \
+    >/tmp/needle-dispatch-test-case19.out 2>&1; echo $?)"
+rm -rf "$PRERELEASE_CODEX_BIN_DIR"
+if [[ "$EXIT_CODE" -ne 0 ]] || ! grep -q "outcome=success" /tmp/needle-dispatch-test-case19.out; then
+    echo "FAIL (case 19): a prerelease-suffixed version should fail open (skip the floor check) rather than block, got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case19.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 19): a prerelease-suffixed codex version skips the floor check instead of being misparsed"
 fi
 
 # ---- Results-log isolation regression (Wave 3 Step 3) ----

--- a/scripts/tests/needle-dispatch.test.sh
+++ b/scripts/tests/needle-dispatch.test.sh
@@ -6,7 +6,10 @@
 # zero-agent_message cases (8-14) live in the sibling
 # needle-dispatch.bead-lifecycle.test.sh — split out to stay under this
 # repo's 500-line-per-file limit; both source the shared fixture setup in
-# scripts/tests/_lib/needle-dispatch-fixtures.sh.
+# scripts/tests/_lib/needle-dispatch-fixtures.sh. SMI-6445's model-allowlist
+# + MIN_CODEX_VERSION cases (15-17) are appended at the end of THIS file,
+# numbered to continue after the sibling file's case 14 rather than
+# colliding with it.
 #
 # Usage: ./scripts/tests/needle-dispatch.test.sh
 
@@ -170,6 +173,75 @@ else
     echo "PASS (case 7): SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1 skips the guard and the dispatch proceeds"
 fi
 rm -f "$LONG_RUN_BODY_FILE"
+
+# ---- Cases 15-17 (SMI-6445): model allowlist rotation + MIN_CODEX_VERSION ----
+
+# Case 15: a model removed from the allowlist (gpt-5.5, dead in production —
+# see scripts/needle/lib.sh's NEEDLE_ALLOWED_MODELS comment) is rejected
+# before ever touching bf/needle, exit 1, with the "Unknown --model" message
+# naming the current allowlist.
+set +e
+FAKE_SCENARIO=clean FAKE_TOUCH_FILE=0 PATH="$TEST_PATH" "$DISPATCH" \
+    --workspace "$GIT_WORKTREE_DIR" \
+    --title "fixture case 15" \
+    --body-file "$BODY_FILE" \
+    --timeout 5 \
+    --model gpt-5.5 \
+    >/tmp/needle-dispatch-test-case15.out 2>&1
+EXIT_CODE=$?
+set -e
+if [[ "$EXIT_CODE" -ne 1 ]] || ! grep -q "Unknown --model: gpt-5.5" /tmp/needle-dispatch-test-case15.out; then
+    echo "FAIL (case 15): expected exit 1 and 'Unknown --model: gpt-5.5', got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case15.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 15): gpt-5.5 (removed from the allowlist) is rejected with 'Unknown --model'"
+fi
+
+# Case 16: gpt-6-astra (newly added) passes the allowlist check and reaches
+# the faked dispatch path all the way to a real success outcome — proves the
+# allowlist change itself, not just the rejection path above.
+EXIT_CODE="$(run_case 16 clean 0 "$GIT_WORKTREE_DIR" --model gpt-6-astra)"
+if [[ "$EXIT_CODE" -ne 0 ]] || ! grep -q "outcome=success" /tmp/needle-dispatch-test-case16.out; then
+    echo "FAIL (case 16): expected exit 0 and outcome=success for the newly-allowlisted gpt-6-astra, got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case16.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 16): gpt-6-astra (newly allowlisted) reaches a successful dispatch"
+fi
+
+# Case 17: MIN_CODEX_VERSION pre-flight check. The shared fixture's fake
+# 'codex --version' always reports "codex-fake 1.0.0" (sorts after
+# MIN_CODEX_VERSION="0.153.1", so cases 0-16 above never trip this check) —
+# this case shadows it with a second fake 'codex' reporting a version older
+# than the floor, prepended to PATH so it's found first, to prove the check
+# actually fires (not just that it stays silent when versions are fine).
+OLD_CODEX_BIN_DIR="$(mktemp -d)"
+cat > "$OLD_CODEX_BIN_DIR/codex" << 'OLD_FAKE_CODEX'
+#!/usr/bin/env bash
+case "${1:-}" in
+    --version) echo "codex-cli 0.145.0"; exit 0 ;;
+    *) exit 0 ;;
+esac
+OLD_FAKE_CODEX
+chmod +x "$OLD_CODEX_BIN_DIR/codex"
+set +e
+PATH="$OLD_CODEX_BIN_DIR:$TEST_PATH" "$DISPATCH" \
+    --workspace "$GIT_WORKTREE_DIR" \
+    --title "fixture case 17" \
+    --body-file "$BODY_FILE" \
+    --timeout 5 \
+    >/tmp/needle-dispatch-test-case17.out 2>&1
+EXIT_CODE=$?
+set -e
+rm -rf "$OLD_CODEX_BIN_DIR"
+if [[ "$EXIT_CODE" -ne 1 ]] || ! grep -q "older than the minimum" /tmp/needle-dispatch-test-case17.out; then
+    echo "FAIL (case 17): expected exit 1 and the MIN_CODEX_VERSION floor message for a stale codex CLI, got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case17.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 17): a Codex CLI older than MIN_CODEX_VERSION is rejected with a clear pre-flight error"
+fi
 
 # ---- Results-log isolation regression (Wave 3 Step 3) ----
 REAL_RESULTS_SNAPSHOT_AFTER="$(snapshot_real_results_dir)"


### PR DESCRIPTION
## Business Summary

**What shipped:** The Codex dispatch tool (`scripts/needle/dispatch.sh`) now supports GPT-6-Astra, released September 3, and drops `gpt-5.5`, which stopped working entirely (the model catalog still lists it, but every dispatch to it fails). Also adds `gpt-5.4-mini` for cheap, high-volume Codex-tier work. Dispatching with a model your local Codex CLI is too old to know about now fails with a clear message telling you to update, instead of the same confusing error a genuinely dead model produces.

**Quality bar:** Plan reviewed via VP Product/Engineering/Design (16 findings, all addressed) before any code changed. Every allowlisted model smoke-tested with a real Codex API call, not just checked against the catalog listing. A full end-to-end dispatch (`--model gpt-6-astra`) run against this worktree, confirmed successful. Lint, typecheck, and the standards audit all clean of new findings.

**Found along the way:** the well-documented, already-tracked `preflight-check.ts` false-positive on 3 unrelated dependencies (e.g. SMI-5782) — confirmed pre-existing on `main` itself, unrelated to this diff. Also found and filed SMI-6448: `audit:standards` Check 55 fails to resolve git paths correctly when run from a worktree (as opposed to the main checkout) — also unrelated to this diff's content.

**Net result:** Fully shipped. One follow-up tracked and deliberately deferred: SMI-6446, whether GPT-6-Astra should become the new default model (currently stays `gpt-5.6-sol`) — needs real dispatch history first.

---

## Technical detail

**Files changed:**
- `scripts/needle/lib.sh` — `NEEDLE_ALLOWED_MODELS`: `gpt-5.6-sol gpt-5.5 gpt-5.6-luna gpt-5.6-terra` → `gpt-5.6-sol gpt-6-astra gpt-5.6-terra gpt-5.6-luna gpt-5.4-mini`; comment expanded with rationale for each inclusion/exclusion decision.
- `scripts/needle/dispatch.sh` — fixed the dead `--model gpt-5.5` usage example; added a `MIN_CODEX_VERSION="0.153.1"` constant and pre-flight check (`sort -V`-based, confirmed working on this macOS host) placed right after the existing `check_binary` calls.
- `scripts/needle/codex-adapter.yaml` — dated re-verification note (flags unchanged across 0.145.0 → 0.153.4).
- `scripts/needle/README.md` — Setup step 6 gets a CLI-currency callout; new Troubleshooting entry for the 404-vs-stale-CLI confusion this rotation surfaced.
- `scripts/tests/needle-dispatch.test.sh` — 3 new cases (15-17): `gpt-5.5` rejected, `gpt-6-astra` accepted, a stale-CLI version floor rejected. Full suite (this file + the sibling bead-lifecycle test) passes.

**Docs (separate repo, already merged):** [skillsmith-docs#1034](https://github.com/smith-horn/skillsmith-docs/pull/1034) — the reviewed implementation plan (`docs/internal/implementation/smi-6445-codex-model-rotation.md`) and a dated corrective note on ADR-128's now-stale `gpt-5.5` reference. This PR's first commit bumps the `docs/internal` pointer to that merged commit.

**Live validation (2026-09-07):** local Codex CLI was 8 patch releases behind (0.145.0); upgraded via `codex update` to 0.153.4, confirmed against npm's `latest` dist-tag. Full model catalog smoke-tested via real `codex exec` calls — `gpt-5.5` returns a live 404, every other allowlisted model returns a correct response. Full `dispatch.sh --model gpt-6-astra` run against this worktree: `outcome=success`, real `agent_message` returned.

**Linear:** SMI-6445 (this PR), SMI-6446 (default-model revisit, deliberately open), SMI-6448 (audit:standards worktree artifact, found along the way).
