### PR TITLE
fix(mcp-server): SMI-6588 -- the namespace pre-flight reports when it could not run

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `install_skill` now reports it when the namespace pre-flight — the check for
+  a name collision with your already-installed skills — could not run. It degrades to
+  letting the install proceed, which is correct for an advisory check, but it used to
+  do so reporting nothing at all, so "no collision found" and "nothing ever looked"
+  were the same result. Three paths could reach it: the rename ledger failing to read,
+  the local inventory failing to scan, and the collision detector throwing. Each now
+  names itself in `tips`, on the same surface the conflict pre-flight uses (SMI-6588).
+
 - **Fix**: `install_skill` now reports it when its pre-flight safety check could not
   run, instead of continuing silently. The pre-flight sat inside a bare `catch {}`
   that predates it; SMI-6529 Wave A0 moved the `checkInstallTarget` guard inside that
@@ -14,8 +22,8 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
   guard unconditionally before any download or disk write, so an unsafe target was
   always refused. What was missing was the report, not the protection. The install's
   outcome is deliberately unchanged; what is no longer invisible is that the
-  pre-flight did not complete — which also means its conflict backup was skipped and
-  a requested `conflictAction` may not have been fully applied. That now rides
+  pre-flight did not complete — which means a requested `conflictAction` may not have
+  been fully applied, and its conflict backup may not have been written. That now rides
   `tips`, the same surface fan-out refusals already use, and names the underlying
   error so a caller can tell "pre-flight passed" from "pre-flight could not be
   evaluated" (SMI-6585).

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,9 +8,12 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
   a name collision with your already-installed skills — could not run. It degrades to
   letting the install proceed, which is correct for an advisory check, but it used to
   do so reporting nothing at all, so "no collision found" and "nothing ever looked"
-  were the same result. Three paths could reach it: the rename ledger failing to read,
-  the local inventory failing to scan, and the collision detector throwing. Each now
-  names itself in `tips`, on the same surface the conflict pre-flight uses (SMI-6588).
+  were the same result. Each failure now names itself in `tips`, on the same surface
+  the conflict pre-flight uses: the rename ledger failing to read, the local inventory
+  failing to scan, and — the one that matters most — the collision detector itself
+  throwing. That last case degrades inside `runInstallPreflight`, which returned a
+  result byte-identical to a clean run; reporting it required a change there, not only
+  at the gate above it (SMI-6588).
 
 - **Fix**: `install_skill` now reports it when its pre-flight safety check could not
   run, instead of continuing silently. The pre-flight sat inside a bare `catch {}`

--- a/packages/mcp-server/src/audit/install-preflight.ts
+++ b/packages/mcp-server/src/audit/install-preflight.ts
@@ -108,6 +108,21 @@ export interface RunInstallPreflightResult {
    * install caller does not re-derive it for telemetry / ledger linkage.
    */
   auditId: AuditId
+  /**
+   * SMI-6588 cross-model review: `null` when the pre-flight actually ran —
+   * and ONLY then. A non-null string means it did not, and says why.
+   *
+   * Before this field, the catch below returned the same
+   * `warnings: [], pendingCollision: null` shape as a clean zero-flag run,
+   * so a caller could not tell "the detector found no collision" from "the
+   * detector threw." SMI-6588's first attempt added reporting one layer up
+   * in `runNamespaceGate` and missed this entirely: that outer catch cannot
+   * fire, because this one already degrades first.
+   *
+   * Required, not optional — every return site must answer it, which is how
+   * a future third return cannot quietly reintroduce the ambiguity.
+   */
+  problem: string | null
 }
 
 /**
@@ -289,6 +304,25 @@ function excludeSelfReinstall(
  * degraded shape (`warnings: []`, `pendingCollision: null`, fresh
  * `auditId`) — the install MUST proceed when the detector breaks (Edit 2).
  */
