### PR TITLE
feat(website): SMI-6433 -- CI warm-up step absorbs Astro's first-load full-reload

### DIFF
--- a/.github/workflows/website-skills-e2e.yml
+++ b/.github/workflows/website-skills-e2e.yml
@@ -25,13 +25,18 @@
 # check is safe here -- contrast device-login-roundtrip.yml /
 # cross-harness-inventory-e2e.yml, which need the event-scoped form.
 #
-# -g 5368 scopes the run to the 2 deterministic mocked tests (SMI-5375):
+# -g '5368|6428' scopes the run to 5 deterministic mocked tests (of 17 total
+# in this file; the other 12 are not run here — see follow-up note below):
 #   - "+N more" compat toggle expands without navigating away (SMI-3529/5367/5368/5369)
 #   - card stretched-link navigates to skill detail (SMI-5368 positive case)
-# These 2 tests self-mock via page.route() so they pass against any served
-# /skills shell with no live-backend dependency. The other 12 live-data tests
-# in the suite are not run here (follow-up: add page.route fixtures to the
-# SMI-1658 suite before wiring those into PR CI).
+#   - SMI-6428 scenario 1: a slow featured-load must not stomp an active search
+#   - SMI-6428 scenario 2: a filter changed before listeners bind is not lost
+#   - SMI-6428 confirmation review findings F-1 + 2: claiming ownership restores
+#     the retry button and clears stale error-state decoration
+# All 5 self-mock via page.route() so they pass against any served /skills
+# shell with no live-backend dependency. The other 12 live-data tests in the
+# suite are not run here (follow-up: add page.route fixtures to the SMI-1658
+# suite before wiring those into PR CI).
 
 name: Website Skills E2E
 
@@ -164,14 +169,21 @@ jobs:
         # 90s timeout -- vercel dev cold-start is ~20-30 s.
         run: npx --yes wait-on http://127.0.0.1:4321/ -t 90000
 
