### PR TITLE
fix(docker): SMI-6491 -- install git-crypt in the dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -286,9 +286,20 @@ RUN npm run build || echo "Build completed with warnings"
 FROM deps AS dev
 
 # SMI-4782 — install psql so scripts/pooler-psql.sh works as documented.
-# Scoped to the dev stage only to keep prod/builder images lean.
+# SMI-6491 — install git-crypt so any in-container git command that touches an
+# encrypted path can run the configured clean/smudge filter. Without it,
+# `git status` fails on supabase/functions/_shared/*, which surfaced two ways:
+# gate-check's G-5 closure test reported `artifact binding: FAILED` (a tooling
+# condition wearing a data verdict's clothes), and Turborepo silently degraded
+# its dirty-hash cache-validity computation to a warning. The git-crypt KEY is
+# already present at runtime via the /app bind mount, and the filters are
+# already registered — only the executable was missing.
+# Both scoped to the dev stage. `builder` is a sibling from `deps` and `prod`
+# descends from `base` via `prod-deps`, so neither inherits these. Compose's
+# `test` service does, since it also builds the `dev` target.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \
+    git-crypt \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -1344,10 +1344,34 @@ try {
     pass('No double-encrypted files')
   }
 } catch {
-  warn(
-    'Skipped (git-crypt not installed) — Check 18 did not run',
-    'Install git-crypt on this runner to exercise this check'
-  )
+  // SMI-6491: "not installed" used to be the only way this could fail inside
+  // the dev container, so the catch-all message was accurate. It no longer is.
+  // The dev image now ships git-crypt, and the remaining in-container failure
+  // is a WORKTREE container, where /app/.git is a file naming a host path that
+  // does not exist inside the container — so no git command runs at all, and
+  // git-crypt exits 1 on `git rev-parse --show-cdup`. Reporting that as
+  // "git-crypt not installed" sends the reader off to install a binary they
+  // already have: the same shape of misleading diagnostic (a tooling condition
+  // wearing another condition's clothes) that SMI-6491 was filed to remove.
+  let gitCryptInstalled = false
+  try {
+    execSync('command -v git-crypt', { stdio: 'ignore' })
+    gitCryptInstalled = true
+  } catch {
+    gitCryptInstalled = false
+  }
+
+  if (gitCryptInstalled) {
+    warn(
+      'Skipped (git-crypt is installed, but `git-crypt status` failed) — Check 18 did not run',
+      'Most often a worktree container: /app/.git is a file naming a host path that does not exist inside it, so no git command can run. Run this check from the main checkout, or on the host.'
+    )
+  } else {
+    warn(
+      'Skipped (git-crypt not installed) — Check 18 did not run',
+      'Install git-crypt on this runner to exercise this check'
+    )
+  }
 }
 
 // 19. docs/ Directory Structure Guard (SMI-2607)