+/**
+ * SMI-6588 cross-model review: describing a caught value must not itself
+ * throw. `Error.message` is typed `string`, but a runtime value need not
+ * honour that — an Error whose `message` is a Symbol makes a template
+ * literal throw `TypeError: Cannot convert a Symbol value to a string`,
+ * turning a deliberately non-blocking degrade into an escaped exception.
+ * `String()` is safe on a Symbol; implicit interpolation is not.
+ */
+function describeThrown(err: unknown): string {
+  let cause: string
+  try {
+    const raw: unknown = err instanceof Error ? err.message : err
+    cause = typeof raw === 'string' ? raw : String(raw)
+  } catch {
+    cause = 'the thrown value could not be described'
+  }
+  return cause.length > 300 ? cause.slice(0, 300) + '…' : cause
+}
+
 export async function runInstallPreflight(
   input: RunInstallPreflightInput
 ): Promise<RunInstallPreflightResult> {
@@ -317,10 +351,17 @@ export async function runInstallPreflight(
     // The catch covers `excludeSelfReinstall` (rejects non-iterable
     // inputs), `synthesizeCandidateEntry`, the spread, AND
     // `detectCollisions`. Any pre-flight failure → install proceeds.
-    console.warn(
-      `[install-preflight] detector failed (${(err as Error).message}); degrading to non-blocking pass`
-    )
-    return { warnings: [], pendingCollision: null, auditId }
+    const cause = describeThrown(err)
+    console.warn(`[install-preflight] detector failed (${cause}); degrading to non-blocking pass`)
+    return {
+      warnings: [],
+      pendingCollision: null,
+      auditId,
+      // SMI-6588: the install still proceeds — that part was always right.
+      // What was missing is that this result is now distinguishable from a
+      // clean run instead of being byte-identical to one.
+      problem: `the namespace collision detector failed (${cause}); this skill was NOT checked for a name collision with your already-installed skills`,
+    }
   }
 
   // Filter to flags involving the candidate. Pre-existing collisions are
@@ -339,7 +380,7 @@ export async function runInstallPreflight(
     // agent's later inspection by auditId still resolves; absence of an
     // audit file would be ambiguous.
     await tryWriteAuditHistory(result)
-    return { warnings: [], pendingCollision: null, auditId }
+    return { warnings: [], pendingCollision: null, auditId, problem: null }
   }
 
   // SMI-4589 Wave 3: run the edit-suggester over the audit result (which
@@ -402,7 +443,7 @@ export async function runInstallPreflight(
 
   await tryWriteAuditHistory(result)
 
-  return { warnings, pendingCollision, auditId }
+  return { warnings, pendingCollision, auditId, problem: null }
 }
 
 function buildWarningMessage(

--- a/packages/mcp-server/src/audit/install-preflight.ts
+++ b/packages/mcp-server/src/audit/install-preflight.ts
@@ -472,8 +472,9 @@ async function collectRecommendedEdits(
     const recommendedEdits = await runEditSuggester(result)
     return new Map(recommendedEdits.map((e) => [e.collisionId as string, e]))
   } catch (err) {
+    // SMI-6588 round 4: a Symbol message made this literal throw, escaping.
     console.warn(
-      `[install-preflight] edit-suggester failed (${(err as Error).message}); proceeding without prose edits`
+      `[install-preflight] edit-suggester failed (${describeThrown(err)}); proceeding without prose edits`
     )
     return new Map()
   }
@@ -488,8 +489,10 @@ async function tryWriteAuditHistory(result: InventoryAuditResult): Promise<void>
   try {
     await writeAuditHistory(result)
   } catch (err) {
+    // SMI-6588 round 4: throwing here escaped while handling a rejection; on a
+    // preventative collision that permitted an install that should be blocked.
     console.warn(
-      `[install-preflight] writeAuditHistory failed (${(err as Error).message}); auditId will be unrecoverable but install proceeds`
+      `[install-preflight] writeAuditHistory failed (${describeThrown(err)}); auditId will be unrecoverable but install proceeds`
     )
   }
 }

--- a/packages/mcp-server/src/audit/install-preflight.ts
+++ b/packages/mcp-server/src/audit/install-preflight.ts
@@ -305,14 +305,19 @@ function excludeSelfReinstall(
  * `auditId`) — the install MUST proceed when the detector breaks (Edit 2).
  */
 /**
- * SMI-6588 cross-model review: describing a caught value must not itself
- * throw. `Error.message` is typed `string`, but a runtime value need not
- * honour that — an Error whose `message` is a Symbol makes a template
- * literal throw `TypeError: Cannot convert a Symbol value to a string`,
- * turning a deliberately non-blocking degrade into an escaped exception.
- * `String()` is safe on a Symbol; implicit interpolation is not.
+ * The single implementation for describing a caught value. Shared by
+ * `install.namespace-gate.ts` and `install.ts` — do not hand-write another copy.
+ *
+ * `Error.message` is typed `string` but a runtime value need not honour it: an
+ * Error whose `message` is a Symbol makes a template literal throw
+ * `TypeError: Cannot convert a Symbol value to a string`, turning a
+ * non-blocking degrade into an escaped exception. `String()` is safe on a
+ * Symbol; implicit interpolation is not.
+ *
+ * Shared precisely because it was not — four hand-written copies existed, and
+ * SMI-6588's review rounds 1-3 each found another one still unfixed.
  */
-function describeThrown(err: unknown): string {
+export function describeThrown(err: unknown): string {
   let cause: string
   try {
     const raw: unknown = err instanceof Error ? err.message : err

--- a/packages/mcp-server/src/tools/install.namespace-gate.ts
+++ b/packages/mcp-server/src/tools/install.namespace-gate.ts
@@ -29,6 +29,7 @@
 import * as path from 'path'
 import {
   runInstallPreflight,
+  describeThrown,
   type CandidateSkill,
   type RunInstallPreflightResult,
 } from '../audit/install-preflight.js'
@@ -189,7 +190,7 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
   } catch (err) {
     // Edit 6: typed version_unsupported (or any other ledger error)
     // surfaces here. Pre-flight is non-blocking; degrade.
-    const cause = describeCause(err)
+    const cause = describeThrown(err)
     console.warn(`[install.namespace-gate] ledger read failed (${cause}); skipping pre-flight`)
     return degradedProceed(candidate, 'the rename ledger could not be read', cause)
   }
@@ -201,7 +202,7 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
     const scan = await scanLocalInventory()
     existingInventory = scan.entries
   } catch (err) {
-    const cause = describeCause(err)
+    const cause = describeThrown(err)
     console.warn(
       `[install.namespace-gate] scanLocalInventory failed (${cause}); skipping pre-flight`
     )
@@ -220,7 +221,7 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
     // `runInstallPreflight` itself already catches detector throws and
     // degrades, but a defensive outer catch keeps the install hot path
     // bulletproof against any future regression.
-    const cause = describeCause(err)
+    const cause = describeThrown(err)
     console.warn(
       `[install.namespace-gate] runInstallPreflight threw (${cause}); proceeding non-blocking`
     )
@@ -263,33 +264,6 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
     },
     problems: preflightProblems,
   }
-}
-
-/**
- * SMI-6588: describing a caught value must not itself throw. A rejection can
- * carry ANY value — `Object.create(null)` has no `toString`, and a hostile or
- * exotic object can throw from one — which would turn a degrade that is
- * supposed to keep the install running into an escaped exception. Same
- * reasoning, and same bound, as `install.ts`'s own catch (SMI-6585).
- */
-function describeCause(err: unknown): string {
-  let cause: string
-  try {
-    // SMI-6588 cross-model review: `Error.message` is typed `string`, but a
-    // runtime value need not honour that — `Object.defineProperty(err,
-    // 'message', { value: Symbol(...) })` produces an Error whose message is
-    // a Symbol. The previous form returned it unchanged (`cause.length` is
-    // `undefined`, so the bound check below was skipped), and the caller's
-    // template literal then threw `TypeError: Cannot convert a Symbol value
-    // to a string` — turning a deliberately non-blocking degrade into an
-    // escaped exception. Verified against a 6-case table: this is the only
-    // input of the six where the call site threw.
-    const raw: unknown = err instanceof Error ? err.message : err
-    cause = typeof raw === 'string' ? raw : String(raw)
-  } catch {
-    cause = 'the thrown value could not be described'
-  }
-  return cause.length > 300 ? cause.slice(0, 300) + '…' : cause
 }
 
 /**

--- a/packages/mcp-server/src/tools/install.namespace-gate.ts
+++ b/packages/mcp-server/src/tools/install.namespace-gate.ts
@@ -154,6 +154,20 @@ export interface NamespaceGateOutcome {
    * path has a single shape to splat.
    */
   resultPatch: Pick<InstallResult, 'installComplete' | 'pendingCollision' | 'warnings'>
