### PR TITLE
docs(core): SMI-6554 — record the two missing ruleset-version history entries

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Docs**: recorded the two missing `SCANNER_RULESET_VERSION` history entries for
+  `2026-09-11.1` and `2026-09-11.2`. Both bumps shipped correctly — the `comparable` gate does
+  re-scan — but the constant had moved twice past the end of its own documented history, so the
+  *direction* and the consequence-if-omitted were unrecorded for both. `.1` is
+  previously-clean-now-flagged (MF-5 delivers new detection). `.2` is the same direction for a
+  sharper reason: it invalidates verdicts `.1` computed wrongly under the array-position
+  suppression, so omitting it would have left the evasion alive in stored data even after the code
+  fix. Raised by another session (SMI-6554) after a downstream stale-dist failure. (SMI-6508)
 - **Fix (security regression, same-day)**: the MF-5 prefixed-secrets entry added below was
   positioned at index 4 of `SENSITIVE_PATH_PATTERNS`, and `scanSensitivePaths` `break`s on the
   **first** entry that matches, in array order. An always-MEDIUM entry ahead of a HIGH-capable one

--- a/packages/core/src/security/scanner/patterns.ts
+++ b/packages/core/src/security/scanner/patterns.ts
@@ -181,6 +181,32 @@ export { EVIDENCE_TYPE_BY_PATTERN } from './patterns.jailbreak.evidence.js'
  * already-scanned skill stays blocked even though the rule no longer flags it.
  * A severity-LOWERING change is the case where forgetting the bump is silent —
  * nothing fails, the fix simply never arrives.
+ *
+ * Bumped to `2026-09-11.1`: SMI-6508 added MF-5, a fifth severity class
+ * (`OBSERVE_ONLY_MEDIUM_PATTERNS`, always MEDIUM) carrying the prefixed
+ * `secrets` assignment form — `API_SECRETS=`, `app_secrets=`, `mySecrets=` and
+ * the singular `API_SECRET=`, none of which the boundary-carrying
+ * SECRETS_ASSIGN_PATTERN could ever match. Direction is
+ * *previously-clean-content-now-flagged*, the same as SMI-6441's and the
+ * opposite of SMI-6505's immediately above: content that produced no
+ * `sensitive_path` finding can now produce a MEDIUM one purely because new
+ * detection exists, not because the content changed. Without the bump the
+ * `comparable` gate reuses the stored pre-MF-5 verdict and an already-scanned
+ * skill never receives the new finding at all.
+ *
+ * Bumped to `2026-09-11.2`: SMI-6508 follow-up — MF-5's entry was moved to the
+ * END of SENSITIVE_PATH_PATTERNS. It had shipped at index 4, and
+ * scanSensitivePaths `break`s on the FIRST matching entry in array order, so an
+ * always-MEDIUM entry ahead of 11 HIGH-capable ones SUPPRESSED them: `passed`
+ * flipped false→true and the install block vanished (appending `# a_secrets:`
+ * to a line was sufficient). Direction is *previously-clean-content-now-flagged*
+ * again, but for a sharper reason than the entry above — this bump does not
+ * merely deliver new detection, it INVALIDATES verdicts that `.1` computed
+ * wrongly. A skill scanned under `2026-09-11.1` may carry a stored `passed:
+ * true` that the suppression produced; without this bump the `comparable` gate
+ * would keep serving it, so the evasion would survive in stored data even
+ * though the code no longer permits it. Forgetting the bump here leaves a
+ * security hole open, not just a fix undelivered.
  */
 export const SCANNER_RULESET_VERSION = '2026-09-11.2' as const
 


### PR DESCRIPTION
## Business Summary

**What shipped:** The security scanner's ruleset-version constant moved twice today without either change being written into the version history that sits directly above it. Both entries are now recorded, with the direction of each change and what breaks if the bump is skipped.

**Why it matters:** that history is how the next person knows whether a given bump made the scanner stricter or more lenient — which determines what goes wrong when someone forgets one. The bumps themselves were correct, so nothing was broken in production; only the record was missing.

**Quality bar:** raised by another session after a downstream build failure. They deliberately did not write the entries themselves, because the direction of each has to be known rather than inferred, and a wrong direction note is worse than a missing one. That was the right call — their inference about the first bump was correct, but the second is a different case.

**Found along the way:** the history block already contains a legacy malformed entry recording a partial version string. Left alone — it is not wrong, just oddly formatted — but it will confuse any automated check that enumerates recorded versions, so it is noted for whoever builds one.

**Net result:** Documentation only, no behaviour change.

---

## Technical detail

`SCANNER_RULESET_VERSION` reached `2026-09-11.2` via `3921ae511` (#2806) and `90953967c` (#2808), while the newest `Bumped to` entry in the same file was `2026-09-10.1`.

**`2026-09-11.1`** — *previously-clean-content-now-flagged*. MF-5 added detection that did not previously exist. Omitted, the `comparable` gate reuses the stored pre-MF-5 verdict and an already-scanned skill never receives the finding.

**`2026-09-11.2`** — same direction, sharper reason, and the one that could not be inferred from a PR title. This bump does not merely deliver new detection; it **invalidates verdicts `.1` computed wrongly**. MF-5 shipped at array index 4, and `scanSensitivePaths` breaks on the first matching entry in array order, so it suppressed 11 HIGH-capable patterns and flipped `passed` from false to true. A skill scanned under `.1` may carry a stored `passed: true` the suppression produced; without this bump the gate keeps serving it, so the evasion survives in stored data even though the code no longer permits it.

**Verified** the constant now matches an anchored `` Bumped to `<version>` `` line.

**For a future machine check** (proposed in SMI-6554, not built here — `scripts/audit-standards.mjs` is an ADR-109 path needing SPARC first), two things it must handle, both confirmed:

```
"Bumped to `2026-09-11.10`".includes("2026-09-11.1")  -> true   (falsely passes)
/Bumped to `2026-09-11\.1`/.test(same)                -> false  (correct)
```

and the legacy entry recording only `` `.2` `` as a version, which breaks any approach that enumerates recorded versions or compares against the newest one.

Refs SMI-6554, SMI-6508.