-      - name: Run skills-filter carve-out tests (SMI-5368, scoped via -g 5368)
+      - name: Warm up dev server (absorb Astro's first-load full-reload, SMI-6433)
+        # See docs/internal/implementation/smi-6433-vite-optimizedeps-prewarm-and-ci-warmup.md
+        # -- one real page load spends the one-time reload so the real test run's
+        # first load is a clean second load.
+        working-directory: packages/website
+        run: node scripts/warmup-skills-e2e.mjs
+
+      - name: Run skills-filter carve-out tests (SMI-5368 + SMI-6428, scoped via -g '5368|6428')
         # No --reporter override: the config's [list, html(open:never)] applies,
         # so the console gets list output AND playwright-report/ is populated for
         # the failure-artifact upload (pr-review F-G). open:never keeps CI non-blocking.
         # --timeout=90000 (SMI-5485): the one genuine failure in 18 shadow runs
         # was a 30s locator.click timeout that passed on retry; timeout-shaped
         # fix, retries stay 0 (config default).
-        run: npx playwright test --config=packages/website/playwright.config.ts --timeout=90000 packages/website/tests/e2e/skills-filter.spec.ts --project=desktop -g 5368
+        run: npx playwright test --config=packages/website/playwright.config.ts --timeout=90000 packages/website/tests/e2e/skills-filter.spec.ts --project=desktop -g '5368|6428'
 
       - name: Upload artifacts on failure
         if: failure()

--- a/packages/website/scripts/warmup-skills-e2e.mjs
+++ b/packages/website/scripts/warmup-skills-e2e.mjs
@@ -1,0 +1,177 @@
+// SMI-6433 -- absorbs the Astro dev server's one-time first-load full-reload
+// (docs/internal/implementation/smi-6433-vite-optimizedeps-prewarm-and-ci-warmup.md)
+// before the real Playwright run starts. Not Vite's dependency optimizer --
+// ruled out directly against the installed vite package (see that doc's
+// "Root cause, re-verified" section). The reload is EXPECTED on this fresh
+// server's first load, but its absence is only a WARNING here, not a hard
+// failure -- what actually matters, and is hard-enforced, is that the
+// server ends this step in a settled state (round-3 plan-review finding
+// #2: gate the required outcome, not the causal model).
+import { chromium } from '@playwright/test'
+
+const url = `${process.env.SKILLSMITH_WEBSITE_URL || 'http://127.0.0.1:4321'}/skills`
+const RELOAD_FRAME_TIMEOUT_MS = 10000
+const RELOAD_NAV_TIMEOUT_MS = 15000
+// Round-4 plan-review finding #1: this used to be a much shorter 3s window,
+// which was weaker than the first load's own 10s allowance -- a reload
+// merely delayed past 3s (but still within what the first load would have
+// tolerated) could slip past undetected. Now the same bound applies
+// whether or not the first load's reload was observed.
+const SECOND_LOAD_QUIET_MS = RELOAD_FRAME_TIMEOUT_MS
+// Round-4 plan-review finding #2: rather than making the reader sum five
+// separate nested timeouts to know the real worst case, the whole script
+// runs under one explicit deadline.
+const OVERALL_TIMEOUT_MS = 60000
+
+// Only sets a nonzero exit code and returns -- run()'s own try/finally
+// (below) is what actually closes the browser, on every path, exactly
+// once. Round-5 plan-review found the previous version's claim that
+// run() closed its browser "on every path it controls" was inaccurate
+// (an exception from newPage()/waitForLoadState()/the second goto()
+// would skip it entirely) -- true cleanup now doesn't depend on that.
+function fail(message) {
+  console.error(`[warmup] FAIL: ${message}`)
+  process.exitCode = 1
+}
+
+// Tracks main-frame navigations and reload-frame sightings against a single
+// shared, monotonically increasing sequence number, updated synchronously
+// inside each event handler. This is deliberate: round-3 plan-review found
+// that snapshotting a navigation count AFTER an `await page.goto()` call
+// races the very thing it's meant to measure -- the reload can complete
+// before that continuation even runs (confirmed possible: the SPARC
+// investigation's own probe saw the reload frame arrive during module
+// execution, before the initial page's own 'load' event). Recording the
+// sequence number AT the moment each event fires, inside the handler
+// itself, has no such race regardless of when any `await` resumes.
+function makeNavTracker(page) {
+  let seq = 0
+  let reloadSeenAtSeq = null
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) seq += 1
+  })
+  page.on('websocket', (ws) => {
+    ws.on('framereceived', ({ payload }) => {
+      if (
+        reloadSeenAtSeq === null &&
+        typeof payload === 'string' &&
+        payload.includes('"full-reload"')
+      ) {
+        reloadSeenAtSeq = seq
+      }
+    })
+  })
+  return {
+    currentSeq: () => seq,
+    reloadSeenAtSeq: () => reloadSeenAtSeq,
+  }
+}
+
+async function run() {
+  const browser = await chromium.launch()
+  try {
+    const page = await browser.newPage()
+    const tracker = makeNavTracker(page)
+
+    console.log(
+      `[warmup] loading ${url} (first load on a fresh server -- expecting the one-time reload)`
+    )
+    // A reload firing mid-navigation can make goto() itself reject (the
+    // client-side location.reload() interrupts the original navigation) --
+    // that's an expected, benign outcome here, not a real failure. The
+    // tracker above is what actually decides success or failure below.
+    // 15s here is a local-loopback request; if it's actually stalled that
+    // long something is already badly wrong and the overall deadline below
+    // catches it regardless.
+    await page.goto(url, { waitUntil: 'load', timeout: 15000 }).catch(() => {})
+
+    const frameDeadline = Date.now() + RELOAD_FRAME_TIMEOUT_MS
+    while (tracker.reloadSeenAtSeq() === null && Date.now() < frameDeadline) {
+      await page.waitForTimeout(100)
+    }
+    const reloadSeenAtSeq = tracker.reloadSeenAtSeq()
+
+    if (reloadSeenAtSeq === null) {
+      console.warn(
+        `[warmup] WARNING: expected the one-time full-reload frame on this fresh server's first load ` +
+          `but none arrived within ${RELOAD_FRAME_TIMEOUT_MS}ms -- this warm-up's causal model may be stale ` +
+          `(re-run the SPARC verification in the SMI-6433 plan doc), but proceeding: the second-load check ` +
+          `below is what actually gates this step.`
+      )
+    } else {
+      console.log(
+        '[warmup] observed the full-reload frame; waiting for the resulting navigation to complete'
+      )
+      const navDeadline = Date.now() + RELOAD_NAV_TIMEOUT_MS
+      while (tracker.currentSeq() <= reloadSeenAtSeq && Date.now() < navDeadline) {
+        await page.waitForTimeout(100)
+      }
+      if (tracker.currentSeq() <= reloadSeenAtSeq) {
+        fail(
+          `full-reload frame observed but no subsequent navigation completed within ${RELOAD_NAV_TIMEOUT_MS}ms`
+        )
+        return
+      }
+      await page.waitForLoadState('load', { timeout: 15000 })
+      console.log('[warmup] reload navigation settled')
+    }
+
+    // The hard gate: regardless of whether the first load's reload was
+    // observed above, a second page load against this same server session
+    // must never reload -- for the SAME bound the first load gets, not a
+    // shorter one, so a merely-delayed reload can't slip past unnoticed
+    // (round-4 plan-review finding #1).
+    const page2 = await browser.newPage()
+    const tracker2 = makeNavTracker(page2)
+    console.log('[warmup] loading a second page to confirm the server stays warm')
+    await page2.goto(url, { waitUntil: 'load', timeout: 15000 })
+    await page2.waitForTimeout(SECOND_LOAD_QUIET_MS)
+    if (tracker2.reloadSeenAtSeq() !== null) {
+      fail(
+        'a second page load triggered another full-reload -- the server did not stay warm as expected'
+      )
+      return
+    }
+    console.log('[warmup] confirmed: second load is clean -- server is warm for the real test run')
+  } finally {
+    // Unconditional, exactly-once cleanup -- covers every path, including
+    // an exception from newPage()/waitForLoadState()/the second goto()
+    // that the earlier per-branch fail() calls didn't reach. Round-5
+    // plan-review found the previous version's comment overclaimed this
+    // without an actual try/finally backing it.
+    await browser.close()
+  }
+}
+
+async function main() {
+  // Round-5 plan-review finding #1: an uncleared setTimeout keeps Node's
+  // event loop alive until the full budget elapses even after run()
+  // finishes -- a successful ~10-12s run would otherwise still take a
+  // full 60s wall-clock in CI. clearTimeout() in finally fixes this.
+  let timeoutHandle
+  let timedOut = false
+  const timeout = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true
+      reject(new Error(`warm-up exceeded its overall ${OVERALL_TIMEOUT_MS}ms budget`))
+    }, OVERALL_TIMEOUT_MS)
+  })
+  try {
+    await Promise.race([run(), timeout])
+  } catch (err) {
+    console.error('[warmup] failed:', err)
+    if (timedOut) {
+      // run() is still executing in the background at this point (JS has
+      // no true cancellation) and may not reach its own cleanup for a
+      // while -- force an immediate hard stop so the documented 60s
+      // budget is a real wall-clock guarantee, not best-effort. This also
+      // force-kills any still-running Chromium child process.
+      process.exit(1)
+    }
+    process.exitCode = 1
+  } finally {
+    clearTimeout(timeoutHandle)
+  }
+}
+
+main()