+  /**
+   * SMI-6588: non-fatal problems this gate hit, for the caller to surface
+   * through `tips`. Empty means the gate ran; a non-empty entry means it
+   * did NOT run and says which step failed.
+   *
+   * This is deliberately NOT folded into `resultPatch.warnings`: that field
+   * is `NamespaceWarning[]` (a structured collision record), and a gate that
+   * never ran has no collision to report — it has a reason. Conflating the
+   * two is what made "found nothing" and "never looked" identical here.
+   *
+   * Non-optional on purpose. An optional field that is sometimes `undefined`
+   * reintroduces the exact ambiguity this issue exists to remove.
+   */
+  problems: string[]
 }
 
 /**
@@ -175,10 +189,9 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
   } catch (err) {
     // Edit 6: typed version_unsupported (or any other ledger error)
     // surfaces here. Pre-flight is non-blocking; degrade.
-    console.warn(
-      `[install.namespace-gate] ledger read failed (${(err as Error).message}); skipping pre-flight`
-    )
-    return degradedProceed(candidate)
+    const cause = describeCause(err)
+    console.warn(`[install.namespace-gate] ledger read failed (${cause}); skipping pre-flight`)
+    return degradedProceed(candidate, 'the rename ledger could not be read', cause)
   }
 
   // Step 2 — scan local inventory + run pre-flight. The scanner runs
@@ -188,10 +201,11 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
     const scan = await scanLocalInventory()
     existingInventory = scan.entries
   } catch (err) {
+    const cause = describeCause(err)
     console.warn(
-      `[install.namespace-gate] scanLocalInventory failed (${(err as Error).message}); skipping pre-flight`
+      `[install.namespace-gate] scanLocalInventory failed (${cause}); skipping pre-flight`
     )
-    return degradedProceed(candidate)
+    return degradedProceed(candidate, 'the local skill inventory could not be scanned', cause)
   }
 
   let preflight: RunInstallPreflightResult
@@ -206,10 +220,11 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
     // `runInstallPreflight` itself already catches detector throws and
     // degrades, but a defensive outer catch keeps the install hot path
     // bulletproof against any future regression.
+    const cause = describeCause(err)
     console.warn(
-      `[install.namespace-gate] runInstallPreflight threw (${(err as Error).message}); proceeding non-blocking`
+      `[install.namespace-gate] runInstallPreflight threw (${cause}); proceeding non-blocking`
     )
-    return degradedProceed(candidate)
+    return degradedProceed(candidate, 'the collision detector threw', cause)
   }
 
   // Step 3 — mode gate.
@@ -225,6 +240,7 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
         pendingCollision: preflight.pendingCollision ?? undefined,
         warnings: preflight.warnings.length > 0 ? preflight.warnings : undefined,
       },
+      problems: [],
     }
   }
 
@@ -237,18 +253,45 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
       installComplete: true,
       warnings: preflight.warnings.length > 0 ? preflight.warnings : undefined,
     },
+    problems: [],
   }
 }
 
 /**
+ * SMI-6588: describing a caught value must not itself throw. A rejection can
+ * carry ANY value — `Object.create(null)` has no `toString`, and a hostile or
+ * exotic object can throw from one — which would turn a degrade that is
+ * supposed to keep the install running into an escaped exception. Same
+ * reasoning, and same bound, as `install.ts`'s own catch (SMI-6585).
+ */
+function describeCause(err: unknown): string {
+  let cause: string
+  try {
+    cause = err instanceof Error ? err.message : String(err)
+  } catch {
+    cause = 'the thrown value could not be described'
+  }
+  return cause.length > 300 ? cause.slice(0, 300) + '…' : cause
+}
+
+/**
  * Degraded-proceed shape used when ledger read, inventory scan, or
- * pre-flight throws. Caller continues the install with no warnings.
+ * pre-flight throws.
+ *
+ * SMI-6588: degrading to `proceed` is correct — the namespace pre-flight is
+ * advisory and must never block an install on its own failure. Reporting
+ * NOTHING was not. `step` names which part failed and `cause` why, so the
+ * caller can tell "no collision was found" from "nothing ever looked."
  *
  * `auditId` is allocated via `newAuditId()` even on the degraded path so
  * the `AuditId` brand invariant holds for any defensive consumer that
  * reads `preflight.auditId` without checking `decision` first.
  */
