### PR TITLE
fix(security): SMI-6466 -- retire 4 allowlist entries cleared by SMI-5207 gating

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -3,28 +3,10 @@
   "generatedAt": "2026-06-02T00:00:00.000Z",
   "allowlist": [
     {
-      "skillId": "github/kcmadden/claude-code-1password-skill",
-      "findingType": "sensitive_path",
-      "messagePattern": "password|credentials",
-      "reason": "1Password integration skill. The product literally contains the word 'password' and its SKILL.md is security guidance telling Claude Code NEVER to ask users to paste passwords/credentials in chat. Bare-keyword sensitive_path regex cannot distinguish 'documents handling of passwords' from 'hardcoded password'. Wave 2 tightens patterns to require assignment/path context. Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
-      "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-07-12",
-      "expiresAt": "2026-10-10"
-    },
-    {
       "skillId": "github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill",
       "findingType": "privilege_escalation",
       "messagePattern": "escalation",
       "reason": "Prompt-injection scanner skill whose description enumerates adversarial techniques it detects ('role manipulation, privilege escalation, ...'). Bare /escalat(e|ion)/i pattern triggered CRITICAL on a defensive-security tool describing its own subject matter. Wave 2 replaces with contextual patterns (privilege_escalation, escalate to root, exploit-to-escalate). Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
-      "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-07-12",
-      "expiresAt": "2026-10-10"
-    },
-    {
-      "skillId": "github/rhysha/claude-security-research-skill",
-      "findingType": "sensitive_path",
-      "messagePattern": "secrets?",
-      "reason": "Security-research skill. 'Secrets' is domain vocabulary (talks about finding/handling secrets as a research topic), not an instruction to access a sensitive path. Bare-keyword match. Wave 2 tightens sensitive_path patterns to require assignment/path/file-extension context. Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-07-12",
       "expiresAt": "2026-10-10"
@@ -101,24 +83,6 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-08-13",
       "expiresAt": "2026-11-11"
-    },
-    {
-      "skillId": "github/binnukarunakar/icm-shipwright",
-      "findingType": "sensitive_path",
-      "messagePattern": "secrets\\?\\\\\\/\\[a-z0-9",
-      "reason": "Workspace-safety tool ('Make AI-agent workspaces safe to run and ship... with secret/PII guardrails and a 17-check lint'). Fetched all 33 files in the repo tree and found zero literal 'secret(s)/' matches in any file content — the only hit anywhere is the repo's own GitHub description phrase 'secret/PII guardrails', which the bare-keyword sensitive_path regex matches case-insensitively. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills (description advertises a security/credential-handling feature). messagePattern is scoped to the path-form pattern's echoed source only (SENSITIVE_PATH_PATTERNS' \\bsecrets?\\/[a-z0-9_.-]+, not the sibling assignment-form \\bsecrets?\\s*[:=] — both feed sensitive_path, and a bare 'secrets?' pattern here would also suppress a real future assignment-form secret leak in this skill). Triaged 2026-08-27 under SMI-6237 — closes GH #2059 (7 consecutive Weekly Security Scan failures since 2026-07-26, all the same skill/finding).",
-      "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-08-27",
-      "expiresAt": "2026-11-25"
-    },
-    {
-      "skillId": "github/lucas-lima-s/claude-skill-repo-audit",
-      "findingType": "sensitive_path",
-      "messagePattern": "secrets\\?\\\\\\/\\[a-z0-9",
-      "reason": "Publish-readiness audit skill whose GitHub repo description reads 'Publish-readiness gate for any repository: secret/PII scans, git-history identity leaks...'. Fetched all 44 files in the repo tree and found zero literal 'secret(s)/' matches in any file content — the only hit anywhere is the repo's own GitHub description phrase 'secret/PII', which the bare-keyword sensitive_path regex matches case-insensitively (the [a-z0-9_.-]+ class swallows 'PII'). Same false-positive class as github/binnukarunakar/icm-shipwright (SMI-6237, 'secret/PII guardrails') and github/RobinGase/skill-protocol-rs. messagePattern is scoped to the path-form pattern's echoed source only (SENSITIVE_PATH_PATTERNS' \\bsecrets?\\/[a-z0-9_.-]+, not the sibling assignment-form \\bsecrets?\\s*[:=] — both feed sensitive_path, and a bare 'secrets?' pattern here would also suppress a real future assignment-form secret leak in this skill). Triaged 2026-09-06 under SMI-6425 — closes GH #2616 + #2060 (recurring Weekly Security Scan failures since 2026-07-26).",
-      "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-09-06",
-      "expiresAt": "2026-12-05"
     }
   ]
 }

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -26,7 +26,6 @@ import {
   parseAllowlistFile,
 } from '../../src/scripts/skill-scanner/allowlist.js'
 import { shouldQuarantine } from '../../src/scripts/skill-scanner/trust-scorer.js'
