### PR TITLE
chore(legal): SMI-6552 -- correct Smith Horn copyright start year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -94,7 +94,7 @@ these terms.
 
 ---
 
-Copyright 2026 Smith Horn Group Ltd
+Copyright 2025-2026 Smith Horn Group Ltd
 
 Licensed under the Elastic License 2.0; you may not use this software except in
 compliance with the Elastic License 2.0.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Skillsmith
-Copyright 2024-2026 Smith Horn Group Ltd
+Copyright 2025-2026 Smith Horn Group Ltd
 
 This product includes software developed by Smith Horn Group Ltd.
 

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: copyright notices now read `2025-2026 Smith Horn Group Ltd`. `LICENSE.md` previously
+  omitted the 2025 start year, and seven source-file headers gave 2024 as the start year. Notice
+  and comment text only, no behavior change. (SMI-6552)
+
 ## v0.3.10
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.3.9).

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 ## [Unreleased]
 
 - **Fix**: copyright notices now read `2025-2026 Smith Horn Group Ltd`. `LICENSE.md` previously
-  omitted the 2025 start year, and seven source-file headers gave 2024 as the start year. Notice
-  and comment text only, no behavior change. (SMI-6552)
+  omitted the 2025 start year, and seven source-file headers plus one test-file header gave 2024
+  as the start year. Notice and comment text only, no behavior change. (SMI-6552)
 
 ## v0.3.10
 

--- a/packages/enterprise/LICENSE.md
+++ b/packages/enterprise/LICENSE.md
@@ -94,7 +94,7 @@ these terms.
 
 ---
 
-Copyright 2026 Smith Horn Group Ltd
+Copyright 2025-2026 Smith Horn Group Ltd
 
 Licensed under the Elastic License 2.0; you may not use this software except in
 compliance with the Elastic License 2.0.

--- a/packages/enterprise/src/audit/scheduled-scan.lock.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.lock.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * @fileoverview Lock-file mutex for the Enterprise scheduled-scan runner.

--- a/packages/enterprise/src/audit/scheduled-scan.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * @fileoverview Enterprise scheduled-scan governance runner.

--- a/packages/enterprise/src/audit/scheduled-scan.types.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * @fileoverview Types for the Enterprise scheduled-scan governance pass.

--- a/packages/enterprise/src/index.ts
+++ b/packages/enterprise/src/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * @smith-horn/enterprise

--- a/packages/enterprise/src/license/quotas.ts
+++ b/packages/enterprise/src/license/quotas.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * SMI-XXXX: Quota Constants and Configuration

--- a/packages/enterprise/src/quota/QuotaEnforcementService.ts
+++ b/packages/enterprise/src/quota/QuotaEnforcementService.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * SMI-XXXX: Quota Enforcement Service

--- a/packages/enterprise/src/quota/index.ts
+++ b/packages/enterprise/src/quota/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * Quota Management Module

--- a/packages/enterprise/tests/license/quotas.test.ts
+++ b/packages/enterprise/tests/license/quotas.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * SMI-1602: Quota System Tests

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
   directories that are git clones and can write into the wrong directory (SMI-6528). On those
   versions, preview with `--dry-run` and update skills one at a time; the install-layer fix is
   tracked in SMI-6529.
+- **Fix**: copyright headers in the three quota middleware source files now read
+  `2025-2026 Smith Horn Group Ltd`; they previously gave 2024 as the start year. Comment-only,
+  no behavior change. (SMI-6552)
 
 ## v0.7.14
 

--- a/packages/mcp-server/src/middleware/quota-helpers.ts
+++ b/packages/mcp-server/src/middleware/quota-helpers.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * SMI-1091: Quota Helpers - Storage and utility functions for quota enforcement

--- a/packages/mcp-server/src/middleware/quota-types.ts
+++ b/packages/mcp-server/src/middleware/quota-types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * SMI-1091: Quota Types - Type definitions for quota enforcement