-function degradedProceed(candidate: CandidateSkill): NamespaceGateOutcome {
+function degradedProceed(
+  candidate: CandidateSkill,
+  step: string,
+  cause: string
+): NamespaceGateOutcome {
   return {
     decision: 'proceed',
     candidate,
@@ -260,5 +303,10 @@ function degradedProceed(candidate: CandidateSkill): NamespaceGateOutcome {
     resultPatch: {
       installComplete: true,
     },
+    problems: [
+      `the namespace pre-flight did not run (${step} failed: ${cause}); the install ` +
+        `proceeded, but this skill was NOT checked for a name collision with your ` +
+        `already-installed skills.`,
+    ],
   }
 }

--- a/packages/mcp-server/src/tools/install.namespace-gate.ts
+++ b/packages/mcp-server/src/tools/install.namespace-gate.ts
@@ -227,6 +227,14 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
     return degradedProceed(candidate, 'the collision detector threw', cause)
   }
 
+  // SMI-6588 cross-model review: the outer catch above is a backstop that in
+  // practice cannot fire for a detector failure — `runInstallPreflight` has
+  // its own catch and degrades first, returning a shape identical to a clean
+  // run. The real detector-failure report therefore comes from `problem`, not
+  // from this file's catch. Keeping both is deliberate: the catch still
+  // covers anything that throws outside `runInstallPreflight`'s own try.
+  const preflightProblems = preflight.problem === null ? [] : [preflight.problem]
+
   // Step 3 — mode gate.
   const hasCollision = preflight.pendingCollision !== null
 
@@ -240,7 +248,7 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
         pendingCollision: preflight.pendingCollision ?? undefined,
         warnings: preflight.warnings.length > 0 ? preflight.warnings : undefined,
       },
-      problems: [],
+      problems: preflightProblems,
     }
   }
 
@@ -253,7 +261,7 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
       installComplete: true,
       warnings: preflight.warnings.length > 0 ? preflight.warnings : undefined,
     },
-    problems: [],
+    problems: preflightProblems,
   }
 }
 
