### PR TITLE
fix(website,mcp-server,cli): SMI-6530 -- stop recommending bulk `skillsmith update` until the safety gate ships

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
-- **Security**: Until the update-safety fix ships, preview `skillsmith update` with `--dry-run`;
-  `update --all` in 0.8.8-0.8.10 can overwrite local edits in skill directories that are git
-  clones and can write into the wrong directory (SMI-6528).
+- **Security**: `skillsmith update --all` in CLI 0.8.8-0.8.10 can overwrite local edits in skill
+  directories that are git clones and can write into the wrong directory (SMI-6528). On those
+  versions, preview with `--dry-run` and update skills one at a time; the install-layer fix is
+  tracked in SMI-6529.
 
 ## v0.8.10
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Security**: Until the update-safety fix ships, preview `skillsmith update` with `--dry-run`;
+  `update --all` in 0.8.8-0.8.10 can overwrite local edits in skill directories that are git
+  clones and can write into the wrong directory (SMI-6528).
+
 ## v0.8.10
 
 - **Fixed**: SMI-6472 -- `src/utils/skill-name.ts`'s re-export of `VALID_SKILL_NAME_RE`/`validateSkillName` now imports from the narrow `@skillsmith/core/utils/skill-name` subpath instead of the `@skillsmith/core` package barrel. The barrel import transitively pulled in `skill-installation.io.ts` -> `safe-fs.ts`'s `fs/promises` needs (`open`/`lstat`/`constants`), breaking `tests/create.test.ts`'s narrow `fs/promises` mock (`mkdir`/`writeFile`/`stat` only) with `[vitest] No "constants" export is defined on the "fs/promises" mock`. No behavior change — only the import path.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -142,8 +142,8 @@ names, or `--all` — bare `skillsmith update` with none of those prints usage
 guidance instead of updating anything.
 
 ```bash
-# Update all skills
-skillsmith update --all
+# Preview what --all would change before applying it
+skillsmith update --all --dry-run
 
 # Update one skill
 skillsmith update skill-name
@@ -833,8 +833,8 @@ npm run dev
 ### Manage Skills
 
 ```bash
-# Update all installed skills
-skillsmith update --all
+# Preview updates to all installed skills, then update one at a time
+skillsmith update --all --dry-run
 
 # Remove a skill
 skillsmith remove community/old-skill

--- a/packages/cli/src/commands/manage.action.ts
+++ b/packages/cli/src/commands/manage.action.ts
@@ -406,9 +406,12 @@ async function updateActionImpl(
       console.log(
         chalk.yellow('Specify one or more skills to update, or pass --all for everything.')
       )
+      // SMI-6530 containment: lead with a dry-run review of everything; a bulk,
+      // non-dry-run `update --all` can overwrite local edits until the update
+      // eligibility gate (SMI-6532) ships.
+      console.log(chalk.dim('  skillsmith update --all --dry-run   # review every update first'))
       console.log(chalk.dim('  skillsmith update <skill>'))
       console.log(chalk.dim('  skillsmith update <skill1> <skill2> ...'))
-      console.log(chalk.dim('  skillsmith update --all'))
       console.log(chalk.dim('  skillsmith update <skill> --dry-run'))
       process.exit(1)
     }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Changed**: the agent pack's CLI fallback commands (`CLI_FALLBACK_COMMANDS` in
+  `services/agent-pack/prompt-source.ts`) now lead with `skillsmith update --all --dry-run` and
+  then per-skill updates, instead of recommending `skillsmith update --all` directly. Containment
+  for SMI-6528: `update --all` in CLI 0.8.8-0.8.10 can overwrite local edits in skill directories
+  that are git clones and can write into the wrong directory (SMI-6530).
+
 - **Fix**: `sensitive_path` MF-4 no longer scores an **embedded** assignment key assigned a bare
   boolean as a real credential. `allow_credentials=True` — the standard FastAPI/Starlette CORS
   middleware flag — was scoring HIGH, which makes `SecurityScanner` compute `passed = false`, which

