### PR TITLE
feat(ci): SMI-6457 -- static guard for host-side fs ops against docker-compose.yml named volumes

### DIFF
--- a/scripts/audit-host-volume-fs-guard-helpers.mjs
+++ b/scripts/audit-host-volume-fs-guard-helpers.mjs
@@ -1,0 +1,288 @@
+/**
+ * audit-host-volume-fs-guard-helpers — SMI-6457.
+ *
+ * Static guard flagging host-side filesystem operations (rm -rf, test -f,
+ * existsSync, etc.) against a path docker-compose.yml has migrated onto a
+ * Docker named volume — the exact bug class behind SMI-6453 (a container-run
+ * server's dependency probe read stale host-side bytes) and SMI-6454 (a
+ * host-run launcher's remediation text told the user to run a container-side
+ * fix that could never reach the host bytes it needed to repair).
+ *
+ * This is a heuristic CANDIDATE GENERATOR, not a definitive classifier: it
+ * cannot know whether a given script's own server process runs host-side
+ * (where a host-side check is correct) or container-side (where it is the
+ * SMI-6453 bug). scripts/mcp-skillsmith-launcher.sh is a confirmed, expected
+ * false-positive source for exactly this reason (SMI-6454's own Out-of-Scope
+ * note) — every match is a candidate for human review, not a verdict.
+ *
+ * See docs/internal/implementation/smi-6457-host-vs-named-volume-fs-op-guard.md
+ * for the full design and its plan-review record.
+ */
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+// js-yaml via createRequire, same pattern already used in
+// scripts/audit-standards.mjs's retro-frontmatter check.
+const require = createRequire(import.meta.url)
+const yaml = require('js-yaml')
+
+const ROOT_ENV_VAR_RE = /^process\.env\.[A-Z0-9_]*REPO_ROOT[A-Z0-9_]*$/
+
+/**
+ * Parses docker-compose.yml text and returns the repo-relative paths backed
+ * by a Docker named volume (not a host bind mount). A `volumes:` list entry
+ * `<name>:<container-path>[:mode]` is a named-volume mount iff `<name>` is
+ * also a key under the top-level `volumes:` block. A literal host path
+ * (starts with '.', '/', or `~`) is a bind mount. A source containing `${`
+ * (shell/Compose interpolation) is UNKNOWN and skipped -- it could resolve
+ * to either shape, and assuming either direction risks a wrong verdict
+ * (plan-review finding, SMI-6457).
+ */
+export function parseNamedVolumeRepoRelativePaths(composeYamlText) {
+  const doc = yaml.load(composeYamlText)
+  if (!doc || typeof doc !== 'object') return []
+
+  const namedVolumeKeys = new Set(Object.keys(doc.volumes ?? {}))
+  const paths = new Set()
+
+  for (const service of Object.values(doc.services ?? {})) {
+    for (const entry of service?.volumes ?? []) {
+      if (typeof entry !== 'string') continue // long syntax (type/source/target) -- out of scope, see plan
+      const parts = entry.split(':')
+      if (parts.length < 2) continue
+      const [source, containerPath] = parts
+      if (source.includes('${')) continue // interpolated -- unknown, skip (never assume bind or volume)
+      if (!namedVolumeKeys.has(source)) continue // literal host path -- bind mount, not a named volume
+      if (containerPath === '/app') continue // mount root itself, no repo-relative sub-path
+      if (!containerPath.startsWith('/app/')) continue // named volume outside /app -- no repo-relative equivalent
+      paths.add(containerPath.slice('/app/'.length).replace(/\/+$/, ''))
+    }
+  }
+  return [...paths]
+}
+
+// ---- Pass 1: single-hop variable resolution -------------------------------
+
+const BASH_LITERAL_ASSIGN_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)=(["'])(.*?)\2\s*$/
+const JS_LITERAL_ASSIGN_RE =
+  /^\s*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(["'`])(.*?)\2\s*;?\s*$/
+const JS_JOIN_ASSIGN_RE =
+  /^\s*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*join\((.*)\)\s*;?\s*$/
+
+/** Strips a `$REPO_ROOT/` or `${REPO_ROOT}/` prefix, returning the literal suffix (or the input unchanged if no such prefix is present). */
+function stripRootVarPrefix(text) {
+  const m = text.match(/^\$\{?(REPO_ROOT)\}?\/(.*)$/)
+  return m ? m[2] : text
+}
+
+/** Resolves a comma-separated `join(...)` argument list to a literal-prefix path, stopping at the first unresolvable (dynamic) argument. Root-env-var args (`process.env.*REPO_ROOT*`) contribute nothing. */
+function resolveJoinArgsToPrefix(argsText, varMap) {
+  const args = splitTopLevelArgs(argsText)
+  const segments = []
+  for (const rawArg of args) {
+    const arg = rawArg.trim()
+    const strLit = arg.match(/^(["'`])(.*)\1$/)
+    if (strLit) {
+      segments.push(strLit[2])
+      continue
+    }
+    if (ROOT_ENV_VAR_RE.test(arg)) continue // root placeholder, contributes nothing
+    if (varMap.has(arg) && varMap.get(arg) != null) {
+      segments.push(varMap.get(arg))
+      continue
+    }
+    // First unresolvable argument -- stop here; segments so far are the
+    // static prefix (SMI-6457 plan-review fix: a dynamic tail does not
+    // disqualify the prefix already established).
+    break
+  }
+  return segments.join('/')
+}
+
+function splitTopLevelArgs(argsText) {
+  const args = []
+  let depth = 0
+  let current = ''
+  let quote = null
+  for (const ch of argsText) {
+    if (quote) {
+      current += ch
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch
+      current += ch
+      continue
+    }
+    if (ch === '(') depth++
+    if (ch === ')') depth--
+    if (ch === ',' && depth === 0) {
+      args.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  if (current.trim()) args.push(current)
+  return args
+}
+
+/** Builds a `Map<varName, resolvedRelativePathOrNull>` for one file's text, per Pass 1's three recognized grammars (plan §1). */
+function buildVariableMap(lines) {
+  const varMap = new Map()
+  for (const line of lines) {
+    const bashMatch = line.match(BASH_LITERAL_ASSIGN_RE)
+    if (bashMatch) {
+      varMap.set(bashMatch[1], stripRootVarPrefix(bashMatch[3]))
+      continue
+    }
+    const jsLitMatch = line.match(JS_LITERAL_ASSIGN_RE)
+    if (jsLitMatch && !jsLitMatch[3].includes('${')) {
+      varMap.set(jsLitMatch[1], jsLitMatch[3])
+      continue
+    }
+    const joinMatch = line.match(JS_JOIN_ASSIGN_RE)
+    if (joinMatch) {
+      varMap.set(joinMatch[1], resolveJoinArgsToPrefix(joinMatch[2], varMap))
+      continue
+    }
+  }
+  return varMap
+}
+
+// ---- Pass 2: operation scan ------------------------------------------------
+
+// `[ -f`/`[ -d`/`[ ! -f`/`[ ! -d` use a negative lookbehind so they don't
+// double-fire inside a `[[ -f`/`[[ -d` token (the second `[` of `[[` would
+// otherwise itself match `\[\s+-f\s+`, producing a duplicate finding).
+const OPERATORS = [
+  { name: 'rm -rf', re: /rm\s+-rf\s+/g },
+  { name: 'test -f', re: /\btest\s+-f\s+/g },
+  { name: 'test -d', re: /\btest\s+-d\s+/g },
+  { name: '[[ -f', re: /\[\[\s+-f\s+/g },
+  { name: '[[ -d', re: /\[\[\s+-d\s+/g },
+  { name: '[ -f', re: /(?<!\[)\[\s+-f\s+/g },
+  { name: '[ ! -f', re: /(?<!\[)\[\s+!\s+-f\s+/g },
+  { name: '[ -d', re: /(?<!\[)\[\s+-d\s+/g },
+  { name: '[ ! -d', re: /(?<!\[)\[\s+!\s+-d\s+/g },
+  { name: 'existsSync', re: /existsSync\(\s*/g },
+  { name: 'fs.access', re: /fs\.access\(\s*/g },
+]
+
+/** Extracts the static (fully-literal-or-resolved) prefix of a bash target token, stopping at the first `$` interpolation -- a dynamic trailing segment (e.g. `$dep_name`) does not disqualify the literal prefix before it. */
+function resolveBashTarget(token, varMap) {
+  const unquoted = token.replace(/^["']|["']$/g, '')
+  const bareVarMatch = unquoted.match(/^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/)
+  if (bareVarMatch) {
+    return varMap.get(bareVarMatch[1]) ?? null
+  }
+  const varPrefixMatch = unquoted.match(/^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?\/(.*)$/)
+  if (varPrefixMatch) {
+    const resolved = varMap.get(varPrefixMatch[1])
+    return resolved != null ? `${resolved}/${varPrefixMatch[2].split('$')[0]}` : null
+  }
+  const dollarIdx = unquoted.indexOf('$')
+  if (dollarIdx === -1) return unquoted // fully literal
+  if (dollarIdx === 0) return null // starts with an unresolvable variable, no literal prefix at all
+  return unquoted.slice(0, dollarIdx) // literal prefix before the interpolation
+}
+
+/** Extracts the static prefix of a JS target expression: a string literal, a resolved bare variable, or a `join(...)` call's literal-prefix (per resolveJoinArgsToPrefix). */
+function resolveJsTarget(exprText, varMap) {
+  const trimmed = exprText.trim()
+  const strLit = trimmed.match(/^(["'`])(.*)\1$/)
+  if (strLit) return strLit[2]
+  const joinCall = trimmed.match(/^join\((.*)\)$/)
+  if (joinCall) {
+    const prefix = resolveJoinArgsToPrefix(joinCall[1], varMap)
+    return prefix || null
+  }
+  if (varMap.has(trimmed)) return varMap.get(trimmed)
+  return null
+}
+
+/** True iff `target` (a resolved static prefix) falls at or beneath one of `namedVolumePaths` -- a full path-segment match, never a partial-segment string match (e.g. `node_modules-foo` must NOT match `node_modules`). */
+function matchesNamedVolumePath(target, namedVolumePaths) {
+  if (!target) return null
+  const norm = target.replace(/^\.\//, '').replace(/\/+$/, '')
+  for (const p of namedVolumePaths) {
+    if (norm === p || norm.startsWith(`${p}/`)) return p
+  }
+  return null
+}
+
+function extractTargetToken(line, matchEndIndex, operatorName) {
+  const rest = line.slice(matchEndIndex)
+  if (operatorName === 'existsSync' || operatorName === 'fs.access') {
+    // Balance parens from the already-consumed opening '(' to find the
+    // first top-level argument (or the whole call if it has none).
+    let depth = 1
+    let end = 0
+    for (let i = 0; i < rest.length; i++) {
+      if (rest[i] === '(') depth++
+      if (rest[i] === ')') depth--
+      if (depth === 0) {
+        end = i
+        break
+      }
+    }
+    return { isJs: true, text: rest.slice(0, end || rest.length) }
+  }
+  const tokenMatch = rest.match(/^\S+/)
+  return { isJs: false, text: tokenMatch ? tokenMatch[0] : '' }
+}
+
+/**
+ * Scans `files` (repo-relative paths) for host-side operations against a
+ * `namedVolumePaths` path, using the two-pass design in the SMI-6457 plan.
+ * Returns `{file, line: lineNumber (1-indexed), operation, matchedPath, lineText}[]`.
+ */
+export function findHostSideNamedVolumeOps(files, namedVolumePaths) {
+  const findings = []
+  for (const file of files) {
+    let text
+    try {
+      text = readFileSync(file, 'utf8')
+    } catch {
+      continue
+    }
+    const lines = text.split('\n')
+    const varMap = buildVariableMap(lines)
+
+    lines.forEach((line, idx) => {
+      for (const op of OPERATORS) {
+        op.re.lastIndex = 0
+        let m
+        while ((m = op.re.exec(line))) {
+          const beforeText = line.slice(0, m.index)
+          if (/docker\s+exec/i.test(beforeText)) continue // same-line docker-exec wrap -- correctly scoped
+
+          const { isJs, text: targetText } = extractTargetToken(line, op.re.lastIndex, op.name)
+          if (!targetText) continue
+
+          const target = isJs
+            ? resolveJsTarget(targetText, varMap)
+            : resolveBashTarget(targetText, varMap)
+          const matchedPath = matchesNamedVolumePath(target, namedVolumePaths)
+          if (!matchedPath) continue
+
+          findings.push({
+            file,
+            line: idx + 1,
+            operation: op.name,
+            matchedPath,
+            lineText: line.trim(),
+          })
+        }
+      }
+    })
+  }
+  return findings
+}
+
+/** Builds the `${file}:${trimmedLineText}` allowlist key for one finding (content-fingerprint, not line-number-keyed -- SMI-6457 plan review). */
+export function allowlistKeyFor(finding) {
+  return `${finding.file}:${finding.lineText}`
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -46,6 +46,11 @@ import {
   classifyGitCryptScanResult,
 } from './audit-standards-helpers.mjs'
 import { getFilesRecursive } from './audit-file-walker-helpers.mjs'
+import {
+  parseNamedVolumeRepoRelativePaths,
+  findHostSideNamedVolumeOps,
+  allowlistKeyFor,
+} from './audit-host-volume-fs-guard-helpers.mjs'
 import { isGitCryptEncrypted } from './ci/check-supply-chain-pins.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
@@ -5821,6 +5826,107 @@ console.log(`\n${BOLD}Check 65: test-suite manifest hygiene (SMI-6343)${RESET}`)
         `Remove the stale entry for '${stale}' — an unnecessary allowlist grant is itself a finding ` +
           '(Check 62 precedent), because a silently-stale row masks a real future regression at that path.'
       )
+    }
+  }
+}
+
+// Check 66: host-side fs ops against docker-compose.yml named-volume paths (SMI-6457)
+console.log(
+  `\n${BOLD}Check 66: host-side fs ops against docker-compose.yml named-volume paths (SMI-6457)${RESET}`
+)
+{
+  const CHECK_66_SHADOW_END_DATE = '2026-10-20'
+  const inShadow = new Date() < new Date(CHECK_66_SHADOW_END_DATE)
+  const report = inShadow ? warn : fail
+  const shadowSuffix = inShadow
+    ? ` [shadow mode through ${CHECK_66_SHADOW_END_DATE} — advisory only]`
+    : ''
+
+  // Heuristic candidate-generator, not a definitive classifier — a matched
+  // line means "a host-side fs op targets a docker-compose.yml named-volume
+  // path with no same-line docker exec wrap", NOT "this is a bug." Each row
+  // below is a confirmed-correct host-side check (its script's own server
+  // runs host-only, or the check never crosses a host/container boundary at
+  // all), triaged during Check 66's own Wave 2 calibration against `main`
+  // (SMI-6457) — never a bare "looked fine" grant.
+  const HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS = {
+    'scripts/mcp-skillsmith-launcher.sh:if [ ! -f "$NM_SENTINEL" ]; then':
+      "the skillsmith MCP server itself runs entirely on the HOST (no docker exec in this launcher's own invocation, SMI-6454) — a host-side check here is correct, not the SMI-6453 bug shape",
+    'scripts/mcp-skillsmith-launcher.sh:if (existsSync(join(pkgDir, "node_modules", name))) return "nested-corrupt";':
+      'same host-only launcher as above — the DEP_PROBE_JS dependency probe correctly runs host-side',
+    'scripts/mcp-skillsmith-launcher.sh:"    rm -rf packages/mcp-server/node_modules/$dep_name':
+      'inert remediation TEXT inside emit_error(), never executed by the script itself, AND correct even if it were (host-only launcher, SMI-6454 fix)',
+    'scripts/lib/check-node-modules-fresh.sh:if [ -f "$SENTINEL" ]; then':
+      'this IS the canonical HOST-tree freshness guard (SMI-5343/5344/6006) — checking host bytes is its entire documented purpose',
+    'scripts/lib/check-node-modules-fresh.sh:if [ ! -f "$SENTINEL" ]; then':
+      'same guard as above, the inverse branch',
+    'scripts/repair-host-native-deps.sh:rm -rf "$dest"':
+      'file header: "audit:host-npm-required ... by-design host-side native binding rebuild per SMI-4549; cannot run in Docker" — deliberately host-only',
+    'scripts/repair-host-native-deps.sh:warn "$pkg_name: refetched but bin/esbuild still fails the ELF check — manual recovery: rm -rf node_modules/@esbuild/$(basename "${linux_dir%/}") && npm pack $pkg_name@$version"':
+      'same host-only script as above — inert instructional text inside a warn() call',
+    'scripts/repair-host-native-deps.sh:if [[ -d "$ROOT_BSQLITE_DIR" ]]; then':
+      'same host-only script, SMI-4780 fallback probe',
+    'scripts/repair-host-native-deps.sh:rm -rf node_modules/better-sqlite3':
+      'same host-only script, root binding reset',
+  }
+
+  const composePath = 'docker-compose.yml'
+  if (!existsSync(composePath)) {
+    warn('Check 66: docker-compose.yml not found — skipping')
+  } else {
+    const namedVolumePaths = parseNamedVolumeRepoRelativePaths(readFileSync(composePath, 'utf8'))
+    // scripts/audit-standards.mjs itself is excluded: HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS
+    // necessarily embeds, as string literals, the exact flagged text of real
+    // findings from OTHER files (for documentation) — Check 66's own
+    // operator/target-resolution logic can't distinguish that from real
+    // executable code, so this file unavoidably self-matches its own
+    // allowlist strings. Confirmed during Check 66's Wave 2 calibration
+    // (SMI-6457) — the one otherwise-legitimate finding this file itself
+    // produced (an npm-overrides existsSync() check that is self-referential
+    // and never crosses a host/container boundary) was independently
+    // confirmed correct before this exclusion was added.
+    const scanFiles = getFilesRecursive('scripts', ['.sh', '.ts', '.mjs']).filter(
+      (f) => !f.includes('.test.') && f !== join('scripts', 'audit-standards.mjs')
+    )
+    const findings = findHostSideNamedVolumeOps(scanFiles, namedVolumePaths)
+
+    const seenAllowlistKeys = new Set()
+    const unallowlisted = []
+    for (const finding of findings) {
+      const key = allowlistKeyFor(finding)
+      if (key in HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS) {
+        seenAllowlistKeys.add(key)
+      } else {
+        unallowlisted.push(finding)
+      }
+    }
+    const staleAllowlistKeys = Object.keys(HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS).filter(
+      (k) => !seenAllowlistKeys.has(k)
+    )
+
+    if (unallowlisted.length === 0 && staleAllowlistKeys.length === 0) {
+      pass(
+        `Check 66: no unallowlisted host-side fs op(s) found against docker-compose.yml's ` +
+          `${namedVolumePaths.length} named-volume path(s) (${seenAllowlistKeys.size} confirmed-correct match(es) allowlisted)`
+      )
+    } else {
+      for (const f of unallowlisted) {
+        report(
+          `Check 66: ${f.file}:${f.line} — ${f.operation} targets '${f.matchedPath}' (a docker-compose.yml ` +
+            `named-volume path) with no same-line docker exec wrap${shadowSuffix}`,
+          `This is a CANDIDATE for the SMI-6453/SMI-6454 bug class, not a confirmed bug — verify whether the ` +
+            `containing script's own server/process runs host-side (host check is correct) or container-side ` +
+            `(host check is the bug). If confirmed correct, add '${allowlistKeyFor(f)}' to ` +
+            `HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS in scripts/audit-standards.mjs with a specific reason.`
+        )
+      }
+      for (const stale of staleAllowlistKeys) {
+        report(
+          `Check 66: '${stale}' is allowlisted in HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS but no longer ` +
+            `matches a current finding (the line changed or moved)${shadowSuffix}`,
+          `Remove the stale entry — an unnecessary allowlist grant is itself a finding (Check 62/65 precedent).`
+        )
+      }
     }
   }
 }

--- a/scripts/tests/audit-host-volume-fs-guard.test.ts
+++ b/scripts/tests/audit-host-volume-fs-guard.test.ts
@@ -1,0 +1,149 @@
+/**
+ * SMI-6457: static guard flagging host-side fs ops against a docker-compose.yml
+ * named-volume path. Fixture cases use the EXACT pre-fix source shapes from
+ * SMI-6453 (not substituted-literal stand-ins) per the plan's Wave 1 Step 3.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+// @ts-expect-error - .mjs helper has no typings
+import {
+  parseNamedVolumeRepoRelativePaths,
+  findHostSideNamedVolumeOps,
+  allowlistKeyFor,
+} from '../audit-host-volume-fs-guard-helpers.mjs'
+
+const FIXTURE_COMPOSE_YAML = `
+services:
+  dev:
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+      - mcp-server-node-modules:/app/packages/mcp-server/node_modules
+      - doc-retrieval-mcp-node-modules:/app/packages/doc-retrieval-mcp/node_modules
+      - website-vercel-output:/app/packages/website/.vercel
+      - \${HOST_CACHE_DIR}:/app/some-cache
+volumes:
+  node_modules:
+  mcp-server-node-modules:
+  doc-retrieval-mcp-node-modules:
+  website-vercel-output:
+`
+
+describe('parseNamedVolumeRepoRelativePaths', () => {
+  it('collects repo-relative paths for named-volume mounts only', () => {
+    const paths = parseNamedVolumeRepoRelativePaths(FIXTURE_COMPOSE_YAML)
+    expect(paths).toContain('node_modules')
+    expect(paths).toContain('packages/mcp-server/node_modules')
+    expect(paths).toContain('packages/doc-retrieval-mcp/node_modules')
+    expect(paths).toContain('packages/website/.vercel')
+  })
+
+  it('excludes the bind-mount root (.:/app)', () => {
+    const paths = parseNamedVolumeRepoRelativePaths(FIXTURE_COMPOSE_YAML)
+    expect(paths).not.toContain('')
+  })
+
+  it('excludes an interpolated ${VAR} source (unknown, not assumed-bind)', () => {
+    const paths = parseNamedVolumeRepoRelativePaths(FIXTURE_COMPOSE_YAML)
+    expect(paths).not.toContain('some-cache')
+  })
+})
+
+describe('findHostSideNamedVolumeOps', () => {
+  const roots: string[] = []
+  const namedVolumePaths = [
+    'node_modules',
+    'packages/mcp-server/node_modules',
+    'packages/doc-retrieval-mcp/node_modules',
+  ]
+
+  function makeFile(content: string): string {
+    const root = mkdtempSync(join(tmpdir(), 'smi6457-'))
+    roots.push(root)
+    const file = join(root, 'launcher.sh')
+    writeFileSync(file, content, 'utf8')
+    return file
+  }
+
+  afterEach(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true })
+  })
+
+  it('fires on the NM_SENTINEL shape (cross-line variable resolution)', () => {
+    const file = makeFile(
+      [
+        '#!/usr/bin/env bash',
+        'NM_SENTINEL="$REPO_ROOT/node_modules/.package-lock.json"',
+        'if [ ! -f "$NM_SENTINEL" ]; then',
+        '  echo missing',
+        'fi',
+      ].join('\n')
+    )
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].matchedPath).toBe('node_modules')
+    expect(findings[0].operation).toBe('[ ! -f')
+  })
+
+  it('fires on the ${REPO_ROOT} (braced) variant', () => {
+    const file = makeFile(
+      ['NM_SENTINEL="${REPO_ROOT}/node_modules/.package-lock.json"', 'test -f "$NM_SENTINEL"'].join(
+        '\n'
+      )
+    )
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].matchedPath).toBe('node_modules')
+  })
+
+  it('fires on the nested-corrupt rm -rf shape via static-prefix matching (dynamic $dep_name tail)', () => {
+    const file = makeFile('rm -rf packages/doc-retrieval-mcp/node_modules/$dep_name')
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].matchedPath).toBe('packages/doc-retrieval-mcp/node_modules')
+    expect(findings[0].operation).toBe('rm -rf')
+  })
+
+  it('does NOT fire when the same nested-corrupt line is docker-exec-wrapped', () => {
+    const file = makeFile(
+      `docker exec "$CONTAINER" sh -c 'rm -rf packages/doc-retrieval-mcp/node_modules/$dep_name'`
+    )
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(0)
+  })
+
+  it('does NOT fire on a target with no resolvable static prefix at all', () => {
+    const file = makeFile('existsSync(dynamicPathFromElsewhere)')
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(0)
+  })
+
+  it('does NOT fire on a path outside any named volume', () => {
+    const file = makeFile('if [ -f "packages/mcp-server/dist/src/index.js" ]; then true; fi')
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(0)
+  })
+
+  it('resolves a JS existsSync(join(...)) call with a literal-prefix + dynamic-tail argument', () => {
+    const file = makeFile(
+      [
+        'const pkgDir = join(process.env.SKILLSMITH_LAUNCHER_REPO_ROOT, "packages", "mcp-server");',
+        'existsSync(join(pkgDir, "node_modules", name))',
+      ].join('\n')
+    )
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].matchedPath).toBe('packages/mcp-server/node_modules')
+  })
+
+  it('allowlistKeyFor is a stable content fingerprint, not line-number-keyed', () => {
+    const file = makeFile('\n\n\nrm -rf packages/doc-retrieval-mcp/node_modules/$dep_name')
+    const findings = findHostSideNamedVolumeOps([file], namedVolumePaths)
+    expect(findings).toHaveLength(1)
+    expect(allowlistKeyFor(findings[0])).toBe(
+      `${file}:rm -rf packages/doc-retrieval-mcp/node_modules/$dep_name`
+    )
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** a new automated check catches a whole class of bug before it ships — a dev script mistakenly assuming files inside Docker and files on your laptop are the same, when they've actually been split apart by a container volume. This is the exact mistake behind two recent fixes (SMI-6453, SMI-6454). The new check scans every script for that pattern and flags candidates for review. It runs in advisory mode for six weeks before it can block anything.

**Quality bar:** plan reviewed twice by an independent model before any code was written — the first pass caught a real gap that would have missed the exact bug this check exists to catch. Calibrated against the real codebase: found 12 candidates, confirmed 9 as correct and documented why, left 2 as live warnings.

**Found along the way:** those 2 remaining warnings are a genuine, live instance of the same bug pattern in two old scripts — filed separately as SMI-6473 rather than fixed here, since it's not yet clear whether those scripts are still used or should just be deleted.

**Net result:** fully shipped, no follow-up needed for this PR (SMI-6473 tracks the separate finding).

---

## Technical detail

- `scripts/audit-host-volume-fs-guard-helpers.mjs` (new) — parses `docker-compose.yml` for named-volume mount targets, then a two-pass scanner: Pass 1 resolves simple same-file bash/JS variable assignments to literal paths; Pass 2 scans `rm -rf`/`test -f`/`[ -f`/`[[ -f`/`existsSync`/`fs.access` for a target whose STATIC PREFIX (not necessarily the whole expression — a dynamic trailing segment like `$dep_name` doesn't disqualify an otherwise-literal prefix) reaches a named-volume path, unless the same line is already `docker exec`-wrapped.
- `scripts/audit-standards.mjs` — new `Check 66`, shadow mode (warn-only) through 2026-10-20, then promotes to fail (Check 59/65's convention). `HOST_VOLUME_GUARD_ALLOWLIST_JUSTIFICATIONS` documents the 9 confirmed-correct matches (`mcp-skillsmith-launcher.sh`'s known-correct host-only checks, `check-node-modules-fresh.sh`'s documented HOST-tree guard, `repair-host-native-deps.sh`'s by-design host-only native rebuild). `scripts/audit-standards.mjs` itself is excluded from the scan — its own allowlist necessarily embeds, as string literals, the exact flagged text of real findings, which otherwise re-triggers the check against itself (found and fixed during this session's calibration run, documented at the exclusion site).
- `scripts/tests/audit-host-volume-fs-guard.test.ts` (new) — 11 tests, all 5 plan-mandated fixture cases (NM_SENTINEL cross-line resolution, `${REPO_ROOT}` braced variant, nested-corrupt `$dep_name` dynamic-suffix static-prefix match, docker-exec-wrapped non-match, fully-unresolvable non-match) plus 3 more.
- Plan: `docs/internal/implementation/smi-6457-host-vs-named-volume-fs-op-guard.md` — two rounds of GPT-5.6-Sol review via NEEDLE (ADR-128). Round 1 found a blocking gap: the original design would have silently skipped the exact `nested-corrupt` acceptance-criteria case (dynamic `$dep_name` suffix), fixed pre-implementation via static-prefix matching.
- Code review: `docs/internal/code_review/2026-09-08-smi-6457-host-volume-fs-guard.md` — 0 findings.
- No production/runtime behavior change — new dev-tooling static-analysis check only, shadow mode.

Linear: SMI-6457 (SMI-6473 filed separately for the genuine finding)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