@@ -267,11 +275,39 @@ export async function runNamespaceGate(input: NamespaceGateInput): Promise<Names
 function describeCause(err: unknown): string {
   let cause: string
   try {
-    cause = err instanceof Error ? err.message : String(err)
+    // SMI-6588 cross-model review: `Error.message` is typed `string`, but a
+    // runtime value need not honour that — `Object.defineProperty(err,
+    // 'message', { value: Symbol(...) })` produces an Error whose message is
+    // a Symbol. The previous form returned it unchanged (`cause.length` is
+    // `undefined`, so the bound check below was skipped), and the caller's
+    // template literal then threw `TypeError: Cannot convert a Symbol value
+    // to a string` — turning a deliberately non-blocking degrade into an
+    // escaped exception. Verified against a 6-case table: this is the only
+    // input of the six where the call site threw.
+    const raw: unknown = err instanceof Error ? err.message : err
+    cause = typeof raw === 'string' ? raw : String(raw)
   } catch {
     cause = 'the thrown value could not be described'
   }
   return cause.length > 300 ? cause.slice(0, 300) + '…' : cause
+}
+
+/**
+ * SMI-6588 cross-model review: the gate runs early in `installSkillImpl`, but
+ * its problems were merged only at the final return. Every exit between the
+ * two dropped them — a scope error, a target-guard refusal, or a conflict
+ * early return would report its own failure while silently discarding the
+ * fact that the namespace pre-flight never ran.
+ *
+ * Lives here rather than in `install.ts` because that file sits at the
+ * 500-line CI gate.
+ */
+export function attachGateProblems<T extends { tips?: string[] }>(
+  result: T,
+  problems: string[]
+): T {
+  if (problems.length === 0) return result
+  return { ...result, tips: [...(result.tips ?? []), ...problems] }
 }
 
 /**
@@ -299,6 +335,9 @@ function degradedProceed(
       warnings: [],
       pendingCollision: null,
       auditId: newAuditId(),
+      // The pre-flight never ran at all on this path, so this synthetic
+      // result must say so rather than mimic a clean one.
+      problem: `${step}: ${cause}`,
     },
     resultPatch: {
       installComplete: true,

--- a/packages/mcp-server/src/tools/install.test.ts
+++ b/packages/mcp-server/src/tools/install.test.ts
@@ -153,9 +153,15 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
     // It MUST carry a default — a bare `vi.fn()` returns `undefined`, and the
     // caller's `if (!targetCheck.ok)` would then throw into the very catch
     // these tests exercise, quietly adding a tip to every other test in the
-    // file. `{ ok: true }` is what the real guard returns for these fixtures.
+    // file.
+    //
+    // SMI-6588: `preExisted` is part of the contract's ok-branch
+    // (`{ ok: true; preExisted: boolean }`). `install.ts` does not read it
+    // today, which is exactly why omitting it was safe AND wrong: the suite
+    // would stay green on the day someone does, handing them `undefined`.
+    // A mock must not be a looser shape than the thing it stands in for.
     mockCheckInstallTarget.mockReset()
-    mockCheckInstallTarget.mockResolvedValue({ ok: true })
+    mockCheckInstallTarget.mockResolvedValue({ ok: true, preExisted: false })
     // ADR-139: deterministic global scope — see the mock's own comment above.
     mockResolveScopedSkillsDir.mockReturnValue({
       scope: 'global',
@@ -170,11 +176,16 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
     // SMI-4588 Wave 2 PR #3: default the namespace gate to `proceed` with
     // no warnings/pending so the Zod boundary tests remain focused on
     // validation behavior. Tests that need the blocking path can override.
+    // SMI-6588: `problems: []` is the "the gate ran and had nothing to say"
+    // shape. It is non-optional on the real type for the same reason it is
+    // spelled out here — an absent field would be indistinguishable from a
+    // gate that never ran.
     mockRunNamespaceGate.mockResolvedValue({
       decision: 'proceed',
       candidate: { identifier: 'test', projectedSourcePath: '/tmp/test' },
       preflight: { warnings: [], pendingCollision: null, auditId: 'mock-audit-id' },
       resultPatch: { installComplete: true },
+      problems: [],
     })
   })
 
@@ -445,6 +456,42 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
       // The install still completed rather than the handler throwing.
       expect(mockInstall).toHaveBeenCalledTimes(1)
       expect(result.tips?.join(' ') ?? '').toContain('could not be described')
+    })
+
+    // SMI-6588: the namespace gate degrades to `proceed` when it cannot run.
+    // These two cases are the point of the change — they must NOT produce the
+    // same result. The negative case is as load-bearing as the positive one:
+    // without it, a regression that tipped on every install would pass.
+    it('reports it when the namespace pre-flight degraded instead of running', async () => {
+      mockRunNamespaceGate.mockResolvedValue({
+        decision: 'proceed',
+        candidate: { identifier: 'test', projectedSourcePath: '/tmp/test' },
+        preflight: { warnings: [], pendingCollision: null, auditId: 'mock-audit-id' },
+        resultPatch: { installComplete: true },
+        problems: [
+          'the namespace pre-flight did not run (the rename ledger could not be read: ' +
+            'EACCES: permission denied); the install proceeded, but this skill was NOT ' +
+            'checked for a name collision with your already-installed skills.',
+        ],
+      })
+
+      const result = await installSkill({ skillId: 'owner/repo/test-skill' })
+
+      // The install still succeeds — the gate is advisory and must never
+      // block on its own failure.
+      expect(result.success).toBe(true)
+      expect(mockInstall).toHaveBeenCalledTimes(1)
+      const reported = result.tips?.join(' ') ?? ''
+      expect(reported).toContain('namespace pre-flight did not run')
+      expect(reported).toContain('EACCES: permission denied')
+    })
+
+    it('adds no tip when the namespace pre-flight ran and found no collision', async () => {
+      // The beforeEach default is a clean `problems: []` gate.
+      const result = await installSkill({ skillId: 'owner/repo/test-skill' })
+
+      expect(result.success).toBe(true)
+      expect(result.tips?.join(' ') ?? '').not.toContain('namespace pre-flight')
     })
 
     it('resolves bare skillId (no slash) via extractSkillName', async () => {

--- a/packages/mcp-server/src/tools/install.test.ts
+++ b/packages/mcp-server/src/tools/install.test.ts
@@ -183,7 +183,7 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
     mockRunNamespaceGate.mockResolvedValue({
       decision: 'proceed',
       candidate: { identifier: 'test', projectedSourcePath: '/tmp/test' },
-      preflight: { warnings: [], pendingCollision: null, auditId: 'mock-audit-id' },
+      preflight: { warnings: [], pendingCollision: null, auditId: 'mock-audit-id', problem: null },
       resultPatch: { installComplete: true },
       problems: [],
     })
@@ -466,7 +466,12 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
       mockRunNamespaceGate.mockResolvedValue({
         decision: 'proceed',
         candidate: { identifier: 'test', projectedSourcePath: '/tmp/test' },
-        preflight: { warnings: [], pendingCollision: null, auditId: 'mock-audit-id' },
+        preflight: {
+          warnings: [],
+          pendingCollision: null,
+          auditId: 'mock-audit-id',
+          problem: null,
+        },
         resultPatch: { installComplete: true },
         problems: [
           'the namespace pre-flight did not run (the rename ledger could not be read: ' +

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -458,7 +458,11 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
   // about rides one surface. A fan-out refusal and a pre-flight that could
   // not be evaluated are both things the caller needs to see without either
   // of them changing the install's success.
-  const nonFatalProblems = [...preflightProblems, ...alsoLinkFailures]
+  //
+  // SMI-6588: `gate.problems` joins them — the namespace gate degrades to
+  // `proceed` on its own failure (correct; it is advisory), but used to do so
+  // silently. Empty whenever the gate actually ran.
+  const nonFatalProblems = [...preflightProblems, ...gate.problems, ...alsoLinkFailures]
   const resultWithTips: InstallResult =
     nonFatalProblems.length > 0
       ? { ...result, tips: [...(result.tips ?? []), ...nonFatalProblems] }

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -357,28 +357,19 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
         }
       }
     } catch (err) {
-      // SMI-6585: this catch predates the guard it now encloses. Wave A0
-      // moved `checkInstallTarget` inside it, which turned a fail-closed
-      // guard into a fail-open one for anything that throws in this block.
-      //
-      // The install's OUTCOME is deliberately unchanged: `service.install()`
-      // runs the same target guard unconditionally before any fetch or disk
-      // write (`skill-installation.service.ts`, and `.content.ts` for the
-      // content path), so a refusal still happens there. Swallowing the
-      // outcome is correct; swallowing the FACT is not.
-      //
-      // What is no longer silent is that the pre-flight did not complete. It
-      // rides `tips`, the same surface the fan-out failures use, so a caller
-      // can tell "pre-flight passed" from "pre-flight could not be evaluated".
-      //
-      // SMI-6585 cross-model review: describing the caught value must not
-      // itself throw. A rejection can carry ANY value — `Object.create(null)`
-      // has no `toString`, and a hostile or exotic object can throw from one —
-      // which would turn "the install's outcome is unchanged" into an escaped
-      // exception from the very handler written to prevent that.
+      // SMI-6585: this catch predates the guard it encloses — Wave A0 moved
+      // `checkInstallTarget` inside it, turning a fail-closed guard fail-open.
+      // The install's OUTCOME is deliberately unchanged (`service.install()`
+      // runs the same target guard unconditionally before any fetch or write),
+      // so swallowing the outcome is correct; swallowing the FACT is not. The
+      // failure now rides `tips`, letting a caller tell "pre-flight passed"
+      // from "pre-flight could not be evaluated".
+      // SMI-6588 confirmation round: a Symbol `message` skipped the bound below
+      // and threw at interpolation. Third of three instances — see describeCause.
       let cause: string
       try {
-        cause = err instanceof Error ? err.message : String(err)
+        const raw: unknown = err instanceof Error ? err.message : err
+        cause = typeof raw === 'string' ? raw : String(raw)
       } catch {
         cause = 'the thrown value could not be described'
       }

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -53,7 +53,7 @@ import {
   readAuditModeOverride,
   extractSkillName,
 } from './install.namespace-gate.js'
-import type { CandidateSkill } from '../audit/install-preflight.js'
+import { describeThrown, type CandidateSkill } from '../audit/install-preflight.js'
 import * as path from 'path'
 
 export { extractSkillName } from './install.namespace-gate.js'
@@ -179,10 +179,10 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
   try {
     candidate = buildPreflightCandidate(validInput.skillId)
   } catch (err) {
-    return buildInvalidSkillIdError(
-      validInput.skillId,
-      err instanceof Error ? err.message : String(err)
-    )
+    // SMI-6588 round 3: `extractSkillName` only ever throws an ordinary Error,
+    // so this site was already safe — routed through the shared helper anyway
+    // so no coercion in this file can drift from the others again.
+    return buildInvalidSkillIdError(validInput.skillId, describeThrown(err))
   }
   const tier = resolveCallerTier()
   const auditMode = resolveAuditMode({
@@ -364,18 +364,11 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
       // so swallowing the outcome is correct; swallowing the FACT is not. The
       // failure now rides `tips`, letting a caller tell "pre-flight passed"
       // from "pre-flight could not be evaluated".
-      // SMI-6588 confirmation round: a Symbol `message` skipped the bound below
-      // and threw at interpolation. Third of three instances — see describeCause.
-      let cause: string
-      try {
-        const raw: unknown = err instanceof Error ? err.message : err
-        cause = typeof raw === 'string' ? raw : String(raw)
-      } catch {
-        cause = 'the thrown value could not be described'
-      }
-      // Bound it: this string is returned to the caller, and an unbounded
-      // message from an arbitrary throw site is not something to pass through.
-      if (cause.length > 300) cause = cause.slice(0, 300) + '…'
+      // SMI-6588: the one shared implementation, which also bounds the string
+      // (an unbounded message from an arbitrary throw site is not something to
+      // pass back to a caller). See describeThrown's own comment for why this
+      // is shared rather than written out here again.
+      const cause = describeThrown(err)
 
       // SMI-6585 cross-model review: "was not applied" claimed more than the
       // code can know. `checkForConflicts` can throw AFTER writing a backup,
@@ -441,7 +434,11 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
           alsoLinkFailures.push(`alsoLink to ${target}: ${warning}`)
         }
       } catch (linkErr) {
-        const message = linkErr instanceof Error ? linkErr.message : String(linkErr)
+        // SMI-6588 round 3: the fourth copy of this coercion, and the only one
+        // with no inner try/catch — a hostile value made `String()` itself
+        // throw, escaping AFTER the primary install had already succeeded and
+        // replacing a success with an exception.
+        const message = describeThrown(linkErr)
         // Best-effort fan-out — log but don't fail the install
         console.error(`[install] alsoLink to ${target} failed:`, message)
         alsoLinkFailures.push(`alsoLink to ${target} failed: ${message}`)

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -47,6 +47,7 @@ import { checkForConflicts } from './install.conflict.js'
 // external import path (used directly by SMI-4737's tests) is unaffected.
 import {
   runNamespaceGate,
+  attachGateProblems,
   buildPreflightCandidate,
   resolveCallerTier,
   readAuditModeOverride,
@@ -242,7 +243,7 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
       scopeError instanceof UnsatisfiableWorkspaceScopeError ||
       scopeError instanceof InvalidScopeValueError
     ) {
-      return buildScopeError(validInput.skillId, scopeError)
+      return attachGateProblems(buildScopeError(validInput.skillId, scopeError), gate.problems)
     }
     throw scopeError
   }
@@ -331,13 +332,16 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
           force: validInput.force,
         })
         if (!targetCheck.ok) {
-          return {
-            success: false,
-            skillId: validInput.skillId,
-            installPath,
-            error: targetCheck.error,
-            ...(targetCheck.tips !== undefined && { tips: targetCheck.tips }),
-          }
+          return attachGateProblems(
+            {
+              success: false,
+              skillId: validInput.skillId,
+              installPath,
+              error: targetCheck.error,
+              ...(targetCheck.tips !== undefined && { tips: targetCheck.tips }),
+            },
+            gate.problems
+          )
         }
 
         const conflictCheck = await checkForConflicts(
@@ -349,7 +353,7 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
         )
 
         if (!conflictCheck.shouldProceed) {
-          return conflictCheck.earlyReturn!
+          return attachGateProblems(conflictCheck.earlyReturn!, gate.problems)
         }
       }
     } catch (err) {
@@ -454,14 +458,10 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
     }
   }
 
-  // SMI-6529 round 7 / SMI-6585: every non-fatal problem this function knows
-  // about rides one surface. A fan-out refusal and a pre-flight that could
-  // not be evaluated are both things the caller needs to see without either
-  // of them changing the install's success.
-  //
-  // SMI-6588: `gate.problems` joins them — the namespace gate degrades to
-  // `proceed` on its own failure (correct; it is advisory), but used to do so
-  // silently. Empty whenever the gate actually ran.
+  // SMI-6529 round 7 / SMI-6585 / SMI-6588: every non-fatal problem this
+  // function knows about rides one surface — a fan-out refusal, a conflict
+  // pre-flight that could not be evaluated, and a namespace pre-flight that
+  // never ran. None of them changes whether the install itself succeeded.
   const nonFatalProblems = [...preflightProblems, ...gate.problems, ...alsoLinkFailures]
   const resultWithTips: InstallResult =
     nonFatalProblems.length > 0

--- a/packages/mcp-server/src/tools/install.types.ts
+++ b/packages/mcp-server/src/tools/install.types.ts
@@ -301,8 +301,13 @@ export interface InstallResult {
   /**
    * SMI-4588 Wave 2 (PR #3): Non-blocking namespace warnings. Populated in
    * `power_user` and `governance` modes when a pre-flight collision is
-   * detected; the install still proceeds. Pre-flight scanner failure is
-   * treated as a clean pass (`warnings: undefined`).
+   * detected; the install still proceeds.
+   *
+   * `warnings: undefined` means the pre-flight ran and found no collision —
+   * and ONLY that. SMI-6588: it used to also mean the pre-flight had failed
+   * and been silently skipped, which made those two states identical to
+   * every caller. A pre-flight that could not run now reports itself through
+   * `tips` instead, so this field carries exactly one meaning.
    */
   warnings?: import('../audit/namespace-audit.types.js').NamespaceWarning[]
 }