--- a/packages/core/src/services/agent-pack/prompt-source.ts
+++ b/packages/core/src/services/agent-pack/prompt-source.ts
@@ -212,8 +212,9 @@ export const CLI_FALLBACK_PARAGRAPHS: readonly string[] = [
 /** Command lines for the CLI Fallback fenced code block, one per line. */
 export const CLI_FALLBACK_COMMANDS: readonly string[] = [
   '# Keep skills current',
-  'skillsmith diff <skill>       # what changed since your installed version',
-  'skillsmith update <skill>     # or: skillsmith update --all',
+  'skillsmith diff <skill>             # what changed since your installed version',
+  'skillsmith update --all --dry-run   # review updates first',
+  'skillsmith update <skill>           # then update one skill at a time',
   '',
   '# Audit and clean up inventory',
   'skillsmith audit collisions',

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
-- **Security**: Until the update-safety fix ships, preview `skillsmith update` with `--dry-run`;
-  `update --all` in 0.8.8-0.8.10 can overwrite local edits in skill directories that are git
-  clones and can write into the wrong directory (SMI-6528).
+- **Security**: `skillsmith update --all` in CLI 0.8.8-0.8.10 can overwrite local edits in skill
+  directories that are git clones and can write into the wrong directory (SMI-6528). On those
+  versions, preview with `--dry-run` and update skills one at a time; the install-layer fix is
+  tracked in SMI-6529.
 
 ## v0.7.14
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Security**: Until the update-safety fix ships, preview `skillsmith update` with `--dry-run`;
+  `update --all` in 0.8.8-0.8.10 can overwrite local edits in skill directories that are git
+  clones and can write into the wrong directory (SMI-6528).
+
 ## v0.7.14
 
 - **Fix**: SMI-5207 -- sensitive_path action-context gating (Wave 1) (#2760)

--- a/packages/mcp-server/src/assets/agent-pack/SKILL.md
+++ b/packages/mcp-server/src/assets/agent-pack/SKILL.md
@@ -123,8 +123,9 @@ If the MCP server is unavailable, use the CLI directly for the same jobs above. 
 
 ```bash
 # Keep skills current
-skillsmith diff <skill>       # what changed since your installed version
-skillsmith update <skill>     # or: skillsmith update --all
+skillsmith diff <skill>             # what changed since your installed version
+skillsmith update --all --dry-run   # review updates first
+skillsmith update <skill>           # then update one skill at a time
 
 # Audit and clean up inventory
 skillsmith audit collisions

--- a/packages/mcp-server/src/assets/skills/skillsmith/SKILL.md
+++ b/packages/mcp-server/src/assets/skills/skillsmith/SKILL.md
@@ -59,7 +59,8 @@ skillsmith install community/jest-helper
 skillsmith validate ./my-skill
 
 # Maintain
-skillsmith update --all
+skillsmith update --all --dry-run
+skillsmith update <skill>
 skillsmith audit collisions
 
 # Retire
@@ -77,7 +78,7 @@ Some lifecycle operations live in the CLI and have no MCP equivalent (yet). When
 |---|---|
 | Pin a skill to a version | `skillsmith pin <skill> <version>` |
 | Unpin a skill | `skillsmith unpin <skill>` |
-| Update all installed skills | `skillsmith update --all` |
+| Preview updates to all installed skills | `skillsmith update --all --dry-run` |
 | Audit advisories (Team+) | `skillsmith audit advisories` |
 | Audit collisions | `skillsmith audit collisions` |
 | Configure audit mode | `skillsmith config set audit_mode <preventative\|power_user\|governance\|off>` |
@@ -174,8 +175,9 @@ The companion **skill-builder** skill guides you through frontmatter, progressiv
 
 ```
 "Ask Skillsmith for updates to my installed skills"
-# Then run in terminal:
-skillsmith update --all
+# Then run in terminal — preview first, then update skills one at a time:
+skillsmith update --all --dry-run
+skillsmith update <skill>
 ```
 
 ### Audit before sharing your skill folder

--- a/packages/mcp-server/src/tools/outdated.identity.ts
+++ b/packages/mcp-server/src/tools/outdated.identity.ts
@@ -139,13 +139,19 @@ export function buildOutdatedDiagnosis(params: {
         safeToBulkUpdate: true,
       }
     case 'outdated':
+      // SMI-6530 containment: `skillsmith update --all` in CLI 0.8.8-0.8.10 can
+      // overwrite local edits in skill directories that are git clones, or
+      // write into the wrong directory. Until the update eligibility gate
+      // (SMI-6532) ships, this state is excluded from bulk update and points
+      // at a dry-run preview followed by updating the skill on its own.
       return {
         state,
         signal: null,
         inconclusiveReason: null,
         summary: 'The registry has newer content for this id than what is installed.',
-        remediation: 'Run `skillsmith update <name>` to install the newer version.',
-        safeToBulkUpdate: true,
+        remediation:
+          'Preview with `skillsmith update <name> --dry-run`, then update this skill on its own.',
+        safeToBulkUpdate: false,
       }
     case 'local-drift':
       return {

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -732,7 +732,7 @@ describe('executeOutdated', () => {
   // ===========================================================================
 
   describe('tamper-check classification', () => {
-    it('classifies a genuine version bump as outdated (safe to bulk-update) when no signal fires', async () => {
+    it('classifies a genuine version bump as outdated (SMI-6530: excluded from bulk update) when no signal fires', async () => {
       const skillId = 'wrsmith108/astro'
       mockedLoadManifest.mockResolvedValue(
         manifestWithSkills([{ id: skillId, name: 'astro', installPath: '/tmp/skills/astro' }])
@@ -754,8 +754,10 @@ describe('executeOutdated', () => {
       expect(result.skills[0].status).toBe('outdated')
       expect(result.skills[0].diagnosis.state).toBe('outdated')
       expect(result.skills[0].diagnosis.signal).toBeNull()
-      expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(true)
-      expect(result.skills[0].diagnosis.remediation).toMatch(/skillsmith update/)
+      // SMI-6530 containment: bulk update is unsafe until the update
+      // eligibility gate (SMI-6532) ships.
+      expect(result.skills[0].diagnosis.safeToBulkUpdate).toBe(false)
+      expect(result.skills[0].diagnosis.remediation).toMatch(/skillsmith update <name> --dry-run/)
       expect(result.summary.outdated).toBe(1)
       expect(result.summary.local_drift).toBe(0)
       expect(result.summary.identity_mismatch).toBe(0)

--- a/packages/mcp-server/src/tools/outdated.ts
+++ b/packages/mcp-server/src/tools/outdated.ts
@@ -96,9 +96,11 @@ export interface OutdatedSkillInfo {
   /**
    * SMI-6343 (Wave 3): widened from `current | outdated | unknown` to a
    * five-state classification separating a genuine version bump
-   * (`outdated`, safe to bulk-update) from a benign local edit
-   * (`local-drift`) and a corrupted recorded identity (`identity-mismatch`)
-   * — see `diagnosis` for the structured explanation.
+   * (`outdated`) from a benign local edit (`local-drift`) and a corrupted
+   * recorded identity (`identity-mismatch`) — see `diagnosis` for the
+   * structured explanation. SMI-6530 containment: `outdated` is no longer
+   * marked safe to bulk-update (see `diagnosis.safeToBulkUpdate`) until the
+   * update eligibility gate (SMI-6532) ships.
    */
   status: 'current' | 'outdated' | 'local-drift' | 'identity-mismatch' | 'unknown'
   /** Semver from the latest version record, if available */

--- a/packages/website/src/lib/inventory-view.suggested-action.test.ts
+++ b/packages/website/src/lib/inventory-view.suggested-action.test.ts
@@ -57,7 +57,7 @@ describe('SKILL_STATE_META — suggestedAction (SMI-5595)', () => {
   it('suggestedAction copy matches the exact reviewed spec strings', () => {
     expect(SKILL_STATE_META.current.suggestedAction).toBe('No action needed.')
     expect(SKILL_STATE_META.drifted.suggestedAction).toBe(
-      'Run `skillsmith update <skill>` on that machine.'
+      'Preview it first: run `skillsmith update <skill> --dry-run` on that machine.'
     )
     expect(SKILL_STATE_META.missing.suggestedAction).toBe(
       'Confirm the skill is still installed, then re-run `skillsmith inventory push` from that machine — or reinstall it if it was removed intentionally.'
@@ -80,7 +80,9 @@ describe('SKILL_STATE_META — suggestedAction (SMI-5595)', () => {
   })
 
   it('drifted and pinned suggestedAction contain the <skill> placeholder inside a backtick span', () => {
-    expect(SKILL_STATE_META.drifted.suggestedAction).toContain('`skillsmith update <skill>`')
+    expect(SKILL_STATE_META.drifted.suggestedAction).toContain(
+      '`skillsmith update <skill> --dry-run`'
+    )
     expect(SKILL_STATE_META.pinned.suggestedAction).toContain('`skillsmith unpin <skill>`')
   })
 

--- a/packages/website/src/lib/inventory-view.ts
+++ b/packages/website/src/lib/inventory-view.ts
@@ -147,7 +147,7 @@ export const SKILL_STATE_META: Record<
   drifted: {
     label: 'Update available',
     description: 'A newer version is available in the registry',
-    suggestedAction: 'Run `skillsmith update <skill>` on that machine.',
+    suggestedAction: 'Preview it first: run `skillsmith update <skill> --dry-run` on that machine.',
   },
   missing: {
     label: 'Missing',
@@ -253,11 +253,14 @@ export function buildInventoryView(rows: InventoryRow[]): DeviceView[] {
 // ─── Device-wide batch tips ───────────────────────────────────────────────────
 
 /**
- * Copy shown when a device has multiple drifted skills, suggesting a single
- * batch-update command instead of updating each skill individually.
+ * Copy shown when a device has multiple drifted skills. SMI-6530: does not
+ * recommend applying `update --all` directly — a bulk, non-dry-run update can
+ * overwrite local edits in skill directories that are git clones, so this
+ * points at reviewing a dry run first and then updating skills individually.
+ * Containment until the update eligibility gate (SMI-6532) ships.
  */
 export const DEVICE_BATCH_UPDATE_TIP =
-  'Multiple skills on this machine have updates — run `skillsmith update --all` to update everything at once.'
+  'Multiple skills on this machine have updates — run `skillsmith update --all --dry-run` to review them, then update each skill individually.'
 
 /**
  * Decide whether to show the {@link DEVICE_BATCH_UPDATE_TIP} for a device.
@@ -265,7 +268,7 @@ export const DEVICE_BATCH_UPDATE_TIP =
  * Threshold is evaluated **device-wide, across all harnesses** — not
  * per-harness. A device with one `drifted` skill under `claude-code` and one
  * `drifted` skill under `cursor` still crosses the threshold, because
- * `skillsmith update --all` operates on the whole machine, not a single
+ * `skillsmith update --all --dry-run` reviews the whole machine, not a single
  * harness. Callers must pass the full flat list of a device's skills
  * (i.e. call this *before* any per-harness grouping) — grouping first and
  * calling this per-harness-group would undercount and suppress the tip.

--- a/packages/website/src/lib/skills-page-render.suggested-action.test.ts
+++ b/packages/website/src/lib/skills-page-render.suggested-action.test.ts
@@ -37,7 +37,7 @@ describe('buildDeviceCardHtml — suggested action / device batch tip (SMI-5595)
     const html = buildDeviceCardHtml(device)
     expect(html).toContain('<span class="skill-action">')
     // '/' is not HTML-significant — escapeHtml leaves it unchanged.
-    expect(html).toContain('<code>skillsmith update acme/widget</code>')
+    expect(html).toContain('<code>skillsmith update acme/widget --dry-run</code>')
   })
 
   it('drifted: escapes a skill id containing < and & inside the rendered <code> span (XSS-safety regression)', () => {
@@ -65,7 +65,7 @@ describe('buildDeviceCardHtml — suggested action / device batch tip (SMI-5595)
     }
     const html = buildDeviceCardHtml(device)
     expect(html).not.toContain('<script>&x')
-    expect(html).toContain('<code>skillsmith update evil/&lt;script&gt;&amp;x</code>')
+    expect(html).toContain('<code>skillsmith update evil/&lt;script&gt;&amp;x --dry-run</code>')
   })
 
   it('drifted: a backtick in the skill id does not shift code-span parity (regression for the split-then-substitute order)', () => {
@@ -96,10 +96,12 @@ describe('buildDeviceCardHtml — suggested action / device batch tip (SMI-5595)
     // inside the already-identified code segment, means a backtick carried in
     // by the skill id can't shift which parts of the surrounding sentence get
     // treated as code — the whole command stays inside one <code> span.
-    expect(html).toContain('<code>skillsmith update acme/wid`get</code>')
+    expect(html).toContain('<code>skillsmith update acme/wid`get --dry-run</code>')
     const actionMatch = html.match(/<span class="skill-action">(.*?)<\/span>/)
     expect(actionMatch).not.toBeNull()
-    expect(actionMatch![1]).toBe('Run <code>skillsmith update acme/wid`get</code> on that machine.')
+    expect(actionMatch![1]).toBe(
+      'Preview it first: run <code>skillsmith update acme/wid`get --dry-run</code> on that machine.'
+    )
   })
 
   it('current: renders a .skill-action span with plain text and no <code> child for a no-command state', () => {
@@ -161,7 +163,7 @@ describe('buildDeviceCardHtml — suggested action / device batch tip (SMI-5595)
     const liHtml = liMatch![0]
     expect(liHtml).toContain('acme/widget')
     expect(liHtml).toContain('<span class="skill-action">')
-    expect(liHtml).toContain('<code>skillsmith update acme/widget</code>')
+    expect(liHtml).toContain('<code>skillsmith update acme/widget --dry-run</code>')
   })
 
   describe('device batch tip (computeDeviceBatchTip integration)', () => {
@@ -197,7 +199,7 @@ describe('buildDeviceCardHtml — suggested action / device batch tip (SMI-5595)
       const html = buildDeviceCardHtml(device)
       const matches = html.match(/class="device-batch-tip"/g) ?? []
       expect(matches).toHaveLength(1)
-      expect(html).toContain('<code>skillsmith update --all</code>')
+      expect(html).toContain('<code>skillsmith update --all --dry-run</code>')
     })
 
     it('renders no .device-batch-tip when 0 or 1 skill is drifted', () => {

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -132,7 +132,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <p>Run this in your terminal:</p>
 
-  <pre><code>{`skillsmith update --all                   # Update all installed skills
+  <pre><code>{`skillsmith update --all --dry-run         # Review what --all would change first
 skillsmith update jest-helper             # Update one skill
 skillsmith update jest-helper commit-lint # Update a specific set of skills
 skillsmith update jest-helper --dry-run   # See what would change without applying`}</code></pre>
@@ -141,6 +141,17 @@ skillsmith update jest-helper --dry-run   # See what would change without applyi
     <code>skillsmith update</code> with no skill names and no <code>--all</code> prints usage
     guidance instead of updating anything — pick one of the forms above.
   </p>
+
+  <div class="callout warning">
+    <p class="callout-heading">Review the dry run, then update one skill at a time</p>
+    <p>
+      Always start with <code>skillsmith update --all --dry-run</code> and review the output
+      before applying anything. Once you have reviewed it, update skills individually rather
+      than re-running with <code>--all</code>. If a skill is its own git clone (you installed it
+      by cloning a repository), update it with <code>git pull</code> in that directory instead of
+      <code>skillsmith update</code>.
+    </p>
+  </div>
 
   <p>
     Before a major-version update, run a


### PR DESCRIPTION
## Business Summary

**What shipped:**
- The account skills page now suggests previewing updates with `--dry-run` and then updating one skill at a time. It no longer suggests `skillsmith update --all`.
- The Maintain tutorial starts with a dry run and tells readers to update a skill that's a git clone with `git pull`.
- Agents using the MCP server no longer see outdated skills marked "safe to bulk-update". They get a dry-run suggestion instead.
- The bundled Skillsmith skill, the agent pack, the CLI README and the CLI's own `skillsmith update` usage hint all start with `--dry-run`.
- The CLI and MCP server changelogs carry a security advisory: in CLI 0.8.8–0.8.10, `update --all` can overwrite local edits in skills that are git clones and can write into the wrong directory.

**Quality bar:** Every changed string has a targeted test. Typecheck (`astro check` included), lint and formatting are clean, and `audit:standards` passes with only pre-existing warnings. The governance review found two gaps: the CLI's own usage hint was missed, and the advisory's wording would have read wrong in the release that contains the fix. Both are fixed in this PR.

**Net result:** Containment is in place and needs no follow-up here. The eligibility gate in SMI-6532 lifts it. The root-cause fixes are SMI-6529 (A0) onward, under SMI-6528. After the A0 release, SMI-6530 also covers deprecating CLI 0.8.8–0.8.10 and mcp-server 0.7.12–0.7.14.

---

## Technical detail

- `packages/website/src/lib/inventory-view.ts`: `drifted.suggestedAction` and `DEVICE_BATCH_UPDATE_TIP` now lead with `--dry-run`. Tests updated in `inventory-view.suggested-action.test.ts` and `skills-page-render.suggested-action.test.ts` (21/21).
- `packages/website/src/pages/docs/tutorials/maintain.astro`: the example leads with a dry run, and a `callout warning` (the page's existing pattern) is added.
- `packages/mcp-server/src/tools/outdated.identity.ts`: the `outdated` state now returns `safeToBulkUpdate: false` with a dry-run remediation. `outdated.ts` has a doc-comment change, and `outdated.test.ts` passes (26/26).
- Agent pack: `packages/mcp-server/src/assets/agent-pack/SKILL.md` is generated from `CLI_FALLBACK_COMMANDS` in `packages/core/src/services/agent-pack/prompt-source.ts`. I edited the source and synced the asset to match. The drift gate `agent-pack.assets.test.ts` passes (15/15) after a core build.
- `packages/mcp-server/src/assets/skills/skillsmith/SKILL.md` and `packages/cli/README.md`: dry-run-first examples.
- `packages/cli/src/commands/manage.action.ts`: the no-argument usage hint leads with `skillsmith update --all --dry-run`. `manage.update.test.ts` passes (20/20). Its existing substring assertion still holds.
- `packages/cli/CHANGELOG.md` and `packages/mcp-server/CHANGELOG.md`: a `[Unreleased]` **Security** entry, scoped to the affected versions.
- Deploy: the website change ships on merge, subject to the existing manual production approval. The CLI and MCP text ships with the next npm release, alongside SMI-6529.
- Governance report: skillsmith-docs `code_review/2026-09-10-smi-6530-update-containment-review.md` (branch `docs/smi-6528-update-safety-plan`).

Linear: SMI-6530 (parent SMI-6528).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01UjS3SJsk5c4kzJJK5iJPDk