--- a/scripts/tests/git-crypt-filter-registration.test.ts
+++ b/scripts/tests/git-crypt-filter-registration.test.ts
@@ -58,6 +58,21 @@ chmodSync(join(GIT_CRYPT_SHIM_DIR, 'git-crypt'), 0o755)
 const GIT_ENV = { ...makeFixtureEnv(), PATH: `${GIT_CRYPT_SHIM_DIR}:${process.env.PATH ?? ''}` }
 
 /**
+ * Every temp directory created during a test, removed in `afterEach`.
+ *
+ * Declared here rather than beside `afterEach` below because
+ * `mirrorWithoutGitCrypt` pushes to it. That function is only ever called
+ * from inside a test, so a later declaration would work — but only by
+ * accident; calling it at module scope would throw on the TDZ.
+ *
+ * `rmSync(..., { recursive: true })` unlinks symlinks rather than following
+ * them, so removing a mirror directory never touches the `/usr/bin` entries
+ * it points at. Verified empirically, not assumed — the failure mode if it
+ * were untrue is deleting system binaries.
+ */
+const tempDirs: string[] = []
+
+/**
  * PATH with NO git-crypt reachable at all — neither the shim above nor a real
  * install — while every OTHER executable stays exactly where it was. T9's
  * premise depends on both halves.
@@ -104,7 +119,6 @@ function pathWithoutAnyGitCrypt(): string {
     .join(':')
 }
 
-const tempDirs: string[] = []
 afterEach(() => {
   for (const d of tempDirs) {
     if (existsSync(d)) rmSync(d, { recursive: true, force: true })

--- a/scripts/tests/git-crypt-filter-registration.test.ts
+++ b/scripts/tests/git-crypt-filter-registration.test.ts
@@ -20,7 +20,15 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 import { execFileSync, spawnSync } from 'node:child_process'
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -36,23 +44,63 @@ const REAL_BASH = execFileSync('bash', ['-c', 'command -v bash'], { encoding: 'u
 // it never actually INVOKES git-crypt (repair is pure `git config` calls),
 // so a do-nothing PATH shim is sufficient and keeps these tests hermetic
 // regardless of whether the real binary happens to be installed in the
-// environment running them (it is NOT inside this repo's own Docker dev
-// container by design — git-crypt operations are host-side, see CLAUDE.md's
-// Git-Crypt section — which is exactly the gap that first surfaced this).
+// environment running them.
+//
+// SMI-6491 correction: this comment used to assert git-crypt "is NOT inside
+// this repo's own Docker dev container by design". That is no longer true —
+// the dev image now installs it, because gate-check's G-5 closure test and
+// Turborepo's dirty-hash computation both need the filter to run in-container.
+// The shim remains correct and still keeps the tests hermetic; only the
+// parenthetical claim about the environment was stale.
 const GIT_CRYPT_SHIM_DIR = mkdtempSync(join(tmpdir(), 'git-crypt-shim-'))
 writeFileSync(join(GIT_CRYPT_SHIM_DIR, 'git-crypt'), '#!/bin/sh\nexit 0\n')
 chmodSync(join(GIT_CRYPT_SHIM_DIR, 'git-crypt'), 0o755)
 const GIT_ENV = { ...makeFixtureEnv(), PATH: `${GIT_CRYPT_SHIM_DIR}:${process.env.PATH ?? ''}` }
 
-/** PATH with NO git-crypt reachable at all (neither the shim nor a real install), for T9. */
+/**
+ * PATH with NO git-crypt reachable at all — neither the shim above nor a real
+ * install — while every OTHER executable stays exactly where it was. T9's
+ * premise depends on both halves.
+ *
+ * SMI-6491, two bugs in sequence, both worth recording because the obvious
+ * fixes are the wrong ones:
+ *
+ * 1. The original helper removed only `dirname(command -v git-crypt)`. That
+ *    was correct on a macOS host, where Homebrew provides exactly one
+ *    git-crypt, and broke the moment git-crypt was installed in the dev
+ *    image: Debian's `/bin` is a symlink to `/usr/bin`, so `type -a
+ *    git-crypt` reports BOTH paths. Removing one left the binary reachable
+ *    via the other, and T9's premise was silently false.
+ *
+ * 2. Removing every directory that holds a git-crypt does not work either —
+ *    on Debian that means dropping `/usr/bin` and `/bin`, which takes `git`,
+ *    `dirname`, and `date` with it. `_lib.sh` then dies while being sourced
+ *    (`line 31: dirname: command not found`), the function never reaches the
+ *    gate under test, and the run exits 0 for a reason unrelated to
+ *    git-crypt. Re-supplying `git` alone does not help; the coreutils are
+ *    needed too, and enumerating them is a guessing game.
+ *
+ * So: replace each git-crypt-bearing directory IN PLACE with a temp mirror of
+ * itself — symlinks to every entry except `git-crypt`. PATH order and every
+ * other binary are preserved exactly; only git-crypt disappears. This keeps
+ * T9 exercising the real `command -v git-crypt` gate rather than a seam, and
+ * is indifferent to how many aliases of one directory the OS exposes.
+ */
+function mirrorWithoutGitCrypt(dir: string): string {
+  const mirror = mkdtempSync(join(tmpdir(), 'path-no-git-crypt-'))
+  tempDirs.push(mirror)
+  for (const name of readdirSync(dir)) {
+    if (name === 'git-crypt') continue
+    symlinkSync(join(dir, name), join(mirror, name))
+  }
+  return mirror
+}
+
 function pathWithoutAnyGitCrypt(): string {
-  const real = (() => {
-    const r = spawnSync('bash', ['-c', 'command -v git-crypt'], { encoding: 'utf8' })
-    return r.status === 0 ? dirname(r.stdout.trim()) : null
-  })()
   return (process.env.PATH ?? '')
     .split(':')
-    .filter((p) => p !== GIT_CRYPT_SHIM_DIR && p !== real)
+    .filter((p) => p !== GIT_CRYPT_SHIM_DIR && p !== '')
+    .map((dir) => (existsSync(join(dir, 'git-crypt')) ? mirrorWithoutGitCrypt(dir) : dir))
     .join(':')
 }
 


### PR DESCRIPTION
## Business Summary

**What shipped:**
- The Docker dev container can now read the project's encrypted files. Previously any in-container command touching them failed, and two tools misreported that failure: the census gate-check called it a data problem, and the build system degraded its cache-correctness check to a warning.
- The standards audit names the real reason it skips its encryption check, instead of telling you to install a tool you already have.
- A test that simulated the tool being absent still does so correctly now that the tool is present.

**Quality bar:** Cross-model plan review (GPT-5.6-Sol, ADR-128) returned READY TO IMPLEMENT with no blocking findings. Full test suite: 12,162 passing, 0 failing. Typecheck, lint, format clean; standards audit 0 failures. Every claim in this PR was verified by running the command, including the two fixes that turned out not to work.

**Found along the way:** Nothing deferred — both consequences of the install (the broken test, the now-false audit message) are fixed in this PR rather than filed. The pre-merge gate also caught a wrong line citation in the plan doc's security argument and two verification items filed as un-runnable that in fact were runnable; all three corrected here.

**Net result:** Shipped. Three verification steps remain that can only run in the main checkout's container, because a worktree container cannot run git at all — they are listed in the plan doc and are checks on the fix, not on whether it merges.