-import { scanSensitivePaths } from '../../src/security/scanner/SecurityScanner.scanners.js'
 import type {
   AllowlistEntry,
   ScanReport,
@@ -471,11 +470,23 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // publish-readiness audit skill whose repo description says 'secret/PII
   // scans'; same description-advertises-a-security-feature FP class as
   // icm-shipwright. Closes GH #2616 + #2060.
+  // SMI-6466 (2026-09-08): 4 entries retired following SMI-5207's MF-3/MF-4
+  // sensitive_path action-context gating. A live post-merge targeted re-scan
+  // (real repo descriptions fetched via `gh api`, real scanner run against a
+  // hand-built imported-skills.json fixture, real edited allowlist file) confirmed
+  // all four now clear with zero HIGH/CRITICAL findings and isQuarantined=false:
+  // binnukarunakar/icm-shipwright and lucas-lima-s/claude-skill-repo-audit clear
+  // to MEDIUM via MF-3 exactly as the SMI-5207 plan predicted; kcmadden/
+  // claude-code-1password-skill and rhysha/claude-security-research-skill clear
+  // with ZERO sensitive_path findings at all (not the predicted MF-4 MEDIUM
+  // downgrade) — their current live GitHub descriptions no longer contain any
+  // text matching any of the 15 SENSITIVE_PATH_PATTERNS, so the MF-4 branch is
+  // never reached; the clear is content-driven, not gate-driven, for these two.
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(13)
+    expect(parsed.allowlist.length).toBe(9)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
@@ -483,14 +494,10 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
         'github/RENJI04/prompt-injection-auditor',
         'github/RobinGase/skill-protocol-rs',
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',
-        'github/binnukarunakar/icm-shipwright',
         'github/dokind/qpay-skills',
         'github/fitz2882/narthex',
         'github/fitz2882/narthex',
-        'github/kcmadden/claude-code-1password-skill',
         'github/leksman/ai-security-guard',
-        'github/lucas-lima-s/claude-skill-repo-audit',
-        'github/rhysha/claude-security-research-skill',
         'github/straygizmo/mdium',
       ].sort()
     )
@@ -522,43 +529,15 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
     }
   })
 