### PR DESCRIPTION
## Business Summary

**What shipped:** the `website-skills-e2e.yml` CI check now runs all 5 of its intended deterministic tests, not just 2 — SMI-6428's 3 new regression tests were only ever running locally, never gating real PRs. A new warm-up step also absorbs a one-time dev-server reload before the real tests start, removing a source of flaky timing in that same CI check.

**Quality bar:** six rounds of adversarial cross-model review (GPT-5.6-Sol, a different model family than the one that wrote this) before any code was written, each round finding and fixing a real bug in the warm-up script's async-timing logic. Fully verified: byte-identical to the reviewed design, exact expected behavior confirmed against a live server, and the widened test filter independently confirmed to select exactly 5 tests.

**Found along the way:** the CI reload's root cause (originally attributed to Vite's dependency pre-bundling in SMI-6428's own plan) turned out to be something else in Astro's dev server — corrected in that doc. Also: neither this repo's plan-review rubric nor its code-review checklist had any language for the class of bug this warm-up script kept hitting (an async observation script's own timing correctness, distinct from the shared-state races those checklists already cover) — filed and fixed separately as SMI-6451, now merged.

**Net result:** fully shipped. One open item flagged for the issue owner, not decided silently: the original Linear ask included adding a Vite config tweak (`optimizeDeps.include`) as part of the fix — research showed it can't actually fix anything (verified: the reload still happens even with every affected dependency pre-configured), so it was dropped rather than shipped as ineffective config surface. Plan doc has the full reasoning.

---

## Technical detail

- `packages/website/scripts/warmup-skills-e2e.mjs` (new): loads `/skills` once, requires the expected reload to complete before the real test run's server context, then confirms a second load stays clean — this second-load check is the actual hard gate, not an assumption about why the reload happens.
- `.github/workflows/website-skills-e2e.yml`: new warm-up step between the preview-server wait and the real test run; `-g` filter widened `5368` → `'5368|6428'`; header comment and step name corrected to match.
- Full SPARC research + all 6 plan-review rounds: `docs/internal/implementation/smi-6433-vite-optimizedeps-prewarm-and-ci-warmup.md`.
- Linear: SMI-6433 (follow-up from SMI-6428). Related: SMI-6451 (plan-review-skill + governance rubric addition, merged).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01GpTwRztnR5suMV3K3RXxha