---

## Technical detail

### `Dockerfile` — one package

`git-crypt` joins `postgresql-client` in the `dev` stage's existing `apt-get install` block.

The key is already in the container at `/app/.git/git-crypt/keys/default` via the bind mount, and `filter.git-crypt.{clean,smudge}` are already registered. Only the executable was missing. Confirmed installed from the image build, not ad hoc: `dpkg-query -W git-crypt` → `git-crypt 0.7.0-0.1`.

Scope: `builder` is a sibling from `deps` and `prod` descends from `base` via `prod-deps`, so neither inherits the package. Compose's `test` service does, since it also builds the `dev` target.

Security: no new key material and no new privilege — the key was already mounted. `.dockerignore:38` excludes `.git` from the build context, and the built image was checked directly: `ls -la /app/.git` inside it returns `No such file or directory`, so there is no key material in any layer. The one honest nuance, stated in the plan doc rather than glossed: making an already-present key *usable* is itself a capability change, even though it creates no new trust boundary.

Size: 195 KiB installed, 163,224 bytes on disk.

### `scripts/tests/git-crypt-filter-registration.test.ts` — T9 regression

T9 asserts `ensure_git_crypt_filter_registered()` refuses to write config when git-crypt is absent from PATH. Installing the binary falsified its premise. Two repairs fail:

1. **Strip `dirname(command -v git-crypt)`** (the original helper) — correct on macOS with one Homebrew git-crypt. On Debian `/bin` symlinks to `/usr/bin`, so `type -a git-crypt` reports both; removing one leaves the binary reachable through the other.
2. **Strip every git-crypt-bearing directory** — takes `/usr/bin` and `/bin`, and with them `git`, `dirname`, `date`. `_lib.sh` dies while being *sourced* (`line 31: dirname: command not found`), never reaches the gate, and exits 0 for an unrelated reason. Re-supplying `git` alone is not enough; the coreutils are needed too.

What works: replace each git-crypt-bearing directory **in place** with a temp mirror of itself — symlinks to every entry except `git-crypt`. PATH order and every other binary survive. T9 keeps exercising the real `command -v git-crypt` gate rather than substituting a test seam.

Verified 21/21 in the container and on the macOS host. `rmSync(recursive)` unlinks symlinks rather than following them, so tearing down a mirror never touches the `/usr/bin` entries it points at — checked empirically, since the failure mode if untrue is deleting system binaries.

### `scripts/audit-standards.mjs` — Check 18 message

Check 18 wrapped `git-crypt status` in a `try`/`catch` and reported every failure as "Skipped (git-crypt not installed)". Accurate in-container until this PR. Now the remaining in-container failure is a *worktree* container, where `git-crypt status` exits 1 on `git rev-parse --show-cdup` because `/app/.git` is a file naming a host path that does not exist inside it.

The catch now probes `command -v git-crypt` and picks between two messages. `warn()` before, `warn()` after, in both branches — this cannot change a CI outcome. Both branches verified live.

Per this test file's own stated convention, Check 18's I/O layer is exercised by running the script rather than unit-tested in isolation; `npm run audit:standards` was run and the new message confirmed.

### ADR-109

The `Dockerfile` change went through SPARC + cross-model plan review before implementation (`docs/internal/implementation/smi-6491-git-crypt-dev-image.md`). The `scripts/audit-standards.mjs` edit is a message-text correction inside an existing `catch` with no pass/fail behaviour change, made necessary by the Dockerfile change it accompanies.

### Not verifiable in a worktree

A worktree container's `/app/.git` is a file containing an absolute host path that does not exist inside it, so every git command returns `fatal: not a git repository`. The package install is verifiable here; the fix itself is not, because the failure being fixed *is* a git invocation.

Three checks remain for the main checkout's container: `git status --porcelain` over the watched paths, a real `turbo run build` with no dirty-hash warning, and a gate-check without `--skip-closure-tests`.

The plan originally listed five. Key-absence and the size delta need Docker but not git, so they never belonged in that bucket — both are now verified above.

### Pre-merge gate

Cross-family review (ADR-128) was dispatched to GPT-5.6-Sol twice via NEEDLE. Both runs failed on an account usage limit that resets later tonight, the first one cutting off mid-review after it had established the trigger map. The gate was completed same-family per `dispatch.sh`'s own documented fallback. Its findings — the wrong `.dockerignore` line, and the two mis-bucketed verification items — are applied above.

Trigger map: PR-01 through PR-06, PR-08 through PR-11, and PR-13 SKIP (no SQL, no migrations, no edge functions, no module moves, no enums in this diff). PR-07 PASS (a `.ts` file changed, no `catch` added in TypeScript). PR-12 PARTIAL (three plan directives open, documented above with the reason). `audit:standards` PASS — 84 passed, 10 warnings, 0 failures, and none of the warnings originate in this diff.

### Out of scope

- Whether other in-container tooling shells out to git over encrypted paths. Two consumers were found incidentally, not by search.
- Whether turbo cache entries computed under the degraded hash are still live. Not asserting they are wrong — stating that nobody has looked.