--- a/packages/mcp-server/src/middleware/quota.ts
+++ b/packages/mcp-server/src/middleware/quota.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
-// Copyright 2024-2025 Smith Horn Group Ltd
+// Copyright 2025-2026 Smith Horn Group Ltd
 
 /**
  * SMI-1091: Quota Enforcement Middleware for MCP Server

--- a/packages/vscode-extension/LICENSE
+++ b/packages/vscode-extension/LICENSE
@@ -94,7 +94,7 @@ these terms.
 
 ---
 
-Copyright 2024-2025 Smith Horn Group Ltd
+Copyright 2025-2026 Smith Horn Group Ltd
 
 Licensed under the Elastic License 2.0; you may not use this software except in
 compliance with the Elastic License 2.0.

--- a/packages/website/src/components/Footer.astro
+++ b/packages/website/src/components/Footer.astro
@@ -35,7 +35,7 @@ const footerLinks = {
   compact && (
     <footer style="margin-top: auto; background: #1f1f23; padding: 1.5rem 2rem;">
       <div style="max-width: 1280px; margin: 0 auto; text-align: center; font-size: 0.875rem; color: #9ca3af;">
-        <p>&copy; {currentYear} Smith Horn Group. All rights reserved.</p>
+        <p>&copy; 2025-{currentYear} Smith Horn Group. All rights reserved.</p>
         <p style="margin-top: 0.25rem;">
           Licensed under{' '}
           <a href="/license" style="color: #9ca3af; text-decoration: underline;">
@@ -179,7 +179,7 @@ const footerLinks = {
         <div class="mt-12 pt-8 border-t border-dark-800">
           <div class="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
             <p class="text-sm text-gray-400">
-              &copy; {currentYear} Smith Horn Group. All rights reserved.
+              &copy; 2025-{currentYear} Smith Horn Group. All rights reserved.
             </p>
             <p class="text-sm text-gray-400">
               Licensed under{' '}


### PR DESCRIPTION
## Business Summary

**What shipped:**
- `NOTICE` now reads `Copyright 2025-2026 Smith Horn Group Ltd` instead of `2024-2026`, since Skillsmith started in 2025.
- The same correction in the three `LICENSE` files and 11 source-file headers, so every Smith Horn copyright line reads `2025-2026`.
- The website footer now shows `© 2025-2026 Smith Horn Group` instead of `© 2026`.

**Quality bar:** A cross-model pre-merge review (GPT-5.6-Sol, the 14-check `pr-reviewer` gate) passed every check and found two issues, both fixed here: the website footer, and an undercount in the enterprise changelog entry. Pre-commit typecheck, lint and prettier passed on both commits. On the first commit, CI was green, including the changelog gate (Check 54).

**Found along the way:** Two problems with the local pre-commit and pre-push checks, both filed rather than fixed here:
- SMI-6553: the first commit attempt failed with false type errors because the worktree's container was still booting.
- SMI-6555: after the rebase, a pre-push test failed against stale compiled code. The check meant to catch stale builds looks at the main checkout, not the worktree being pushed.

**Net result:** Done. No follow-up for this change.

---

## Ticket

[SMI-6552](https://linear.app/smith-horn-group/issue/SMI-6552)

## Technical detail

| Before | After | Files |
|---|---|---|
| `2024-2026` | `2025-2026` | `NOTICE` |
| `2024-2025` | `2025-2026` | `packages/vscode-extension/LICENSE`, 8 files in `packages/enterprise/{src,tests}`, 3 files in `packages/mcp-server/src/middleware/quota*.ts` |
| `2026` | `2025-2026` | `LICENSE`, `packages/enterprise/LICENSE.md` |
| `© {currentYear}` | `© 2025-{currentYear}` | `packages/website/src/components/Footer.astro` (compact and full footers) |

- Third-party copyright lines in `NOTICE` (Anthropic 2024 and others) are unchanged.
- `[Unreleased]` entries were added to `packages/mcp-server/CHANGELOG.md` and `packages/enterprise/CHANGELOG.md`, because both packages' `src/` files changed and `audit:standards` Check 54 requires changelog growth for that. The website package isn't in Check 54's package list and has no changelog.
- Only comment, notice and display text changed. No logic changed, and no test pins the footer text, so no tests were added.
- Check: `git grep -n "Copyright.*Smith Horn"` returns 15 lines, all `2025-2026`. No website page renders a copyright outside `Footer.astro`.

## Testing

- [x] Pre-commit hook on both commits: typecheck (in the worktree container), ESLint, prettier, file-length
- [x] `npm run audit:standards`: 0 failed locally and in CI. The 4 warnings that appear only in the worktree run come from git not resolving inside the worktree container (tracked in SMI-5605), not from this diff.
- [x] Cross-model `pr-reviewer` gate: 14/14 PASS or SKIP (trigger absent), two findings fixed in `b8db4a0a3`
- [ ] Unit/E2E tests: not applicable (text-only change)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_017wqD5PSXwuvhsCSZbnheu5
