### PR TITLE
fix(ci): SMI-6520 -- wire the dangling-symlink test into CI; it shipped unreachable

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -53,6 +53,8 @@ on:
       - 'scripts/lib/check-mount-composition.probes.sh'
       - 'scripts/lib/check-mount-composition.identity.sh'
       - 'scripts/tests/check-mount-composition.test.sh'
+      - 'scripts/verify-worktree-symlinks.sh'
+      - 'scripts/tests/verify-worktree-symlinks-dangling.test.sh'
       - 'scripts/tests/worktree-port-collision.test.sh'
       - 'scripts/tests/worktree-dev-port.test.sh'
       - 'scripts/tests/regen-worktree-overrides.test.sh'
@@ -126,6 +128,8 @@ jobs:
             scripts/lib/check-mount-composition.probes.sh \
             scripts/lib/check-mount-composition.identity.sh \
             scripts/tests/check-mount-composition.test.sh \
+            scripts/verify-worktree-symlinks.sh \
+            scripts/tests/verify-worktree-symlinks-dangling.test.sh \
             scripts/tests/worktree-port-collision.test.sh \
             scripts/tests/worktree-dev-port.test.sh \
             scripts/tests/regen-worktree-overrides.test.sh \
@@ -176,6 +180,8 @@ jobs:
           bash -n scripts/lib/check-mount-composition.probes.sh
           bash -n scripts/lib/check-mount-composition.identity.sh
           bash -n scripts/tests/check-mount-composition.test.sh
+          bash -n scripts/verify-worktree-symlinks.sh
+          bash -n scripts/tests/verify-worktree-symlinks-dangling.test.sh
           bash -n scripts/tests/worktree-port-collision.test.sh
           bash -n scripts/tests/worktree-dev-port.test.sh
           bash -n scripts/tests/regen-worktree-overrides.test.sh
@@ -217,6 +223,7 @@ jobs:
           bash scripts/tests/website-vercel-output-volume.test.sh
           bash scripts/tests/repair-worktree-container-symlinks.test.sh
           bash scripts/tests/check-mount-composition.test.sh
+          bash scripts/tests/verify-worktree-symlinks-dangling.test.sh
           bash scripts/tests/worktree-port-collision.test.sh
           bash scripts/tests/worktree-dev-port.test.sh
           bash scripts/tests/regen-worktree-overrides.test.sh


### PR DESCRIPTION
## Business Summary

**What shipped:** A test that verifies worktree symlink health now runs in CI. It and the script it tests landed in PR #2805 referenced by no workflow, so CI neither ran the test nor linted the script.

**Quality bar:** Both files were checked against the three gates they are being added to — `shellcheck -S warning`, `bash -n`, and the test itself — before wiring, not after. The test passes 8 of 8 and reports its own denominator. Repo-wide reachability after the change is 25 shell tests on disk, 25 named in a workflow, zero orphans.

**Found along the way:** The check that found this was itself wrong on the first pass — it measured a stale checkout and reported a clean result. Detail below, because the same mistake would defeat any future version of this check.

**Net result:** Done. This closes the last unreachable shell test in the tree.

---

## Technical detail

### What was unreachable

- `scripts/tests/verify-worktree-symlinks-dangling.test.sh` — added by #2805, in no workflow
- `scripts/verify-worktree-symlinks.sh` — modified by #2805, in no workflow

`validate-hooks.yml` carries four enumerated lists. The test is added to all four; the script to the first three only, since it is the subject under test rather than a test:

| list | test | script |
| -- | -- | -- |
| `paths:` trigger | yes | yes |
| `shellcheck` | yes | yes |
| `bash -n` | yes | yes |
| `Hooks unit tests` execution | yes | no |

### How it was found, and how the check first got it wrong

This applies SMI-6488's proposed rule 4 — *is every test artifact reachable by some runner* — to this wave's own output. Two ways to get it wrong, both hit:

**Wrong tree.** The first run measured the main checkout, which was three commits behind and contained neither new file. It reported `23 on disk, 23 wired, no orphans` — a confident clean result from a tree where the orphan did not exist yet. Measured against `origin/main`: `25 on disk, 24 wired`.

**Wrong runner set.** Grepping `validate-hooks.yml` alone reports four false orphans — `deploy-detection`, both `needle-dispatch` tests, and `pooler-psql` — all of which other workflows run. The set-difference has to be taken over every workflow, not the one that looks canonical. A check with that defect would report four false positives today, which is worse than no check: it trains people to ignore the output, and a real orphan then hides in the noise.

Both constraints are recorded on SMI-6488 for whoever implements the check.

### Scope

`.github/workflows/` is an ADR-109 path. **Corrected before merge — the original wording of this paragraph was wrong twice, and both errors are recorded rather than silently rewritten.**

It claimed this edit was "already approved" by the sibling #2805. It was not approved by anything: the plan's ADR-109 section said `.github/workflows/**` was *never touched* and that "an implementer editing those has left the plan". #2805 departed from the plan too, undocumented. Both departures are now recorded in the plan, and the prohibition narrowed rather than withdrawn, by PR #2815 (squash `9faff6c0`) — which is why this PR was held until that landed. It merges under an amended plan, not against a stale one.

It also cited PR #1990 (SMI-5771) as wiring "seven previously-unwired test files the same way". Measured: `git show --numstat 8a8075207` reports **five** test files plus three implementation scripts into `validate-hooks.yml` (30 insertions, 1 deletion — the deletion is an existing entry gaining a trailing `\` as a new one was appended), and the remaining **two received new workflow files** (`validate-needle-dispatch.yml` +40, `validate-pooler-psql.yml` +36) — a shape the amended rule explicitly excludes. And #1990 ran its own SPARC + plan-review first (plan `33e2c23` 11:58 → review `54ea5ca` 13:31 → merge 14:56 → retro `c1ea34e` 14:58, all 2026-07-20), so it is evidence that ADR-109 **applies** to this edit shape, not that it can be skipped.

What survives: registering these two files in `validate-hooks.yml` reduces risk rather than adding it, and shipping a test CI never runs reproduces the exact defect this wave exists to eliminate. That case now rests on the amended plan, which permits exactly this and nothing more.

### Verification

```
shellcheck -S warning <both files>   exit 0
bash -n <both files>                 exit 0
bash …dangling.test.sh               8 passed, 0 failed (denominator: 8)
reachability after change            25 on disk, 25 wired, 0 orphans
```