-  // SMI-6425 regression boundary: the new lucas-lima-s/claude-skill-repo-audit
-  // entry's messagePattern is scoped to the path-form sensitive_path pattern's
-  // echoed source only. A future genuine leak matching the SIBLING
-  // assignment-form pattern (\bsecrets?\s*[:=]/i) for the same skill and
-  // finding type must still be quarantined, not silently swallowed by this
-  // entry. This proves the scoping is airtight against the real production
-  // allowlist, not just narrowly worded in the JSON reason field.
-  it('does not allowlist the sibling assignment-form sensitive_path pattern for the new entry', () => {
-    const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
-    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
-    const parsed = parseAllowlistFile(raw)
-    const matcher = buildMatcher(parsed.allowlist)
-    const skillId = 'github/lucas-lima-s/claude-skill-repo-audit'
-
-    // The path-form match this entry exists to suppress. Hand-written
-    // messages here would be exactly the anti-false-green-mock pattern the
-    // governance skill warns about (H-3): a message hardcoded to what the
-    // scanner used to emit stays green even if a later change alters the
-    // format, hiding a real re-quarantine. Derive it from the actual
-    // scanner instead — content adjacent to a real, currently-allowlisted
-    // secrets-path mention with no action evidence nearby.
-    const pathFormFinding = scanSensitivePaths(
-      'Publish-readiness gate: secret/PII scans, git-history identity leaks'
-    ).find((f) => f.type === 'sensitive_path')
-    expect(pathFormFinding, 'fixture no longer produces a sensitive_path finding').toBeDefined()
-    expect(matcher.isAllowed(skillId, pathFormFinding!)).toBe(true)
-
-    // A hypothetical future assignment-form leak for the SAME skill and
-    // finding type must still be caught — also derived from the real
-    // scanner, a genuine `secrets: <value>` assignment.
-    const assignmentFormFinding = scanSensitivePaths('secrets: Tr0ub4dor&3').find(
-      (f) => f.type === 'sensitive_path'
-    )
-    expect(
-      assignmentFormFinding,
-      'fixture no longer produces a sensitive_path finding'
-    ).toBeDefined()
-    expect(matcher.isAllowed(skillId, assignmentFormFinding!)).toBe(false)
-  })
+  // SMI-6425's regression-boundary test for the lucas-lima-s/
+  // claude-skill-repo-audit entry's messagePattern scoping lived here. That
+  // entry was retired under SMI-6466 (live post-merge re-scan confirmed the
+  // MF-3 gate clears it to MEDIUM without any allowlist entry at all), so the
+  // entry-specific scoping proof no longer has an entry to prove airtight
+  // scoping for — removed rather than left asserting against a skillId with
+  // zero matching allowlist rows. The underlying scanner behavior (path-form
+  // vs. assignment-form sensitive_path classification) stays covered by
+  // packages/core/tests/security/sensitive-path-fp.test.ts and
+  // sensitive-path-adversarial-review.test.ts, which test the scanner
+  // directly rather than through an allowlist entry.
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** Removed 4 entries from the security scanner's allowlist that a recent scanner fix (SMI-5207) made redundant. These skills no longer need a manual exception — the scanner now clears them on its own.

**Quality bar:** Verified live, not just reasoned from the plan. Ran a full-corpus post-merge security scan plus a targeted re-scan of each skill's real GitHub content with the allowlist entries removed.

**Found along the way:** Two of the four entries (`kcmadden/claude-code-1password-skill`, `rhysha/claude-security-research-skill`) cleared because their GitHub descriptions have since changed, not because the scanner's tightened classifier caught them as SMI-5207's plan predicted. That classifier fix was never actually exercised against their original text in this live check — it's still covered at the unit-test level, but not proven against real-world content. Recording this against SMI-5207's plan doc so the gap isn't lost.

**Net result:** All four entries removed. Allowlist count: 13 → 9.

---

## Technical detail

- `data/skills-security-allowlist.json` — removed 4 entries: `binnukarunakar/icm-shipwright`, `lucas-lima-s/claude-skill-repo-audit`, `kcmadden/claude-code-1password-skill`, `rhysha/claude-security-research-skill`.
- `packages/core/tests/skill-scanner/allowlist.test.ts` — updated entry count from 13 to 9; removed the SMI-6425 entry-scoping regression test tied to the removed `icm-shipwright` entry. That test's actual coverage (scanner path-form vs. assignment-form behavior) lives on in `sensitive-path-adversarial-review.test.ts` and `sensitive-path-fp.test.ts`.
- Verification: `weekly-security-scan.yml` corpus run [34253264384](https://github.com/smith-horn/skillsmith/actions/runs/34253264384) (post-merge), plus a targeted re-scan of each skill's live GitHub content through the actual scanner with the edited allowlist active.
  - `binnukarunakar/icm-shipwright` — sensitive_path MEDIUM, not quarantined. Clears via MF-3 as predicted.
  - `lucas-lima-s/claude-skill-repo-audit` — sensitive_path MEDIUM, not quarantined; also present in the full corpus run. Clears via MF-3 as predicted.
  - `kcmadden/claude-code-1password-skill` — zero findings (LOW). Prediction said MF-4 → MEDIUM; the live description no longer contains any assignment-shaped text matching `SENSITIVE_PATH_PATTERNS`, so MF-4 is never reached. Clear is content-driven, not gate-driven.
  - `rhysha/claude-security-research-skill` — zero findings (LOW), same content-driven mechanism.
- 829 tests green in-container.



[skip-impl-check] — this PR only edits data/skills-security-allowlist.json (a config file) and its test; no packages/*/src implementation code changes.