--- a/packages/mcp-server/tests/integration/install-namespace.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install-namespace.integration.test.ts
@@ -249,6 +249,10 @@ describe('install namespace integration', () => {
     expect(outcome.resultPatch.warnings).toBeDefined()
     expect(outcome.resultPatch.warnings!.length).toBeGreaterThan(0)
     expect(outcome.resultPatch.warnings![0]!.kind).toBe('exact')
+    // SMI-6588: the negative half of case 5's assertion. A gate that really
+    // ran reports no problems, so a regression that tipped on every install
+    // fails here rather than passing quietly.
+    expect(outcome.problems).toEqual([])
   })
 
   it('case 4: governance mode + collision → proceeds with warnings[]', async () => {
@@ -291,6 +295,15 @@ describe('install namespace integration', () => {
     expect(outcome.resultPatch.warnings).toBeUndefined()
     expect(outcome.resultPatch.pendingCollision).toBeUndefined()
     expect(warnSpy).toHaveBeenCalled()
+
+    // SMI-6588: the three assertions above are ALL satisfied by a gate that
+    // ran cleanly and found nothing — which is exactly the ambiguity this
+    // degraded path used to fall into. `console.warn` firing was the only
+    // evidence, and it never reached the caller. The outcome must now say so
+    // itself, and name the step that failed.
+    expect(outcome.problems).toHaveLength(1)
+    expect(outcome.problems[0]).toContain('namespace pre-flight did not run')
+    expect(outcome.problems[0]).toContain('rename ledger could not be read')
   })
 
   it('case 6: mid-rename atomicity probe — target_exists short-circuits before mutation; ledger NOT appended', async () => {

--- a/packages/mcp-server/tests/integration/install.target-guard-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install.target-guard-preflight.integration.test.ts
@@ -47,6 +47,11 @@ vi.mock('../../src/tools/install.namespace-gate.js', async (importActual) => {
       candidate: input.candidate,
       preflight: { warnings: [], pendingCollision: null, auditId: 'test-audit-id' },
       resultPatch: { installComplete: true },
+      // SMI-6588: `problems` is non-optional on NamespaceGateOutcome and
+      // `install.ts` spreads it. Omitting it here spreads `undefined` and
+      // throws — and TypeScript cannot catch that through an untyped mock
+      // factory, which is precisely why the field is not optional.
+      problems: [],
     })),
   }
 })

