### PR TITLE
chore(release): weekly cadence bump — 2026-09-09

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35162,7 +35162,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -35193,8 +35193,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.12.2",
-        "@skillsmith/mcp-server": "^0.7.13",
+        "@skillsmith/core": "^0.12.3",
+        "@skillsmith/mcp-server": "^0.7.14",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.11"
@@ -35203,7 +35203,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@smith-horn/enterprise": "^0.3.9"
+        "@smith-horn/enterprise": "^0.3.10"
       },
       "peerDependenciesMeta": {
         "@smith-horn/enterprise": {
@@ -35324,7 +35324,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -35388,7 +35388,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@ruvector/core": "0.1.32",
-        "@skillsmith/core": "^0.12.2",
+        "@skillsmith/core": "^0.12.3",
         "better-sqlite3": "11.10.0",
         "glob": "11.1.0",
         "minimatch": "10.2.6",
@@ -35529,18 +35529,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1125.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-        "@skillsmith/core": "^0.12.2",
+        "@skillsmith/core": "^0.12.3",
         "jose": "^6.2.2",
         "stripe": "22.6.1",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.13",
+        "@skillsmith/mcp-server": "^0.7.14",
         "@smithy/config-resolver": "4.7.2",
         "@smithy/core": "3.33.3",
         "@smithy/middleware-endpoint": "4.7.2",
@@ -35555,7 +35555,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.13"
+        "@skillsmith/mcp-server": "^0.7.14"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -35601,12 +35601,12 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.12.2",
+        "@skillsmith/core": "^0.12.3",
         "@supabase/supabase-js": "2.114.0",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
@@ -35656,7 +35656,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.10
+
 - **Fixed**: SMI-6472 -- `src/utils/skill-name.ts`'s re-export of `VALID_SKILL_NAME_RE`/`validateSkillName` now imports from the narrow `@skillsmith/core/utils/skill-name` subpath instead of the `@skillsmith/core` package barrel. The barrel import transitively pulled in `skill-installation.io.ts` -> `safe-fs.ts`'s `fs/promises` needs (`open`/`lstat`/`constants`), breaking `tests/create.test.ts`'s narrow `fs/promises` mock (`mkdir`/`writeFile`/`stat` only) with `[vitest] No "constants" export is defined on the "fs/promises" mock`. No behavior change — only the import path.
 
 ## v0.8.9

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills 
 
 ## Contents
 
-- [What's New](#whats-new-in-v089)
+- [What's New](#whats-new-in-v0810)
 - [Installation](#installation)
 - [Commands](#commands)
   - [inventory](#inventory)
@@ -16,7 +16,7 @@ Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills 
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.9
+## What's New in v0.8.10
 
 - **Multi-client targeting fixed across the board**: `install`, `list`, `remove`, `update`, `sync`, and `search -i`'s install action now all honor `SKILLSMITH_CLIENT`/`--client` consistently — previously several of these silently acted on the Claude Code directory regardless of the flag or env var.
 - **`update` no longer fails after a fresh install**: now resolves the installed skill's registry source from the manifest `install` already writes, instead of a dead-code path that could never find it.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
   "bin": {
@@ -39,14 +39,14 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.12.2",
-    "@skillsmith/mcp-server": "^0.7.13",
+    "@skillsmith/core": "^0.12.3",
+    "@skillsmith/mcp-server": "^0.7.14",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.11"
   },
   "peerDependencies": {
-    "@smith-horn/enterprise": "^0.3.9"
+    "@smith-horn/enterprise": "^0.3.10"
   },
   "peerDependenciesMeta": {
     "@smith-horn/enterprise": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.12.3
+
 - **Add**: `SecurityScanner.weak-passwords.ts` — a generated, versioned list of common weak passwords (vendored from SecLists, hash-pinned, capped to the top 5,000 by frequency rank), built by the new `scripts/gen-weak-password-lexicon.mjs` generator and mirrored byte-identically into the Node and Deno/Supabase edge scanner twins. This wave ships the data pipeline only — no scanner behavior changes; the `sensitive_path` detection change that consumes this data is a separate, follow-on change (SMI-6441 Wave 1)
 - **Added**: SMI-6472 -- new `./utils/skill-name` subpath export (`VALID_SKILL_NAME_RE`, `validateSkillName`), matching the existing narrow-subpath convention (`./services/skill-installation-io`, etc.) rather than requiring consumers to import the full package barrel for a small, dependency-free utility.
 - **Fix**: `scripts/skill-scanner/index.ts` no longer runs its CLI `main()` unconditionally at module-load time — the invocation is guarded by the standard `import.meta.url === \`file://${process.argv[1]}\`` check, so importing the barrel for its exports (types, categorizer, trust-scorer, file-scanner, logger, reporter, scanner) no longer hijacks `process.argv`, runs a scan, or exits the importing process. `main` is now exported, and the `scripts/scan-imported-skills.ts` backwards-compat shim (the `weekly-security-scan.yml` entry point) invokes it explicitly under its own identical guard — direct `npx tsx` execution of either file is unchanged (SMI-6464)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,13 +6,13 @@ Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills 
 
 ## Contents
 
-- [What's New](#whats-new-in-v0122)
+- [What's New](#whats-new-in-v0123)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.12.2
+## What's New in v0.12.3
 
 - **New `resolveSessionTier` client** (`sync/license-status-client.ts`): authenticates a stored `skillsmith login` session against `/license-status` so the MCP server can resolve a real subscription tier without a separately-configured `SKILLSMITH_API_KEY`, instead of silently falling back to `community`.
 - **Scanner: bundled-file scan expanded to operational code** (Gap 8 of the ClawHavoc remediation): the indexer now reads `scripts/`, `src/`, and `bin/` alongside `SKILL.md`, closing a blind spot where a backdoor buried mid-function in working operational code was structurally invisible.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.12.2'
+export const VERSION = '0.12.3'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/doc-retrieval-mcp/package.json
+++ b/packages/doc-retrieval-mcp/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@ruvector/core": "0.1.32",
-    "@skillsmith/core": "^0.12.2",
+    "@skillsmith/core": "^0.12.3",
     "better-sqlite3": "11.10.0",
     "glob": "11.1.0",
     "minimatch": "10.2.6",

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.10
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.3.9).
+
 ## v0.3.9
 
 - **Chore**: bump stripe from 20.2.0 to 22.6.1 (#2661)

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1125.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-    "@skillsmith/core": "^0.12.2",
+    "@skillsmith/core": "^0.12.3",
     "jose": "^6.2.2",
     "stripe": "22.6.1",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.13",
+    "@skillsmith/mcp-server": "^0.7.14",
     "@smithy/config-resolver": "4.7.2",
     "@smithy/core": "3.33.3",
     "@smithy/middleware-endpoint": "4.7.2",
@@ -62,7 +62,7 @@
     "vitest": "4.1.11"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.13"
+    "@skillsmith/mcp-server": "^0.7.14"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.14
+
+- **Fix**: SMI-5207 -- sensitive_path action-context gating (Wave 1) (#2760)
 - **Fixed**: SMI-6472 -- `skill_validate` now enforces two additional Agent Skills
   spec requirements that were previously silently accepted. (1) Frontmatter `name` must match
   the canonical slug format (lowercase letters, digits, and hyphens, starting with a lowercase

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server for agent skill publishing, installation, an
 
 Part of Skillsmith: a registry for sharing, scanning, and tracking agent skills across teams.
 
-## What's New in v0.7.13
+## What's New in v0.7.14
 
 - **Fix: 0.7.10 was uninstallable** — it imported `@skillsmith/core` exports (`SessionTierAuthError`, `SessionTierTransientError`, `resolveSessionTier`, `getApiBaseUrl`) that only shipped in core 0.12.0, but this package's own dependency floor still allowed the older, broken-for-this-purpose 0.11.7. The `@skillsmith/core` dependency is now `^0.12.0` (SMI-6143). No other changes in this release.
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
   "type": "module",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.12.2",
+    "@skillsmith/core": "^0.12.3",
     "@supabase/supabase-js": "2.114.0",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.13",
+  "version": "0.7.14",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
@@ -19,7 +19,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -120,7 +120,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.13'
+const PACKAGE_VERSION = '0.7.14'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.10
+
 - **Chore**: SMI-6472 -- `src/utils/skillNameValidation.ts`'s auto-generated header now tracks `packages/core/src/utils/skill-name.ts` as its source instead of `packages/cli/src/utils/skill-name.ts` (`scripts/sync-skill-name-validation.mjs` retargeted, not retired -- retiring it would give the extension a `@skillsmith/core` runtime dependency and trip ADR-113's explicit trip-wire). No functional change: `VALID_SKILL_NAME_RE`/`validateSkillName`'s exported content is byte-identical, only the source-of-truth comment changed.
 
 ## v0.7.9

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "A registry for sharing, scanning, and tracking agent skills across teams.",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).