--- a/packages/mcp-server/tests/integration/install.target-guard-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install.target-guard-preflight.integration.test.ts
@@ -45,7 +45,7 @@ vi.mock('../../src/tools/install.namespace-gate.js', async (importActual) => {
     runNamespaceGate: vi.fn(async (input: { candidate: { identifier: string } }) => ({
       decision: 'proceed' as const,
       candidate: input.candidate,
-      preflight: { warnings: [], pendingCollision: null, auditId: 'test-audit-id' },
+      preflight: { warnings: [], pendingCollision: null, auditId: 'test-audit-id', problem: null },
       resultPatch: { installComplete: true },
       // SMI-6588: `problems` is non-optional on NamespaceGateOutcome and
       // `install.ts` spreads it. Omitting it here spreads `undefined` and

--- a/packages/mcp-server/tests/integration/install.workspace-scope.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install.workspace-scope.integration.test.ts
@@ -60,6 +60,11 @@ vi.mock('../../src/tools/install.namespace-gate.js', async (importActual) => {
       candidate: input.candidate,
       preflight: { warnings: [], pendingCollision: null, auditId: 'test-audit-id' },
       resultPatch: { installComplete: true },
+      // SMI-6588: `problems` is non-optional on NamespaceGateOutcome and
+      // `install.ts` spreads it. Omitting it here spreads `undefined` and
+      // throws — and TypeScript cannot catch that through an untyped mock
+      // factory, which is precisely why the field is not optional.
+      problems: [],
     })),
   }
 })

--- a/packages/mcp-server/tests/integration/install.workspace-scope.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install.workspace-scope.integration.test.ts
@@ -58,7 +58,7 @@ vi.mock('../../src/tools/install.namespace-gate.js', async (importActual) => {
     runNamespaceGate: vi.fn(async (input: { candidate: { identifier: string } }) => ({
       decision: 'proceed' as const,
       candidate: input.candidate,
-      preflight: { warnings: [], pendingCollision: null, auditId: 'test-audit-id' },
+      preflight: { warnings: [], pendingCollision: null, auditId: 'test-audit-id', problem: null },
       resultPatch: { installComplete: true },
       // SMI-6588: `problems` is non-optional on NamespaceGateOutcome and
       // `install.ts` spreads it. Omitting it here spreads `undefined` and

--- a/packages/mcp-server/tests/unit/install-preflight.test.ts
+++ b/packages/mcp-server/tests/unit/install-preflight.test.ts
@@ -81,6 +81,11 @@ describe('runInstallPreflight', () => {
     expect(result.pendingCollision).toBeNull()
     // ULID shape — bubbled from the detector through the result.
     expect(result.auditId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+    // SMI-6588: the negative control for the degrade assertion below. The
+    // three lines above are ALL satisfied by a run where the detector threw
+    // and was swallowed — that was the defect. `problem === null` is the only
+    // thing here that distinguishes this clean run from that one.
+    expect(result.problem).toBeNull()
   })
 
   it('returns pendingCollision on exact collision in preventative mode (case 2)', async () => {
@@ -170,6 +175,19 @@ describe('runInstallPreflight', () => {
     expect(result.warnings).toEqual([])
     expect(result.pendingCollision).toBeNull()
     expect(result.auditId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+
+    // SMI-6588 (cross-model review finding 1): the three assertions above are
+    // satisfied IDENTICALLY by case 1's clean run — which is precisely the
+    // defect. This function's catch returned a result byte-identical to
+    // "detector ran, found nothing", so every caller above it was blind to
+    // the difference. SMI-6588's first attempt added reporting one layer up
+    // in `runNamespaceGate` and could never fire, because this catch degrades
+    // first. The distinction has to be made here.
+    expect(result.problem).not.toBeNull()
+    expect(result.problem).toContain('collision detector failed')
+    // The report must name what the user actually lost, not merely that
+    // something failed.
+    expect(result.problem).toContain('NOT checked for a name collision')
   })
 
   it('persists audit history with the bubbled auditId (case 6)', async () => {


### PR DESCRIPTION
## Business Summary

**What shipped:**

- `install_skill` now reports when its namespace pre-flight — the check for whether a skill's name collides with one you already have — could not run. That outcome was previously indistinguishable from "the check ran and found nothing."
- That report now survives an install that fails for an unrelated reason. Previously a scope error, a target-guard refusal, or a conflict early return would report its own failure while discarding the fact that the collision check never happened.
- A caught error can no longer crash the very handlers written to keep an install non-fatal. One of those crashes could permit an install that should have been blocked.
- The release note for the previous fix no longer claims the conflict backup "was skipped." The code cannot determine that.

**Quality bar:** Five rounds of independent review on GPT-5.6-Sol via NEEDLE (ADR-128, cross-family per CLAUDE.md). **Rounds 1 through 4 each found a real defect; round 5 returned PASS.** Every finding was verified against the code before being acted on — two candidate findings from my own analysis were investigated and disproven rather than filed. Typecheck, Prettier, ESLint and Vitest all clean, each with its scope asserted rather than inferred from an exit code.

**Found along the way:** five issues filed rather than folded in — SMI-6589, SMI-6590, SMI-6591, SMI-6592, SMI-6594.

**Net result:** Shipped. Five follow-ups tracked, none blocking.

---

## Technical detail

### The defect

`runNamespaceGate` degrades to `decision: 'proceed'` when it cannot complete. That is correct — the pre-flight is advisory and must never block an install because it itself failed. It did so while reporting nothing, so `warnings: undefined` carried two meanings at once. `install.types.ts` documented this as intended: *"Pre-flight scanner failure is treated as a clean pass."*

### What five rounds found

| Round | Verdict | Finding |
|---|---|---|
| 1 | BLOCKED | Detector failures indistinguishable from clean runs; problems dropped at three post-gate exits; the reporting helper could itself throw |
| 2 | BLOCKED | A **third** hand-written copy of that coercion, still unfixed |
| 3 | BLOCKED | A **fourth** copy, in `alsoLink` — no inner `try/catch`, and it runs *after* the install has already succeeded |
| 4 | BLOCKED | Two more copies in a **different spelling**, inside the file hosting the shared helper |
| 5 | **PASS** | Semantic sweep of all 10 `catch` bindings against 9 coercion forms — no seventh site, no third spelling |

Round 1 corrected the fix's own premise. It had added reporting only at the gate and claimed three degrade paths, one being "the collision detector threw" — a path that cannot reach the gate's catch, because `runInstallPreflight` catches detector failures itself and returns a result byte-identical to a clean run. The most important path was still collapsed, one function below where the fix sat.

Round 4's was the sharpest, because the miss was in my verification rather than the code: after round 3 I asserted *"exactly one bare coercion remains in the three files I own"* — true for the spelling I grepped, false in fact. The sweep was narrower than the claim drawn from it.

### The fix stopped being a patch

Four hand-written copies of one six-line function is *why* "fixed two of three" was possible. Round 3's finding was addressed by consolidation: `describeThrown` is now the single exported implementation, `describeCause` is deleted, and nine call sites route through it. Verified by assertion — 1 definition, 9 call sites, 0 leftovers, and a comment-stripped scan showing exactly one coercion remaining, inside the helper's own body.

### Why one site was security-relevant

`tryWriteAuditHistory` throwing while handling a rejection escapes `runInstallPreflight`. On a `preventative` collision that converted a detected collision into a degraded `proceed` — permitting an install that should have been blocked. Round 5 traced the fixed path end to end and confirmed `pendingCollision` now survives to `decision: 'block'`.

### Design notes

- `problems` is not folded into `resultPatch.warnings`: that field is a structured collision record. A gate that never ran has no collision to report — it has a reason.
- Both new fields are non-optional. An optional field that is sometimes `undefined` is the ambiguity being removed — and making them required is what surfaced two untyped mock factories that would have thrown at runtime, invisible to typecheck.
- `alsoLink`'s failure message is now bounded at 300 characters like its siblings. Round 4 was asked to argue against this and judged it reasonable, noting only that stderr is bounded too.

### CI note

`pointer-check` went red mid-review with `R3: stale: behind skillsmith-docs:main by 1 commits` — a peer pushed to docs main after my pointer commit. Ancestry was intact, so a re-bump resolved it. Unrelated to this code.

Full review record: `docs/internal/pr-reviews/2026-09-13-smi-6588-namespace-gate-silent-degrade.md`.

Closes SMI-6588.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
