### PR TITLE
fix(ci): SMI-6580/6569 -- pointer-guard integrity: a failed alert must fail the job, and the local check must read the right repo

### DIFF
--- a/scripts/ci/check-submodule-pointer.helpers.sh
+++ b/scripts/ci/check-submodule-pointer.helpers.sh
@@ -75,6 +75,48 @@ repo_slug() {
     printf '%s:%s' "$_CSP_SLUG" "$_CSP_BRANCH"
 }
 
+# git_sub <submodule-dir> <git-args...> — run git against a SUBMODULE working
+# directory, immune to an inherited GIT_DIR (SMI-6569).
+#
+# `git -C <dir>` does NOT override GIT_DIR: -C changes the working directory,
+# but an ABSOLUTE GIT_DIR still wins over repo discovery, so the command runs
+# against the OUTER repo while appearing to target the submodule. Git exports
+# an absolute GIT_DIR into hooks on a push FROM A LINKED WORKTREE — this
+# repo's default workspace — so `.husky/pre-push`'s invocation hit this on
+# every run. Measured on git 2.50.0 against docs/internal:
+#
+#   GIT_DIR unset             -> git -C docs/internal cat-file -e <sha>^{commit} -> exit 0
+#   GIT_DIR=<absolute>        -> same command                                    -> exit 128
+#   GIT_DIR=".git" (RELATIVE) -> same command                                    -> exit 0
+#
+# A relative GIT_DIR re-resolves against -C's new cwd and is harmless; only an
+# absolute one redirects. End-to-end on one identical tree, the symptom was a
+# fabricated R1 ("was never pushed") for a commit that is pushed and reachable,
+# which ALSO suppressed the true verdict (R3) because R1 is a Layer-1
+# precondition that short-circuits Layer 2 entirely.
+#
+# Every git call in this file that targets the submodule must go through this
+# wrapper, not just the R1 existence check: under a contaminated GIT_DIR the
+# fetch, the origin/<branch> rev-parse, and every merge-base/rev-list/branch
+# comparison were all reading the OUTER repo too. R1 simply failed first and
+# masked the rest.
+#
+# Calls targeting the OUTER repo (`git -C "$_CSP_ROOT" ls-tree`, and
+# check-submodule-pointer.sh's own rev-parse/diff) deliberately do NOT use
+# this wrapper: they want the outer repo, and an inherited worktree GIT_DIR
+# already names it. Verified — `rev-parse --show-toplevel` and `ls-tree HEAD`
+# return identical results with and without GIT_DIR set.
+#
+# GIT_WORK_TREE is unset alongside GIT_DIR as defence in depth. Measured, only
+# GIT_DIR is actually exported into hooks, and unsetting GIT_DIR alone is
+# sufficient; unsetting both costs nothing and removes the remaining way a
+# caller's environment could redirect these reads.
+git_sub() {
+    _CSP_GIT_SUB_DIR="$1"
+    shift
+    env -u GIT_DIR -u GIT_WORK_TREE git -C "$_CSP_GIT_SUB_DIR" "$@"
+}
+
 # print_result — unified output line. severity: PASS|PASS-WARN|SKIP|FAIL.
 # is_blocking (0/1) downgrades a FAIL's displayed severity to WARN (mount
 # not in BLOCKING_MOUNTS) without changing the caller's exit-code decision,
@@ -125,7 +167,7 @@ evaluate_mount() {
     # Not-initialized check: test for a LITERAL .git entry directly under the
     # mount directory (file or dir — a submodule's own .git is a file
     # pointing at ../../.git/modules/<path> since git 1.7.8+). Deliberately
-    # NOT `git -C "$_CSP_DIR" rev-parse --git-dir`: for an uninitialized
+    # NOT `git_sub "$_CSP_DIR" rev-parse --git-dir`: for an uninitialized
     # mount (an empty directory with no .git of its own), git's repo
     # discovery walks UP the directory tree and silently finds the PARENT
     # repo's own .git instead of failing — that would make this check
@@ -144,7 +186,7 @@ evaluate_mount() {
     _CSP_FETCH_OK=0
     _CSP_I=0
     while [ "$_CSP_I" -lt "$_CSP_ATTEMPTS" ]; do
-        if git -C "$_CSP_DIR" fetch origin --prune --quiet 2>/dev/null; then
+        if git_sub "$_CSP_DIR" fetch origin --prune --quiet 2>/dev/null; then
             _CSP_FETCH_OK=1
             break
         fi
@@ -156,14 +198,14 @@ evaluate_mount() {
         return 1
     fi
 
-    _CSP_T="$(git -C "$_CSP_DIR" rev-parse -q --verify "refs/remotes/origin/$_CSP_BRANCH" 2>/dev/null)"
+    _CSP_T="$(git_sub "$_CSP_DIR" rev-parse -q --verify "refs/remotes/origin/$_CSP_BRANCH" 2>/dev/null)"
     if [ -z "$_CSP_T" ]; then
         print_result "FAIL" "$_CSP_MOUNT" "R-FETCH: infra: fetch failed, not a content problem — re-run the check" "$_CSP_BLOCK"
         return 1
     fi
 
     # --- Layer 1 preconditions: R1 (S exists), R10/R11 (B) ---
-    if ! git -C "$_CSP_DIR" cat-file -e "${_CSP_S}^{commit}" 2>/dev/null; then
+    if ! git_sub "$_CSP_DIR" cat-file -e "${_CSP_S}^{commit}" 2>/dev/null; then
         print_result "FAIL" "$_CSP_MOUNT" "R1: \`$_CSP_S\` was never pushed, or its branch was deleted; push a valid commit at that SHA (or a valid replacement) and re-bump" "$_CSP_BLOCK"
         return 1
     fi
@@ -172,7 +214,7 @@ evaluate_mount() {
     _CSP_B_RESOLVABLE=0
     if [ -n "$_CSP_B" ]; then
         _CSP_B_AVAILABLE=1
-        if git -C "$_CSP_DIR" cat-file -e "${_CSP_B}^{commit}" 2>/dev/null; then
+        if git_sub "$_CSP_DIR" cat-file -e "${_CSP_B}^{commit}" 2>/dev/null; then
             _CSP_B_RESOLVABLE=1
         fi
     fi
@@ -219,13 +261,13 @@ evaluate_layer2() {
     # T-axis: S vs T (R2/R3/R4/R5/R6 — mutually exclusive with each other).
     if [ "$_CSP_S" = "$_CSP_T" ]; then
         : # R2 PASS
-    elif git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_S" "$_CSP_T" 2>/dev/null; then
-        _CSP_BEHIND="$(git -C "$_CSP_DIR" rev-list --count "${_CSP_S}..${_CSP_T}" 2>/dev/null || echo '?')"
+    elif git_sub "$_CSP_DIR" merge-base --is-ancestor "$_CSP_S" "$_CSP_T" 2>/dev/null; then
+        _CSP_BEHIND="$(git_sub "$_CSP_DIR" rev-list --count "${_CSP_S}..${_CSP_T}" 2>/dev/null || echo '?')"
         _CSP_SLUG="$(repo_slug "$_CSP_ROOT/.gitmodules" "$_CSP_MOUNT")"
         _CSP_FAIL_RULES+=("R3")
         _CSP_FAIL_MSGS+=("R3: stale: behind \`$_CSP_SLUG\` by $_CSP_BEHIND commits; re-bump with \`scripts/bump-docs-pointer.sh\`")
-    elif git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_T" "$_CSP_S" 2>/dev/null; then
-        if git -C "$_CSP_DIR" branch -r --contains "$_CSP_S" 2>/dev/null | grep -q .; then
+    elif git_sub "$_CSP_DIR" merge-base --is-ancestor "$_CSP_T" "$_CSP_S" 2>/dev/null; then
+        if git_sub "$_CSP_DIR" branch -r --contains "$_CSP_S" 2>/dev/null | grep -q .; then
             print_result "PASS-WARN (R4)" "$_CSP_MOUNT" "\`$_CSP_S\` is ahead of \`$_CSP_T\` and lives on a live remote branch (legitimate 'docs PR merged just after' case, SMI-5666)" "$_CSP_BLOCK"
             _CSP_R4_WARNED=1
         else
@@ -240,7 +282,7 @@ evaluate_layer2() {
     # B-axis: S vs B (R7) — only when B is available (R10: absent => skip
     # this axis, not the whole mount; T-axis above still stands).
     if [ "$_CSP_B_AVAILABLE" -eq 1 ] && [ "$_CSP_S" != "$_CSP_B" ] \
-        && git -C "$_CSP_DIR" merge-base --is-ancestor "$_CSP_S" "$_CSP_B" 2>/dev/null; then
+        && git_sub "$_CSP_DIR" merge-base --is-ancestor "$_CSP_S" "$_CSP_B" 2>/dev/null; then
         _CSP_FAIL_RULES+=("R7")
         _CSP_FAIL_MSGS+=("R7: backward regression: this pointer already registers \`$_CSP_B\` on \`$_CSP_REF\`, which is ahead of the proposed \`$_CSP_S\`; re-bump to \`$_CSP_B\` or a descendant of it, never to an ancestor")
     fi

--- a/scripts/ci/check-submodule-pointer.helpers.sh
+++ b/scripts/ci/check-submodule-pointer.helpers.sh
@@ -107,44 +107,19 @@ repo_slug() {
 # already names it. Verified — `rev-parse --show-toplevel` and `ls-tree HEAD`
 # return identical results with and without GIT_DIR set.
 #
-# WHICH vars are unset, and why it is not just GIT_DIR. An earlier version of
-# this wrapper unset only GIT_DIR and GIT_WORK_TREE and claimed that "removes
-# the remaining way a caller's environment could redirect these reads". That
-# claim was false, and measurement is what caught it — governance review found
-# it, and it reproduced here against docs/internal:
+# WHICH vars are cleared, and why, lives in ONE place: git-env-sanitize.sh.
+# This wrapper delegates there rather than carrying its own copy of the list —
+# an earlier version kept a second inline copy in submodule-pointer-autorepair.sh
+# synchronised only by a comment, which is drift waiting to happen.
 #
-#   GIT_COMMON_DIR=<outer .git>          + env -u GIT_DIR -u GIT_WORK_TREE -> exit 128
-#   GIT_OBJECT_DIRECTORY=<outer objects> + env -u GIT_DIR -u GIT_WORK_TREE -> exit 128
-#
-# Both redirect straight through a GIT_DIR-only unset, producing the same
-# failure class as the original bug. The other six discovery vars
-# (GIT_INDEX_FILE, GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_NAMESPACE,
-# GIT_PREFIX, GIT_CEILING_DIRECTORIES, GIT_DISCOVERY_ACROSS_FILESYSTEM)
-# measured harmless for these call shapes, and git exports none of the eight
-# into hooks natively — so this is hardening against a class, not a live
-# trigger. It is unset anyway because enumerating "which ones happen to matter
-# for today's exact commands" is the brittle version of this fix.
-#
-# The list mirrors GIT_DISCOVERY_VARS in scripts/tests/_lib/git-fixture-env.ts
-# (SMI-4693, audited 2026-05-03), which is this repo's single source of truth
-# for the discovery-redirect threat model. Keep them in sync.
-#
-# DELIBERATE DIVERGENCE from that list: its last two entries, GIT_CONFIG and
-# XDG_CONFIG_HOME, are NOT unset here. Those route config resolution, not repo
-# discovery, and this wrapper runs a real authenticated `git fetch` whose
-# credentials come from the `url.<base>.insteadOf` rewrite that CI installs
-# with `git config --global`. Narrowing to the discovery class keeps the fix
-# scoped to the defect. (Measured that it would in fact have been safe either
-# way: `git config --global` writes to $HOME/.gitconfig even when
-# XDG_CONFIG_HOME is set, and the rewrite is still visible with
-# XDG_CONFIG_HOME unset — so this is a scoping choice, not a workaround.)
+# Note that the entry point (check-submodule-pointer.sh) already calls
+# sanitize_git_env() for the whole process, so in the normal path this wrapper
+# is defence in depth rather than the active fix. It still matters: a test that
+# sources this file directly does not go through that entry point.
 git_sub() {
     _CSP_GIT_SUB_DIR="$1"
     shift
-    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
-        -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_NAMESPACE \
-        -u GIT_PREFIX -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
-        git -C "$_CSP_GIT_SUB_DIR" "$@"
+    git_sanitized -C "$_CSP_GIT_SUB_DIR" "$@"
 }
 
 # print_result — unified output line. severity: PASS|PASS-WARN|SKIP|FAIL.

--- a/scripts/ci/check-submodule-pointer.helpers.sh
+++ b/scripts/ci/check-submodule-pointer.helpers.sh
@@ -107,14 +107,44 @@ repo_slug() {
 # already names it. Verified — `rev-parse --show-toplevel` and `ls-tree HEAD`
 # return identical results with and without GIT_DIR set.
 #
-# GIT_WORK_TREE is unset alongside GIT_DIR as defence in depth. Measured, only
-# GIT_DIR is actually exported into hooks, and unsetting GIT_DIR alone is
-# sufficient; unsetting both costs nothing and removes the remaining way a
-# caller's environment could redirect these reads.
+# WHICH vars are unset, and why it is not just GIT_DIR. An earlier version of
+# this wrapper unset only GIT_DIR and GIT_WORK_TREE and claimed that "removes
+# the remaining way a caller's environment could redirect these reads". That
+# claim was false, and measurement is what caught it — governance review found
+# it, and it reproduced here against docs/internal:
+#
+#   GIT_COMMON_DIR=<outer .git>          + env -u GIT_DIR -u GIT_WORK_TREE -> exit 128
+#   GIT_OBJECT_DIRECTORY=<outer objects> + env -u GIT_DIR -u GIT_WORK_TREE -> exit 128
+#
+# Both redirect straight through a GIT_DIR-only unset, producing the same
+# failure class as the original bug. The other six discovery vars
+# (GIT_INDEX_FILE, GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_NAMESPACE,
+# GIT_PREFIX, GIT_CEILING_DIRECTORIES, GIT_DISCOVERY_ACROSS_FILESYSTEM)
+# measured harmless for these call shapes, and git exports none of the eight
+# into hooks natively — so this is hardening against a class, not a live
+# trigger. It is unset anyway because enumerating "which ones happen to matter
+# for today's exact commands" is the brittle version of this fix.
+#
+# The list mirrors GIT_DISCOVERY_VARS in scripts/tests/_lib/git-fixture-env.ts
+# (SMI-4693, audited 2026-05-03), which is this repo's single source of truth
+# for the discovery-redirect threat model. Keep them in sync.
+#
+# DELIBERATE DIVERGENCE from that list: its last two entries, GIT_CONFIG and
+# XDG_CONFIG_HOME, are NOT unset here. Those route config resolution, not repo
+# discovery, and this wrapper runs a real authenticated `git fetch` whose
+# credentials come from the `url.<base>.insteadOf` rewrite that CI installs
+# with `git config --global`. Narrowing to the discovery class keeps the fix
+# scoped to the defect. (Measured that it would in fact have been safe either
+# way: `git config --global` writes to $HOME/.gitconfig even when
+# XDG_CONFIG_HOME is set, and the rewrite is still visible with
+# XDG_CONFIG_HOME unset — so this is a scoping choice, not a workaround.)
 git_sub() {
     _CSP_GIT_SUB_DIR="$1"
     shift
-    env -u GIT_DIR -u GIT_WORK_TREE git -C "$_CSP_GIT_SUB_DIR" "$@"
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
+        -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_NAMESPACE \
+        -u GIT_PREFIX -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
+        git -C "$_CSP_GIT_SUB_DIR" "$@"
 }
 
 # print_result — unified output line. severity: PASS|PASS-WARN|SKIP|FAIL.
@@ -172,6 +202,10 @@ evaluate_mount() {
     # discovery walks UP the directory tree and silently finds the PARENT
     # repo's own .git instead of failing — that would make this check
     # always report "initialized" even when the submodule plainly isn't.
+    # SMI-6569 makes this MORE true, not less: git_sub exists precisely to
+    # strip the env hints that would otherwise short-circuit discovery, so it
+    # guarantees the upward walk this check must avoid. A plain filesystem
+    # test is the right tool here and no wrapper changes that.
     _CSP_DIR="$_CSP_ROOT/$_CSP_MOUNT"
     if [ ! -e "$_CSP_DIR/.git" ]; then
         print_result "SKIP" "$_CSP_MOUNT" "local submodule checkout not initialized — cannot verify ancestry locally (CI initializes this before running; a developer pushing without the submodule checked out is never blocked)" "$_CSP_BLOCK"

--- a/scripts/ci/check-submodule-pointer.sh
+++ b/scripts/ci/check-submodule-pointer.sh
@@ -44,8 +44,19 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=git-env-sanitize.sh
+source "$SCRIPT_DIR/git-env-sanitize.sh"
 # shellcheck source=check-submodule-pointer.helpers.sh
 source "$SCRIPT_DIR/check-submodule-pointer.helpers.sh"
+
+# SMI-6569: clear the inherited git environment BEFORE resolving the repo root
+# below. Every git call in this script and its helpers — outer-repo calls
+# included — depends on this. See git-env-sanitize.sh for the executed
+# counterexamples; the short version is that an inherited GIT_DIR pointed at a
+# different valid repository makes the outer `ls-tree` return empty with exit
+# 0, which evaluate_mount reads as "no gitlink entry, nothing to check" and
+# reports as a PASS.
+sanitize_git_env
 
 # v1 blocking allowlist (plan's "Scope boundary" design decision). The three
 # skillsmith-strategy mounts (.claude/skills, .claude/plans,

--- a/scripts/ci/git-env-sanitize.sh
+++ b/scripts/ci/git-env-sanitize.sh
@@ -1,0 +1,111 @@
+# scripts/ci/git-env-sanitize.sh
+# SMI-6569 — single source of truth for the git environment variables that can
+# change this guard's verdict, plus the entry-point sanitizer that clears them.
+# Sourced only, never run standalone. Bash (not POSIX sh) — arrays are used.
+#
+# ## Why this exists
+#
+# `git -C <dir>` does NOT override an inherited git environment. `-C` changes
+# the working directory; the environment still wins over repo discovery. Git
+# exports an absolute GIT_DIR into hooks on a push from a linked worktree,
+# which is this repo's default workspace, so `.husky/pre-push` hit this on
+# every run: every submodule-directed call in check-submodule-pointer.helpers.sh
+# was reading the OUTER repo, producing a fabricated R1 that also suppressed
+# the true verdict.
+#
+# ## Why the contract is "verdict-affecting", not "discovery"
+#
+# An earlier fix scoped this to repo *discovery* and unset ten variables. Two
+# separate reviews found that insufficient, both with executed counterexamples:
+#
+#   1. GIT_COMMON_DIR and GIT_OBJECT_DIRECTORY redirect a submodule-directed
+#      call even with GIT_DIR and GIT_WORK_TREE unset (exit 128 on a
+#      `cat-file -e` for a commit that exists).
+#
+#   2. GIT_SHALLOW_FILE is not a discovery variable at all, and does not
+#      redirect anything — it rewrites the repository's *ancestry*:
+#
+#          clean                      -> rev-parse --is-shallow-repository = false
+#          GIT_SHALLOW_FILE=/dev/null -> rev-parse --is-shallow-repository = true
+#
+#      Shallow boundaries change what `merge-base --is-ancestor` and
+#      `rev-list --count` return, which is exactly what R3-R7 are decided on.
+#      A guard that classifies ancestry cannot ignore an ancestry override.
+#      GIT_GRAFT_FILE rewrites parentage the same way.
+#
+# So the boundary this file defends is "anything an inherited environment can
+# use to change which commits this guard believes exist or how they are
+# related" — a superset of discovery. Adding a variable here is cheap; missing
+# one produces a confident wrong verdict.
+#
+# ## Relationship to GIT_DISCOVERY_VARS
+#
+# The first ten entries mirror GIT_DISCOVERY_VARS in
+# scripts/tests/_lib/git-fixture-env.ts (SMI-4693, audited 2026-05-03), which
+# is the test-fixture side of the same threat model. Keep them in sync. The
+# last two are additions this file needs and that list does not have, because
+# a fixture builds its own repos from scratch and never evaluates inherited
+# ancestry.
+#
+# Two entries of that list are deliberately NOT mirrored: GIT_CONFIG and
+# XDG_CONFIG_HOME. Those route config resolution rather than repo state, and
+# this guard runs a real authenticated `git fetch` whose credentials come from
+# the url.<base>.insteadOf rewrite CI installs with `git config --global`.
+# Measured that clearing them would in fact have been safe — `git config
+# --global` writes to $HOME/.gitconfig even when XDG_CONFIG_HOME is set, and
+# the rewrite stays visible with it unset — so this is a scoping choice, not a
+# workaround. `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*`
+# / `GIT_CONFIG_PARAMETERS` can inject arbitrary config including remote URLs
+# and are a separate, unaddressed surface — tracked rather than guessed at.
+
+SKILLSMITH_GIT_VERDICT_VARS=(
+    # --- repo discovery (mirrors GIT_DISCOVERY_VARS) ---
+    GIT_DIR
+    GIT_WORK_TREE
+    GIT_INDEX_FILE
+    GIT_OBJECT_DIRECTORY
+    GIT_ALTERNATE_OBJECT_DIRECTORIES
+    GIT_COMMON_DIR
+    GIT_NAMESPACE
+    GIT_PREFIX
+    GIT_CEILING_DIRECTORIES
+    GIT_DISCOVERY_ACROSS_FILESYSTEM
+    # --- ancestry rewriting (this file's own additions) ---
+    GIT_SHALLOW_FILE
+    GIT_GRAFT_FILE
+)
+
+# sanitize_git_env — clear the whole set for the remainder of this process.
+#
+# Call this ONCE at the entry point of any script that evaluates gitlink
+# ancestry, BEFORE resolving the repo root. Sanitizing at process entry rather
+# than per call is what makes the OUTER-repo calls safe too: an earlier fix
+# wrapped only the submodule-directed calls, on the reasoning that an inherited
+# worktree GIT_DIR already names the outer repo. That reasoning held only for
+# the specific value a hook exports. Executed counterexample — GIT_DIR pointed
+# at the submodule's own gitdir while running an OUTER call:
+#
+#   clean    ls-tree HEAD -- docs/internal -> 160000 commit f87c529… docs/internal
+#   poisoned ls-tree HEAD -- docs/internal -> (empty), exit 0
+#
+# An empty S is read by evaluate_mount as "no gitlink entry at --ref … nothing
+# to check" and returns PASS. That is a wrong answer delivered as a pass, which
+# is the exact failure class this guard exists to prevent — and in
+# submodule-pointer-autorepair.sh the same class reaches `add`, `commit` and
+# `push`.
+sanitize_git_env() {
+    unset "${SKILLSMITH_GIT_VERDICT_VARS[@]}"
+}
+
+# git_sanitized <git-args...> — run git with the verdict-affecting environment
+# cleared for that one invocation. Defence in depth for callers that source
+# this file without going through an entry point that called
+# sanitize_git_env(), and for anything spawned with an environment this process
+# does not control.
+git_sanitized() {
+    _SGE_ENV_ARGS=()
+    for _SGE_VAR in "${SKILLSMITH_GIT_VERDICT_VARS[@]}"; do
+        _SGE_ENV_ARGS+=(-u "$_SGE_VAR")
+    done
+    env "${_SGE_ENV_ARGS[@]}" git "$@"
+}

--- a/scripts/ci/submodule-pointer-autorepair.sh
+++ b/scripts/ci/submodule-pointer-autorepair.sh
@@ -217,7 +217,14 @@ main() {
     if [ "$RULE" = "R3" ]; then
         # The only auto-repairable case: fast-forward the gitlink to T.
         BRANCH="$(git config -f "$REPO_ROOT/.gitmodules" --get submodule."$MOUNT".branch 2>/dev/null || echo main)"
-        T_SHA="$(git -C "$MOUNT_DIR" rev-parse "origin/$BRANCH")"
+        # `env -u GIT_DIR -u GIT_WORK_TREE` for the same reason as
+        # check-submodule-pointer.helpers.sh's git_sub (SMI-6569): `git -C`
+        # does NOT override an absolute inherited GIT_DIR, so without this the
+        # call silently reads the OUTER repo. Not currently defective here —
+        # this script runs from a GitHub Actions step, which exports no
+        # GIT_DIR, unlike a hook on a push from a linked worktree — but the
+        # pattern is identical and hardening it costs nothing.
+        T_SHA="$(env -u GIT_DIR -u GIT_WORK_TREE git -C "$MOUNT_DIR" rev-parse "origin/$BRANCH")"
 
         # No `set -e` in this script (the push result below needs explicit
         # if/else branching), so this sequence must fail loudly and stop here
@@ -225,7 +232,7 @@ main() {
         # below with a HEAD that never actually advanced (governance review
         # finding — a job with write access to main must never risk pushing a
         # stale HEAD because an earlier step in the same run silently failed).
-        if ! git -C "$MOUNT_DIR" checkout --detach --quiet "$T_SHA" \
+        if ! env -u GIT_DIR -u GIT_WORK_TREE git -C "$MOUNT_DIR" checkout --detach --quiet "$T_SHA" \
             || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" add "$MOUNT" \
             || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" \
                 commit --quiet -m "chore(docs): fast-forward docs/internal pointer to ${T_SHA:0:7} [auto-repair SMI-6260]"; then

--- a/scripts/ci/submodule-pointer-autorepair.sh
+++ b/scripts/ci/submodule-pointer-autorepair.sh
@@ -3,11 +3,12 @@
 # SMI-6260 Wave 2 — post-merge TOCTOU closure for docs/internal's gitlink.
 # Invoked by the `pointer-autorepair` job in
 # .github/workflows/submodule-pointer-check.yml on every push to `main`
-# touching a .gitmodules mount. Not named as a separate file in the plan's
-# item 5 "Files" list, which names only the workflow YAML — added here to
-# keep the workflow YAML's own complexity bounded and to match this repo's
-# existing convention of a dedicated script behind a thin workflow step
-# (see scripts/prod-deploy-cancel-monitor.sh + .github/workflows/prod-deploy-cancel-monitor.yml).
+# touching a .gitmodules mount. Lives here rather than inline in the workflow
+# YAML to keep that file's complexity bounded, matching this repo's existing
+# convention of a dedicated script behind a thin workflow step (see
+# scripts/prod-deploy-cancel-monitor.sh + .github/workflows/prod-deploy-cancel-monitor.yml).
+# SMI-6260's plan named only the workflow YAML and SMI-6580's draft repeated
+# that error; the corrected plan names THIS file as the alerting surface.
 #
 # Design (binding):
 # docs/internal/implementation/smi-6260-docs-internal-pointer-regression-gate.md
@@ -17,7 +18,52 @@
 # branch, matching check-submodule-pointer.sh's own --mode=block exit-code
 # semantics (only a BLOCKING_MOUNTS failure sets the non-zero exit).
 #
-# Required env:
+# SMI-6580 Wave 1 — this alerting path failed SILENTLY in production: it
+# correctly detected a real ADR-143 ancestry violation, then failed to open
+# the alert issue and still concluded `success`. Root cause (confirmed via
+# workflow run 34719995369, the line immediately above the swallowed
+# `::warning::`): `gh issue create --label submodule-pointer-regression`
+# failed with `could not add label: 'submodule-pointer-regression' not
+# found` — the label had never been created on this repo (`gh api
+# repos/smith-horn/skillsmith/labels --paginate` returned 49 labels, none of
+# them this one). Five independent silent-success paths, all fixed together
+# here (fixing the label without the rest would just move the failure
+# elsewhere; fixing the rest without the label would still fail the exact
+# same way):
+#   (a) `open_or_skip_issue` now runs an idempotent `gh label create`
+#       immediately before `gh issue create`, matching the established
+#       shape in scripts/prod-deploy-cancel-monitor.sh:178 and
+#       scripts/status-external-probe.sh:148. This label is also now
+#       pre-registered in scripts/setup-github-labels.sh, so a fresh repo
+#       never depends on this call-site create running first.
+#   (b) A failed `gh issue create` now captures stderr, emits it as a
+#       `::error::` naming the actual cause, and returns non-zero — the
+#       previous `|| echo "::warning::…"` discarded the cause and always
+#       returned 0.
+#   (c) Every caller of `open_or_skip_issue` now propagates that non-zero
+#       into this script's own exit status instead of the previous
+#       unconditional `exit 0` after every branch.
+#   (d) The dedupe `gh issue list` query's own failure is now distinguished
+#       from "no existing issue" (previously folded together by
+#       `|| echo ""`) — a `gh` outage no longer silently disables dedup and
+#       proceeds as though nothing were already reported.
+#   (e) A `check-submodule-pointer.sh` exit code of 2 (a BROKEN INVOCATION —
+#       unknown argument, an unresolvable --ref/--target/--before; see that
+#       script's own :69-71, :76, :94-101) is now distinguished from exit 1
+#       (a normal FAIL/R-FETCH content verdict) and fails loudly instead of
+#       being folded into "nothing actionable, exit 0".
+#
+# Testability: the body that was previously top-level imperative code (the
+# GITHUB_SHA/BEFORE_SHA requireds, the check-submodule-pointer.sh subprocess
+# call, and the FAIL_LINE/RULE dispatch) now lives in main(), called only
+# when this file is executed directly (the BASH_SOURCE guard at the very
+# bottom) — exactly what `run: ./scripts/ci/submodule-pointer-autorepair.sh`
+# does in the workflow. This lets scripts/tests/submodule-pointer-autorepair.test.ts
+# `source` the file to unit-test `open_or_skip_issue` directly (with a faked
+# `gh` on PATH) without triggering any of main()'s side effects or requiring
+# a real git fixture.
+#
+# Required env (only read inside main(), i.e. only when executed directly):
 #   GITHUB_SHA        the pushed commit (T-side ref for check-submodule-pointer.sh)
 #   BEFORE_SHA         resolved B_prev source (github.event.before, or the
 #                      workflow's HEAD~1 fallback for a null/new-branch before)
@@ -37,50 +83,61 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MOUNT="docs/internal"
 MOUNT_DIR="$REPO_ROOT/$MOUNT"
-OUTPUT_FILE="$(mktemp)"
-
-: "${GITHUB_SHA:?GITHUB_SHA required}"
-: "${BEFORE_SHA:?BEFORE_SHA required}"
-SHADOW="${SHADOW:-1}"
-MAIN_PUSH_PAT="${MAIN_PUSH_PAT:-}"
-GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-smith-horn/skillsmith}"
-
-"$REPO_ROOT/scripts/ci/check-submodule-pointer.sh" \
-    --mode=block \
-    --ref="$GITHUB_SHA" \
-    --before="$BEFORE_SHA" \
-    >"$OUTPUT_FILE" 2>&1
-EXIT_CODE=$?
-cat "$OUTPUT_FILE"
-
-if [ "$EXIT_CODE" -eq 0 ]; then
-    echo "[pointer-autorepair] no blocking-mount violation on this push — nothing to do."
-    exit 0
-fi
-
-FAIL_LINE="$(grep -E "^FAIL \[${MOUNT}\]: " "$OUTPUT_FILE" | head -1 || true)"
-if [ -z "$FAIL_LINE" ]; then
-    echo "[pointer-autorepair] non-zero exit but no blocking-mount FAIL line found for $MOUNT — nothing actionable (likely R-FETCH, already handled by the caller's own fetch-outcome gate)."
-    exit 0
-fi
-
-RULE="$(printf '%s' "$FAIL_LINE" | sed -E 's/^FAIL \[[^]]+\]: (R[0-9]+):.*/\1/')"
-echo "[pointer-autorepair] matched rule: $RULE"
 
 # ---------------------------------------------------------------------------
 # Deduped GitHub issue helper — dedupe key is the exact commit SHA this run
 # is reacting to (a fresh regression on a later push always gets its own
 # issue, even if an older one for a prior SHA is still open).
+#
+# Reads globals set by main() before dispatch: GITHUB_REPOSITORY, GITHUB_SHA,
+# FAIL_LINE, RULE. A unit test that sources this file directly must set
+# those four (plus a faked `gh` on PATH) before calling this function.
+#
+# Returns 0 on success OR on a legitimate skip (already reported). Returns
+# 1 on any failure that means the alert was NOT actually delivered — the
+# dedupe query failing (SMI-6580d) or the issue create failing (SMI-6580b) —
+# so callers must propagate this to the script's own exit status
+# (SMI-6580c), never assume success just because the function returned.
 # ---------------------------------------------------------------------------
 open_or_skip_issue() {
     _SPA_REMEDIATION="$1"
-    _SPA_EXISTING="$(gh issue list --repo "$GITHUB_REPOSITORY" \
+
+    # SMI-6580(d): distinguish "the dedupe query itself failed" from "no
+    # existing issue" — the original `|| echo ""` folded both into an empty
+    # string, so a `gh` outage silently disabled dedup and proceeded as if
+    # nothing were open. `gh issue list`'s own exit status is now captured
+    # explicitly instead of being discarded.
+    #
+    # stderr goes to a FILE, never `2>&1` into the captured value. `gh` writes
+    # advisory notices to stderr on otherwise-successful calls (new-release
+    # nags, auth/deprecation warnings), and merging those into the capture
+    # makes a non-empty `_SPA_EXISTING` on a run where NO issue exists — which
+    # this function would then read as "already reported" and skip alerting.
+    # That is the SMI-6580 silent-miss reintroduced by its own fix; measured
+    # with a faked `gh` that prints a release notice on a successful list.
+    _SPA_ERR_FILE="$(mktemp)"
+    if ! _SPA_EXISTING="$(gh issue list --repo "$GITHUB_REPOSITORY" \
         --search "\"commit ${GITHUB_SHA}\" in:body" --state all \
-        --json number -q '.[0].number' 2>/dev/null || echo "")"
+        --json number -q '.[0].number' 2>"$_SPA_ERR_FILE")"; then
+        echo "::error::[pointer-autorepair] dedupe query failed (gh issue list) — cannot safely determine whether ${RULE} on ${GITHUB_SHA} was already reported, refusing to proceed as though it wasn't: $(cat "$_SPA_ERR_FILE")"
+        rm -f "$_SPA_ERR_FILE"
+        return 1
+    fi
+    rm -f "$_SPA_ERR_FILE"
     if [ -n "${_SPA_EXISTING:-}" ] && [ "$_SPA_EXISTING" != "null" ]; then
         echo "[pointer-autorepair] already reported as issue #${_SPA_EXISTING}, skipping"
         return 0
     fi
+
+    # SMI-6580(a): the label must exist before `gh issue create --label`
+    # references it, or the create silently fails with "not found" — the
+    # exact SMI-6580 root cause (see this file's header note). Idempotent
+    # and safe to call on every run; matches the established shape in
+    # scripts/prod-deploy-cancel-monitor.sh:178 and
+    # scripts/status-external-probe.sh:148. This label is also pre-
+    # registered in scripts/setup-github-labels.sh so a fresh repo doesn't
+    # depend on this call-site create running first.
+    gh label create submodule-pointer-regression --color b60205 --force >/dev/null 2>&1 || true
 
     # shellcheck disable=SC2016  # single-quoted ON PURPOSE: the backticked
     # `pointer-autorepair`/`main`/etc. spans are literal Markdown, not shell
@@ -89,61 +146,135 @@ open_or_skip_issue() {
     _SPA_BODY="$(printf '%s\n\nDetected by `pointer-autorepair` (SMI-6260) on push to `main`, commit %s.\n\n**Remediation**: %s\n\n_Auto-generated by `.github/workflows/submodule-pointer-check.yml` (SMI-6260)._' \
         "$FAIL_LINE" "$GITHUB_SHA" "$_SPA_REMEDIATION")"
 
-    gh issue create --repo "$GITHUB_REPOSITORY" \
+    # SMI-6580(b): capture stderr and surface the actual cause instead of
+    # discarding it into a generic `::warning::` that always returned 0.
+    # stderr to a FILE (not `2>&1`) so stdout stays clean for the created
+    # issue's URL, which is echoed below — the pre-SMI-6580 code let `gh`
+    # print that URL straight to the job log, and losing it would make a
+    # successful alert harder to find than a failed one.
+    _SPA_ERR_FILE="$(mktemp)"
+    if ! _SPA_URL="$(gh issue create --repo "$GITHUB_REPOSITORY" \
         --label submodule-pointer-regression \
         --title "docs/internal pointer regression on main (${RULE}) — commit ${GITHUB_SHA:0:7}" \
-        --body "$_SPA_BODY" || echo "::warning::gh issue create failed for ${RULE} on ${GITHUB_SHA}"
+        --body "$_SPA_BODY" 2>"$_SPA_ERR_FILE")"; then
+        echo "::error::[pointer-autorepair] gh issue create failed for ${RULE} on ${GITHUB_SHA}: $(cat "$_SPA_ERR_FILE")"
+        rm -f "$_SPA_ERR_FILE"
+        return 1
+    fi
+    rm -f "$_SPA_ERR_FILE"
+    echo "[pointer-autorepair] opened issue for ${RULE} on ${GITHUB_SHA}: ${_SPA_URL}"
+    return 0
 }
 
-if [ "$RULE" = "R3" ]; then
-    # The only auto-repairable case: fast-forward the gitlink to T.
-    BRANCH="$(git config -f "$REPO_ROOT/.gitmodules" --get submodule."$MOUNT".branch 2>/dev/null || echo main)"
-    T_SHA="$(git -C "$MOUNT_DIR" rev-parse "origin/$BRANCH")"
+# main — the actual driver, previously top-level imperative code. Only
+# invoked by the BASH_SOURCE guard at the bottom of this file, never when
+# the file is merely `source`d (e.g. by a unit test wanting only
+# open_or_skip_issue). Returns the same exit-status contract the script
+# always had: 0 for "handled" (including every legitimate skip/degrade
+# path), 1 for anything that means an alert or repair did NOT actually
+# happen when it should have (SMI-6580 fix).
+main() {
+    OUTPUT_FILE="$(mktemp)"
 
-    # No `set -e` in this script (the push result below needs explicit
-    # if/else branching), so this sequence must fail loudly and stop here
-    # rather than silently falling through to the push-or-shadow branch
-    # below with a HEAD that never actually advanced (governance review
-    # finding — a job with write access to main must never risk pushing a
-    # stale HEAD because an earlier step in the same run silently failed).
-    if ! git -C "$MOUNT_DIR" checkout --detach --quiet "$T_SHA" \
-        || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" add "$MOUNT" \
-        || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" \
-            commit --quiet -m "chore(docs): fast-forward docs/internal pointer to ${T_SHA:0:7} [auto-repair SMI-6260]"; then
-        echo "::error::[pointer-autorepair] failed to prepare the R3 repair commit (checkout/add/commit) — aborting without pushing or alerting on a stale HEAD; re-run the workflow"
-        exit 1
+    : "${GITHUB_SHA:?GITHUB_SHA required}"
+    : "${BEFORE_SHA:?BEFORE_SHA required}"
+    SHADOW="${SHADOW:-1}"
+    MAIN_PUSH_PAT="${MAIN_PUSH_PAT:-}"
+    GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-smith-horn/skillsmith}"
+
+    "$REPO_ROOT/scripts/ci/check-submodule-pointer.sh" \
+        --mode=block \
+        --ref="$GITHUB_SHA" \
+        --before="$BEFORE_SHA" \
+        >"$OUTPUT_FILE" 2>&1
+    EXIT_CODE=$?
+    cat "$OUTPUT_FILE"
+
+    if [ "$EXIT_CODE" -eq 0 ]; then
+        echo "[pointer-autorepair] no blocking-mount violation on this push — nothing to do."
+        return 0
     fi
 
-    if [ "$SHADOW" = "1" ]; then
-        echo "[pointer-autorepair] shadow mode — R3 detected, auto-repair PUSH suppressed, but still alerting (per plan's shadow-mode-scope clarification)."
-        open_or_skip_issue "SHADOW MODE: would fast-forward to ${T_SHA} (commit prepared locally, not pushed). Once shadow mode ends, or manually now: \`./scripts/bump-docs-pointer.sh\`"
-    elif [ -z "$MAIN_PUSH_PAT" ]; then
-        echo "::warning::SKILLSMITH_MAIN_PUSH_PAT not provisioned — degrading to alert-only for this R3 detection."
-        open_or_skip_issue "SKILLSMITH_MAIN_PUSH_PAT is not provisioned; auto-repair cannot push. Run manually: \`./scripts/bump-docs-pointer.sh\`"
-    else
-        if git -C "$REPO_ROOT" push "https://x-access-token:${MAIN_PUSH_PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main; then
-            echo "[pointer-autorepair] pushed fast-forward repair to main: ${T_SHA}"
-        else
-            echo "::warning::auto-repair push failed — falling back to alerting"
-            open_or_skip_issue "Auto-repair push failed (see workflow run log). Run manually: \`./scripts/bump-docs-pointer.sh\`"
+    FAIL_LINE="$(grep -E "^FAIL \[${MOUNT}\]: " "$OUTPUT_FILE" | head -1 || true)"
+    if [ -z "$FAIL_LINE" ]; then
+        # SMI-6580(e): exit 2 from check-submodule-pointer.sh means a BROKEN
+        # INVOCATION (unknown argument, or --ref/--target/--before failing
+        # to resolve to a commit — see its own :69-71, :76, :94-101), not a
+        # normal "nothing matched" verdict. Only exit 1 with no FAIL line is
+        # the legitimate R-FETCH-already-handled-elsewhere case; exit 2 must
+        # fail loudly instead of being silently treated as "nothing to do".
+        if [ "$EXIT_CODE" -eq 2 ]; then
+            echo "::error::[pointer-autorepair] check-submodule-pointer.sh exited 2 (broken invocation, not a content verdict) — see its output above; this is a bug in how this script invoked it, not a docs/internal regression"
+            return 1
         fi
+        echo "[pointer-autorepair] non-zero exit but no blocking-mount FAIL line found for $MOUNT — nothing actionable (likely R-FETCH, already handled by the caller's own fetch-outcome gate)."
+        return 0
     fi
-    exit 0
+
+    RULE="$(printf '%s' "$FAIL_LINE" | sed -E 's/^FAIL \[[^]]+\]: (R[0-9]+):.*/\1/')"
+    echo "[pointer-autorepair] matched rule: $RULE"
+
+    if [ "$RULE" = "R3" ]; then
+        # The only auto-repairable case: fast-forward the gitlink to T.
+        BRANCH="$(git config -f "$REPO_ROOT/.gitmodules" --get submodule."$MOUNT".branch 2>/dev/null || echo main)"
+        T_SHA="$(git -C "$MOUNT_DIR" rev-parse "origin/$BRANCH")"
+
+        # No `set -e` in this script (the push result below needs explicit
+        # if/else branching), so this sequence must fail loudly and stop here
+        # rather than silently falling through to the push-or-shadow branch
+        # below with a HEAD that never actually advanced (governance review
+        # finding — a job with write access to main must never risk pushing a
+        # stale HEAD because an earlier step in the same run silently failed).
+        if ! git -C "$MOUNT_DIR" checkout --detach --quiet "$T_SHA" \
+            || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" add "$MOUNT" \
+            || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" \
+                commit --quiet -m "chore(docs): fast-forward docs/internal pointer to ${T_SHA:0:7} [auto-repair SMI-6260]"; then
+            echo "::error::[pointer-autorepair] failed to prepare the R3 repair commit (checkout/add/commit) — aborting without pushing or alerting on a stale HEAD; re-run the workflow"
+            return 1
+        fi
+
+        if [ "$SHADOW" = "1" ]; then
+            echo "[pointer-autorepair] shadow mode — R3 detected, auto-repair PUSH suppressed, but still alerting (per plan's shadow-mode-scope clarification)."
+            if ! open_or_skip_issue "SHADOW MODE: would fast-forward to ${T_SHA} (commit prepared locally, not pushed). Once shadow mode ends, or manually now: \`./scripts/bump-docs-pointer.sh\`"; then
+                return 1
+            fi
+        elif [ -z "$MAIN_PUSH_PAT" ]; then
+            echo "::warning::SKILLSMITH_MAIN_PUSH_PAT not provisioned — degrading to alert-only for this R3 detection."
+            if ! open_or_skip_issue "SKILLSMITH_MAIN_PUSH_PAT is not provisioned; auto-repair cannot push. Run manually: \`./scripts/bump-docs-pointer.sh\`"; then
+                return 1
+            fi
+        else
+            if git -C "$REPO_ROOT" push "https://x-access-token:${MAIN_PUSH_PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main; then
+                echo "[pointer-autorepair] pushed fast-forward repair to main: ${T_SHA}"
+            else
+                echo "::warning::auto-repair push failed — falling back to alerting"
+                if ! open_or_skip_issue "Auto-repair push failed (see workflow run log). Run manually: \`./scripts/bump-docs-pointer.sh\`"; then
+                    return 1
+                fi
+            fi
+        fi
+        return 0
+    fi
+
+    case "$RULE" in
+        R1 | R5 | R6 | R7)
+            open_or_skip_issue "Run \`./scripts/bump-docs-pointer.sh\` (see the rule message above for the exact target)." || return 1
+            ;;
+        R11)
+            open_or_skip_issue "A maintainer must manually repair main's docs/internal pointer directly (see ADR-143's docs-internal-pointer-repair note) before R7 can validate new bumps against it." || return 1
+            ;;
+        R8)
+            open_or_skip_issue "R8 should not occur on a push to main (PAT is always available server-side) — investigate the workflow run directly." || return 1
+            ;;
+        *)
+            open_or_skip_issue "See the rule message above." || return 1
+            ;;
+    esac
+
+    return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+    exit $?
 fi
-
-case "$RULE" in
-    R1 | R5 | R6 | R7)
-        open_or_skip_issue "Run \`./scripts/bump-docs-pointer.sh\` (see the rule message above for the exact target)."
-        ;;
-    R11)
-        open_or_skip_issue "A maintainer must manually repair main's docs/internal pointer directly (see ADR-143's docs-internal-pointer-repair note) before R7 can validate new bumps against it."
-        ;;
-    R8)
-        open_or_skip_issue "R8 should not occur on a push to main (PAT is always available server-side) — investigate the workflow run directly."
-        ;;
-    *)
-        open_or_skip_issue "See the rule message above."
-        ;;
-esac
-
-exit 0

--- a/scripts/ci/submodule-pointer-autorepair.sh
+++ b/scripts/ci/submodule-pointer-autorepair.sh
@@ -84,25 +84,26 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MOUNT="docs/internal"
 MOUNT_DIR="$REPO_ROOT/$MOUNT"
 
-# git_mount <git-args...> — run git against the SUBMODULE working directory,
-# immune to an inherited git-discovery environment (SMI-6569). Same contract
-# and same var list as check-submodule-pointer.helpers.sh's git_sub(); this
-# script does not source that file, so the wrapper is duplicated rather than
-# shared. Keep the two lists in sync, and in sync with GIT_DISCOVERY_VARS in
-# scripts/tests/_lib/git-fixture-env.ts (SMI-4693), which is the source of
-# truth for the threat model.
+# SMI-6569: clear the inherited git environment for this whole process. This
+# script's own git calls include `add`, `commit` and `push` against the OUTER
+# repo — the highest-consequence calls in the guard — and an earlier fix
+# wrapped only the submodule-directed ones. See git-env-sanitize.sh for the
+# executed counterexample showing an outer call returning a wrong answer with
+# exit 0 under a poisoned GIT_DIR.
 #
-# `git -C <dir>` does NOT override an absolute inherited GIT_DIR, and measured,
-# GIT_COMMON_DIR and GIT_OBJECT_DIRECTORY redirect even when GIT_DIR is unset.
-# Not currently defective here — this script runs from a GitHub Actions step,
-# which exports none of these — unlike a hook on a push from a linked worktree.
-# It is hardened anyway because the call shape is identical to the one that
-# WAS defective, and a reader should not have to work out which copy is safe.
+# Not a live trigger here (a GitHub Actions step exports none of these, unlike
+# a hook on a push from a linked worktree), but this script is the one that can
+# push to main, so it gets the same treatment rather than an argument about why
+# it does not need it.
+# shellcheck source=git-env-sanitize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/git-env-sanitize.sh"
+sanitize_git_env
+
+# git_mount <git-args...> — run git against the SUBMODULE working directory.
+# Delegates the variable list to git-env-sanitize.sh; see git_sub() in
+# check-submodule-pointer.helpers.sh for the sibling wrapper.
 git_mount() {
-    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
-        -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_NAMESPACE \
-        -u GIT_PREFIX -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
-        git -C "$MOUNT_DIR" "$@"
+    git_sanitized -C "$MOUNT_DIR" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -123,22 +124,44 @@ git_mount() {
 open_or_skip_issue() {
     _SPA_REMEDIATION="$1"
 
-    # SMI-6580(d): distinguish "the dedupe query itself failed" from "no
-    # existing issue" — the original `|| echo ""` folded both into an empty
-    # string, so a `gh` outage silently disabled dedup and proceeded as if
-    # nothing were open. `gh issue list`'s own exit status is now captured
-    # explicitly instead of being discarded.
+    # SMI-6580(F-4): a machine-readable dedupe key, embedded in the body and
+    # searched for verbatim. The previous key was the prose `commit <sha>`,
+    # which matches ANY issue whose body happens to mention that commit —
+    # combined with `--state all`, an old closed incident write-up discussing
+    # the same SHA would suppress a real pointer alert and return success.
+    # This marker cannot appear by accident, and the query below is also
+    # constrained by label.
+    _SPA_DEDUPE_KEY="pointer-autorepair-key:${MOUNT}:${GITHUB_SHA}"
+
+    # Label creation comes FIRST, before the dedupe query, because that query
+    # is label-constrained (below) and `gh issue list --label` against a label
+    # that does not exist is not a state this function should have to reason
+    # about. It is also the SMI-6580 root cause, so it belongs ahead of every
+    # other gh call rather than immediately before the create.
     #
-    # stderr goes to a FILE, never `2>&1` into the captured value. `gh` writes
-    # advisory notices to stderr on otherwise-successful calls (new-release
-    # nags, auth/deprecation warnings), and merging those into the capture
-    # makes a non-empty `_SPA_EXISTING` on a run where NO issue exists — which
-    # this function would then read as "already reported" and skip alerting.
-    # That is the SMI-6580 silent-miss reintroduced by its own fix; measured
-    # with a faked `gh` that prints a release notice on a successful list.
-    _SPA_ERR_FILE="$(mktemp)"
+    # SMI-6580(F-5): `|| true` on its own would make a failed label write
+    # indistinguishable from success. Tolerate failure only when the label
+    # demonstrably already exists; otherwise say so, because the next call is
+    # the one SMI-6580 was about.
+    _SPA_ERR_FILE="$(mktemp)" || {
+        echo "::error::[pointer-autorepair] mktemp failed — cannot capture gh diagnostics, refusing to run the alert path blind"
+        return 1
+    }
+    if ! gh label create submodule-pointer-regression --color b60205 \
+        --description "docs/internal pointer regression pointer-autorepair could not safely auto-repair (SMI-6260/SMI-6580)" \
+        >/dev/null 2>"$_SPA_ERR_FILE"; then
+        if gh label list --repo "$GITHUB_REPOSITORY" \
+            --search submodule-pointer-regression --json name \
+            -q '.[].name' 2>/dev/null | grep -qx submodule-pointer-regression; then
+            : # already exists — the expected steady state, nothing to report
+        else
+            echo "::warning::[pointer-autorepair] could not create label 'submodule-pointer-regression' and could not confirm it exists: $(cat "$_SPA_ERR_FILE"). The issue create below will fail if the label is genuinely missing, and that failure is now fatal."
+        fi
+    fi
+
     if ! _SPA_EXISTING="$(gh issue list --repo "$GITHUB_REPOSITORY" \
-        --search "\"commit ${GITHUB_SHA}\" in:body" --state all \
+        --label submodule-pointer-regression \
+        --search "\"${_SPA_DEDUPE_KEY}\" in:body" --state all \
         --json number -q '.[0].number' 2>"$_SPA_ERR_FILE")"; then
         echo "::error::[pointer-autorepair] dedupe query failed (gh issue list) — cannot safely determine whether ${RULE} on ${GITHUB_SHA} was already reported, refusing to proceed as though it wasn't: $(cat "$_SPA_ERR_FILE")"
         rm -f "$_SPA_ERR_FILE"
@@ -150,22 +173,16 @@ open_or_skip_issue() {
         return 0
     fi
 
-    # SMI-6580(a): the label must exist before `gh issue create --label`
-    # references it, or the create silently fails with "not found" — the
-    # exact SMI-6580 root cause (see this file's header note). Idempotent
-    # and safe to call on every run; matches the established shape in
-    # scripts/prod-deploy-cancel-monitor.sh:178 and
-    # scripts/status-external-probe.sh:148. This label is also pre-
-    # registered in scripts/setup-github-labels.sh so a fresh repo doesn't
-    # depend on this call-site create running first.
-    gh label create submodule-pointer-regression --color b60205 --force >/dev/null 2>&1 || true
-
     # shellcheck disable=SC2016  # single-quoted ON PURPOSE: the backticked
     # `pointer-autorepair`/`main`/etc. spans are literal Markdown, not shell
     # command substitution — the %s placeholders are printf format specs,
     # substituted via printf's own args below, never shell-expanded.
-    _SPA_BODY="$(printf '%s\n\nDetected by `pointer-autorepair` (SMI-6260) on push to `main`, commit %s.\n\n**Remediation**: %s\n\n_Auto-generated by `.github/workflows/submodule-pointer-check.yml` (SMI-6260)._' \
-        "$FAIL_LINE" "$GITHUB_SHA" "$_SPA_REMEDIATION")"
+    #
+    # The trailing HTML comment carries the dedupe key. It is invisible in
+    # rendered Markdown and is what the query above matches on, so dedupe no
+    # longer depends on prose that an unrelated issue could reproduce.
+    _SPA_BODY="$(printf '%s\n\nDetected by `pointer-autorepair` (SMI-6260) on push to `main`, commit %s.\n\n**Remediation**: %s\n\n_Auto-generated by `.github/workflows/submodule-pointer-check.yml` (SMI-6260)._\n\n<!-- %s -->' \
+        "$FAIL_LINE" "$GITHUB_SHA" "$_SPA_REMEDIATION" "$_SPA_DEDUPE_KEY")"
 
     # SMI-6580(b): capture stderr and surface the actual cause instead of
     # discarding it into a generic `::warning::` that always returned 0.
@@ -173,7 +190,10 @@ open_or_skip_issue() {
     # issue's URL, which is echoed below — the pre-SMI-6580 code let `gh`
     # print that URL straight to the job log, and losing it would make a
     # successful alert harder to find than a failed one.
-    _SPA_ERR_FILE="$(mktemp)"
+    _SPA_ERR_FILE="$(mktemp)" || {
+        echo "::error::[pointer-autorepair] mktemp failed — cannot capture gh's diagnostics for the issue create, refusing to attempt the alert blind"
+        return 1
+    }
     if ! _SPA_URL="$(gh issue create --repo "$GITHUB_REPOSITORY" \
         --label submodule-pointer-regression \
         --title "docs/internal pointer regression on main (${RULE}) — commit ${GITHUB_SHA:0:7}" \
@@ -195,7 +215,15 @@ open_or_skip_issue() {
 # path), 1 for anything that means an alert or repair did NOT actually
 # happen when it should have (SMI-6580 fix).
 main() {
-    OUTPUT_FILE="$(mktemp)"
+    # SMI-6580(F-5): mktemp's own failure was unchecked, and the file was never
+    # removed. An unchecked mktemp means `>"$OUTPUT_FILE"` writes to the empty
+    # string and the evaluator's output is lost, which this function would then
+    # scan for a FAIL line and find none.
+    OUTPUT_FILE="$(mktemp)" || {
+        echo "::error::[pointer-autorepair] mktemp failed — cannot capture the evaluator's output, refusing to run blind"
+        return 1
+    }
+    trap 'rm -f "$OUTPUT_FILE"' RETURN
 
     : "${GITHUB_SHA:?GITHUB_SHA required}"
     : "${BEFORE_SHA:?BEFORE_SHA required}"
@@ -216,19 +244,37 @@ main() {
         return 0
     fi
 
-    FAIL_LINE="$(grep -E "^FAIL \[${MOUNT}\]: " "$OUTPUT_FILE" | head -1 || true)"
-    if [ -z "$FAIL_LINE" ]; then
-        # SMI-6580(e): exit 2 from check-submodule-pointer.sh means a BROKEN
-        # INVOCATION (unknown argument, or --ref/--target/--before failing
-        # to resolve to a commit — see its own :69-71, :76, :94-101), not a
-        # normal "nothing matched" verdict. Only exit 1 with no FAIL line is
-        # the legitimate R-FETCH-already-handled-elsewhere case; exit 2 must
-        # fail loudly instead of being silently treated as "nothing to do".
-        if [ "$EXIT_CODE" -eq 2 ]; then
-            echo "::error::[pointer-autorepair] check-submodule-pointer.sh exited 2 (broken invocation, not a content verdict) — see its output above; this is a bug in how this script invoked it, not a docs/internal regression"
+    # SMI-6580(e): capture grep's OWN status instead of ending the pipeline
+    # with `| head -1 || true`, which masked both producer and consumer
+    # failure. grep exits 1 for "no match" (expected and benign) and >1 for a
+    # real error — an unreadable output file, a bad pattern. Those are not the
+    # same event and must not both read as "no FAIL line".
+    FAIL_LINE=""
+    if GREP_OUT="$(grep -E "^FAIL \[${MOUNT}\]: " "$OUTPUT_FILE")"; then
+        FAIL_LINE="$(printf '%s\n' "$GREP_OUT" | head -1)"
+    else
+        GREP_STATUS=$?
+        if [ "$GREP_STATUS" -gt 1 ]; then
+            echo "::error::[pointer-autorepair] could not scan the evaluator's output for a ${MOUNT} FAIL line (grep exited ${GREP_STATUS}, not 0-match-found or 1-no-match) — the verdict is unknown, refusing to report success"
             return 1
         fi
-        echo "[pointer-autorepair] non-zero exit but no blocking-mount FAIL line found for $MOUNT — nothing actionable (likely R-FETCH, already handled by the caller's own fetch-outcome gate)."
+    fi
+
+    if [ -z "$FAIL_LINE" ]; then
+        # ALLOWLIST, not a denylist. An earlier version special-cased exit 2
+        # and let every other non-zero status fall through to "nothing
+        # actionable, return 0" — so 126 (not executable), 127 (interpreter
+        # missing), a signal death, or any future status meant this job
+        # reported success on a run that never produced a verdict.
+        #
+        # Only exit 1 is a content verdict. Exit 2 is a broken invocation
+        # (unknown argument, or --ref/--target/--before not resolving — see
+        # check-submodule-pointer.sh's own argument parsing and ref checks).
+        if [ "$EXIT_CODE" -ne 1 ]; then
+            echo "::error::[pointer-autorepair] check-submodule-pointer.sh exited ${EXIT_CODE} with no ${MOUNT} FAIL line. Only exit 1 is a content verdict; 2 means this script invoked it wrongly, and anything else means it crashed, was signalled, or could not run at all. See its output above. Not treating this as 'nothing to do'."
+            return 1
+        fi
+        echo "[pointer-autorepair] exit 1 with no blocking-mount FAIL line for $MOUNT — nothing actionable (an R-FETCH or a non-blocking-mount warning, already handled by the caller's own fetch-outcome gate)."
         return 0
     fi
 

--- a/scripts/ci/submodule-pointer-autorepair.sh
+++ b/scripts/ci/submodule-pointer-autorepair.sh
@@ -84,6 +84,27 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MOUNT="docs/internal"
 MOUNT_DIR="$REPO_ROOT/$MOUNT"
 
+# git_mount <git-args...> — run git against the SUBMODULE working directory,
+# immune to an inherited git-discovery environment (SMI-6569). Same contract
+# and same var list as check-submodule-pointer.helpers.sh's git_sub(); this
+# script does not source that file, so the wrapper is duplicated rather than
+# shared. Keep the two lists in sync, and in sync with GIT_DISCOVERY_VARS in
+# scripts/tests/_lib/git-fixture-env.ts (SMI-4693), which is the source of
+# truth for the threat model.
+#
+# `git -C <dir>` does NOT override an absolute inherited GIT_DIR, and measured,
+# GIT_COMMON_DIR and GIT_OBJECT_DIRECTORY redirect even when GIT_DIR is unset.
+# Not currently defective here — this script runs from a GitHub Actions step,
+# which exports none of these — unlike a hook on a push from a linked worktree.
+# It is hardened anyway because the call shape is identical to the one that
+# WAS defective, and a reader should not have to work out which copy is safe.
+git_mount() {
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
+        -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_NAMESPACE \
+        -u GIT_PREFIX -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
+        git -C "$MOUNT_DIR" "$@"
+}
+
 # ---------------------------------------------------------------------------
 # Deduped GitHub issue helper — dedupe key is the exact commit SHA this run
 # is reacting to (a fresh regression on a later push always gets its own
@@ -217,14 +238,7 @@ main() {
     if [ "$RULE" = "R3" ]; then
         # The only auto-repairable case: fast-forward the gitlink to T.
         BRANCH="$(git config -f "$REPO_ROOT/.gitmodules" --get submodule."$MOUNT".branch 2>/dev/null || echo main)"
-        # `env -u GIT_DIR -u GIT_WORK_TREE` for the same reason as
-        # check-submodule-pointer.helpers.sh's git_sub (SMI-6569): `git -C`
-        # does NOT override an absolute inherited GIT_DIR, so without this the
-        # call silently reads the OUTER repo. Not currently defective here —
-        # this script runs from a GitHub Actions step, which exports no
-        # GIT_DIR, unlike a hook on a push from a linked worktree — but the
-        # pattern is identical and hardening it costs nothing.
-        T_SHA="$(env -u GIT_DIR -u GIT_WORK_TREE git -C "$MOUNT_DIR" rev-parse "origin/$BRANCH")"
+        T_SHA="$(git_mount rev-parse "origin/$BRANCH")"
 
         # No `set -e` in this script (the push result below needs explicit
         # if/else branching), so this sequence must fail loudly and stop here
@@ -232,7 +246,7 @@ main() {
         # below with a HEAD that never actually advanced (governance review
         # finding — a job with write access to main must never risk pushing a
         # stale HEAD because an earlier step in the same run silently failed).
-        if ! env -u GIT_DIR -u GIT_WORK_TREE git -C "$MOUNT_DIR" checkout --detach --quiet "$T_SHA" \
+        if ! git_mount checkout --detach --quiet "$T_SHA" \
             || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" add "$MOUNT" \
             || ! git -C "$REPO_ROOT" -c user.name="skillsmith-bot" -c user.email="bot@skillsmith.app" \
                 commit --quiet -m "chore(docs): fast-forward docs/internal pointer to ${T_SHA:0:7} [auto-repair SMI-6260]"; then

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -32,7 +32,8 @@ set -euo pipefail
 REPO="smith-horn/skillsmith"
 
 # ---------------------------------------------------------------------------
-# Taxonomy (26 labels total: 5 Type + 13 Domain + 7 Scope + 1 Workflow)
+# Taxonomy (27 labels total: 5 Type + 13 Domain + 7 Scope + 1 Workflow +
+# 1 Monitoring alert)
 # Format: "<name>|<color-without-hash>|<description>"
 # ---------------------------------------------------------------------------
 TAXONOMY=(
@@ -69,6 +70,20 @@ TAXONOMY=(
 
   # Workflow (1) — applied automatically by Issue Forms, removed by maintainers after triage
   "needs-triage|E4E669|Awaiting maintainer triage into Linear"
+
+  # Monitoring alerts (1) — SMI-6580 Wave 1: pre-registering this label here
+  # (in addition to the idempotent call-site `gh label create` in
+  # scripts/ci/submodule-pointer-autorepair.sh) means a fresh repo's alerting
+  # path never depends on this script having been run first. Root cause:
+  # `gh issue create --label submodule-pointer-regression` was failing
+  # ("not found") because the label had never existed on this repo, and the
+  # failure was being swallowed into a `::warning::` with the script still
+  # exiting 0 (see submodule-pointer-autorepair.sh's own header note). The
+  # other three monitor-only labels this same audit found missing
+  # (telemetry-liveness, prod-deploy-approval-cancelled,
+  # status-external-outage) are tracked separately under SMI-6586, which has
+  # its own fix plan — deliberately not added here.
+  "submodule-pointer-regression|B60205|docs/internal pointer regression pointer-autorepair could not safely auto-repair (SMI-6260/SMI-6580)"
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/check-submodule-pointer.test.ts
+++ b/scripts/tests/check-submodule-pointer.test.ts
@@ -230,13 +230,39 @@ describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
 
     const args = ['--mode=block', '--ref=HEAD', `--target=${c1}`]
     const clean = runScript(f.parentDir, args)
-    const contaminated = runScript(f.parentDir, args, {
-      GIT_DIR: join(f.parentDir, '.git'),
-    })
 
+    // GIT_DIR is the var git actually exports into hooks and the one that
+    // caused the reported bug. GIT_COMMON_DIR and GIT_OBJECT_DIRECTORY are
+    // included because they redirect identically and survive a GIT_DIR-only
+    // unset — measured, each producing exit 128 on the same `cat-file -e`
+    // call under `env -u GIT_DIR -u GIT_WORK_TREE`. Git exports neither into
+    // hooks, so they are a hardened class rather than a live trigger; the
+    // first version of this fix unset only GIT_DIR and claimed to have closed
+    // the class, which was false.
+    for (const varName of ['GIT_DIR', 'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY']) {
+      const value =
+        varName === 'GIT_OBJECT_DIRECTORY'
+          ? join(f.parentDir, '.git', 'objects')
+          : join(f.parentDir, '.git')
+      const contaminated = runScript(f.parentDir, args, { [varName]: value })
+      assertVerdictUnchanged(varName, clean, contaminated)
+    }
+  })
+
+  /**
+   * The SMI-6569 invariant: a git-discovery environment variable must not
+   * change this check's verdict. Asserted as full stdout + exit-status
+   * equality rather than by symptom name — see the caller for why naming a
+   * symptom would let the test pass against the bug in this fixture.
+   */
+  function assertVerdictUnchanged(
+    varName: string,
+    clean: RunResult,
+    contaminated: RunResult
+  ): void {
     // The real verdict survives contamination.
-    expect(contaminated.stdout).toContain('R3:')
-    expect(contaminated.stdout).toContain('stale')
+    expect(contaminated.stdout, `${varName}: true verdict lost`).toContain('R3:')
+    expect(contaminated.stdout, `${varName}: true verdict lost`).toContain('stale')
 
     // Neither contamination symptom is produced. Which one appears without
     // the fix depends on whether the OUTER repo has an `origin` remote:
@@ -248,14 +274,14 @@ describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
     // Both are the same defect. Asserting only R1 here would make this test
     // pass against the bug in the fixture, which is why the invariant below
     // is the load-bearing assertion rather than either symptom name.
-    expect(contaminated.stdout).not.toContain('R1:')
-    expect(contaminated.stdout).not.toContain('R-FETCH:')
+    expect(contaminated.stdout, `${varName}: fabricated R1`).not.toContain('R1:')
+    expect(contaminated.stdout, `${varName}: fabricated R-FETCH`).not.toContain('R-FETCH:')
 
-    // The invariant, and the strongest form of it: GIT_DIR must not change
-    // the verdict at all, exit status included.
-    expect(contaminated.status).toBe(clean.status)
-    expect(contaminated.stdout).toBe(clean.stdout)
-  })
+    // The invariant, and the strongest form of it: the variable must not
+    // change the verdict at all, exit status included.
+    expect(contaminated.status, `${varName}: exit status changed`).toBe(clean.status)
+    expect(contaminated.stdout, `${varName}: stdout changed`).toBe(clean.stdout)
+  }
 
   it('R4: S is a strict descendant of T and lives on a live remote branch -> PASS + warning', () => {
     const f = track(buildFixture())

--- a/scripts/tests/check-submodule-pointer.test.ts
+++ b/scripts/tests/check-submodule-pointer.test.ts
@@ -122,11 +122,20 @@ interface RunResult {
   stderr: string
 }
 
-function runScript(parentDir: string, args: string[]): RunResult {
+/**
+ * `envOverrides` exists for the SMI-6569 case, which must inject an absolute
+ * GIT_DIR — the one thing `makeFixtureEnv()` deliberately does not set,
+ * because every other test needs a clean environment.
+ */
+function runScript(
+  parentDir: string,
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {}
+): RunResult {
   const result = spawnSync('bash', [SCRIPT, ...args], {
     cwd: parentDir,
     encoding: 'utf8',
-    env: makeFixtureEnv(),
+    env: { ...makeFixtureEnv(), ...envOverrides },
   })
   return { status: result.status ?? -1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
 }
@@ -195,6 +204,57 @@ describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
     expect(r.stdout).toContain('R3:')
     expect(r.stdout).toContain('stale')
     expect(r.stdout).toContain('by 1 commits')
+  })
+
+  it('SMI-6569: an absolute inherited GIT_DIR does not fabricate R1 or suppress the true verdict', () => {
+    // `git -C <dir>` does NOT override an absolute GIT_DIR — -C changes the
+    // cwd, but GIT_DIR still wins over repo discovery, so every submodule-
+    // directed call in the helpers ran against the OUTER repo instead. Git
+    // exports an absolute GIT_DIR into hooks on a push FROM A LINKED
+    // WORKTREE, which is this repo's default workspace, so `.husky/pre-push`
+    // hit this on every run.
+    //
+    // The damage was in two directions at once: R1 ("was never pushed") is
+    // FABRICATED for a commit that is pushed and reachable, AND because R1 is
+    // a Layer-1 precondition it short-circuits Layer 2, SUPPRESSING the real
+    // verdict. This fixture is the R3 case above, so the true answer is known
+    // and the suppression is observable rather than merely asserted-absent.
+    //
+    // A relative GIT_DIR (".git") re-resolves against -C's cwd and is
+    // harmless; only an absolute one redirects. Hence the absolute path here.
+    const f = track(buildFixture())
+    const c1 = commitGitlink(f.parentDir, f.base, 'base bump (target)')
+    commitGitlink(f.parentDir, f.T, 'S = T (stale once remote advances)')
+    commitFile(f.seedDir, 'f2.txt', 'advance\n', 'remote advances past T')
+    git(f.seedDir, 'push', '-q', 'origin', f.branch)
+
+    const args = ['--mode=block', '--ref=HEAD', `--target=${c1}`]
+    const clean = runScript(f.parentDir, args)
+    const contaminated = runScript(f.parentDir, args, {
+      GIT_DIR: join(f.parentDir, '.git'),
+    })
+
+    // The real verdict survives contamination.
+    expect(contaminated.stdout).toContain('R3:')
+    expect(contaminated.stdout).toContain('stale')
+
+    // Neither contamination symptom is produced. Which one appears without
+    // the fix depends on whether the OUTER repo has an `origin` remote:
+    //   - production (outer repo HAS origin): the misdirected fetch succeeds
+    //     against the wrong repo, so the failure surfaces later as a
+    //     fabricated R1 — the reported SMI-6569 symptom.
+    //   - this fixture (parent has NO origin): the misdirected fetch itself
+    //     fails, so it surfaces earlier as R-FETCH.
+    // Both are the same defect. Asserting only R1 here would make this test
+    // pass against the bug in the fixture, which is why the invariant below
+    // is the load-bearing assertion rather than either symptom name.
+    expect(contaminated.stdout).not.toContain('R1:')
+    expect(contaminated.stdout).not.toContain('R-FETCH:')
+
+    // The invariant, and the strongest form of it: GIT_DIR must not change
+    // the verdict at all, exit status included.
+    expect(contaminated.status).toBe(clean.status)
+    expect(contaminated.stdout).toBe(clean.stdout)
   })
 
   it('R4: S is a strict descendant of T and lives on a live remote branch -> PASS + warning', () => {

--- a/scripts/tests/check-submodule-pointer.test.ts
+++ b/scripts/tests/check-submodule-pointer.test.ts
@@ -225,7 +225,7 @@ describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
     const f = track(buildFixture())
     const c1 = commitGitlink(f.parentDir, f.base, 'base bump (target)')
     commitGitlink(f.parentDir, f.T, 'S = T (stale once remote advances)')
-    commitFile(f.seedDir, 'f2.txt', 'advance\n', 'remote advances past T')
+    const advanced = commitFile(f.seedDir, 'f2.txt', 'advance\n', 'remote advances past T')
     git(f.seedDir, 'push', '-q', 'origin', f.branch)
 
     const args = ['--mode=block', '--ref=HEAD', `--target=${c1}`]
@@ -239,13 +239,73 @@ describe('check-submodule-pointer.sh — R0-R11 + R-FETCH', () => {
     // hooks, so they are a hardened class rather than a live trigger; the
     // first version of this fix unset only GIT_DIR and claimed to have closed
     // the class, which was false.
-    for (const varName of ['GIT_DIR', 'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY']) {
-      const value =
-        varName === 'GIT_OBJECT_DIRECTORY'
-          ? join(f.parentDir, '.git', 'objects')
-          : join(f.parentDir, '.git')
-      const contaminated = runScript(f.parentDir, args, { [varName]: value })
-      assertVerdictUnchanged(varName, clean, contaminated)
+    // Real ancestry-rewriting payloads. The boundary must be the ADVANCED
+    // commit (the new upstream tip), not `T`: shallow and graft files cut a
+    // commit's PARENTS, so detaching `T` leaves `T -> advanced` intact and
+    // changes nothing. Cutting `advanced`'s parents is what makes `T`
+    // unreachable from the tip, flipping `merge-base --is-ancestor` and the
+    // `rev-list --count` that R3's "behind by N" is built from.
+    //
+    // An earlier version of this test pointed both at /dev/null, which flips
+    // `rev-parse --is-shallow-repository` to true but lists no boundary and
+    // truncates nothing — it passed against the bug. Caught by removing the
+    // two vars from the sanitizer and watching the test still pass.
+    const shallowFile = join(f.root, 'poison-shallow')
+    writeFileSync(shallowFile, `${advanced}\n`)
+    const graftFile = join(f.root, 'poison-graft')
+    writeFileSync(graftFile, `${advanced}\n`)
+
+    const poisons: { name: string; value: string; why: string }[] = [
+      {
+        name: 'GIT_DIR',
+        value: join(f.parentDir, '.git'),
+        why: 'the var git actually exports into hooks; the reported bug',
+      },
+      {
+        name: 'GIT_COMMON_DIR',
+        value: join(f.parentDir, '.git'),
+        why: 'redirects identically and survives a GIT_DIR-only unset (measured exit 128)',
+      },
+      {
+        name: 'GIT_OBJECT_DIRECTORY',
+        value: join(f.parentDir, '.git', 'objects'),
+        why: 'same — survives a GIT_DIR-only unset',
+      },
+      {
+        // The counterexample that broke the "outer-repo calls are safe because
+        // an inherited worktree GIT_DIR already names the outer repo" claim.
+        // Pointing GIT_DIR at a DIFFERENT valid repository made the outer
+        // `ls-tree HEAD -- docs/internal` return EMPTY with exit 0, which
+        // evaluate_mount reads as "no gitlink entry … nothing to check" and
+        // reports as PASS — a wrong answer delivered as a pass.
+        name: 'GIT_DIR',
+        value: join(f.mountDir, '.git'),
+        why: 'points at the SUBMODULE repo, poisoning the OUTER calls too',
+      },
+      {
+        // Not a discovery variable at all — it rewrites ancestry. The file
+        // must name a REAL boundary commit to bite: an empty or /dev/null
+        // shallow file flips `rev-parse --is-shallow-repository` to true but
+        // truncates nothing, so a test using it would pass against the bug.
+        // With `T` listed as a boundary, T loses its parents, so
+        // `merge-base --is-ancestor <base> <T>` flips 0 -> 1 and
+        // `rev-list --count` drops — which is exactly what R3-R7 decide on.
+        name: 'GIT_SHALLOW_FILE',
+        value: shallowFile,
+        why: 'rewrites ancestry rather than redirecting discovery',
+      },
+      {
+        // Same class: a graft line naming a commit with no parents detaches
+        // it from its history.
+        name: 'GIT_GRAFT_FILE',
+        value: graftFile,
+        why: 'rewrites parentage, same class as GIT_SHALLOW_FILE',
+      },
+    ]
+
+    for (const p of poisons) {
+      const contaminated = runScript(f.parentDir, args, { [p.name]: p.value })
+      assertVerdictUnchanged(`${p.name} (${p.why})`, clean, contaminated)
     }
   })
 

--- a/scripts/tests/submodule-pointer-autorepair.test.ts
+++ b/scripts/tests/submodule-pointer-autorepair.test.ts
@@ -1,0 +1,425 @@
+/**
+ * SMI-6580 Wave 1 — scripts/ci/submodule-pointer-autorepair.sh test suite.
+ *
+ * This alerting path had ZERO coverage before this file (the only file
+ * mentioning `open_or_skip_issue` was the script itself) and failed
+ * silently in production: it correctly detected a real ADR-143 ancestry
+ * violation, then failed to open the alert issue while still concluding
+ * `success`, because `gh issue create --label submodule-pointer-regression`
+ * failed on a label that had never been created — a failure the old code
+ * swallowed into a `::warning::` and an unconditional `exit 0`.
+ *
+ * Two testing strategies, matching the two precedents named for this task:
+ *  - `open_or_skip_issue` is unit-tested by `source`-ing the real script
+ *    (the BASH_SOURCE guard at its bottom means main()'s side effects never
+ *    run on a plain `source`) and calling the function directly, with a
+ *    faked `gh` binary prepended to PATH — mirrors
+ *    scripts/tests/needle-dispatch.test.sh's "fake the binaries on PATH"
+ *    technique.
+ *  - The exit-code-2-vs-1 distinction (and one full end-to-end replay of
+ *    the real production defect) is tested by invoking the real script as
+ *    a genuine child process against small real git fixtures — mirrors
+ *    scripts/tests/check-submodule-pointer.test.ts's approach (and reuses
+ *    its exact fixture shape for the R1 case, since check-submodule-
+ *    pointer.sh's own exit/FAIL-line contract is what autorepair.sh reads).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const SCRIPT = join(REPO_ROOT, 'scripts', 'ci', 'submodule-pointer-autorepair.sh')
+
+const FAKE_SHA_1 = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+
+// ---------------------------------------------------------------------------
+// Fake `gh` — logs `<subcommand> <subcommand2>` (e.g. "issue create") to a
+// file so tests can assert call ORDER, and behaves per env-var switches so
+// each call site (dedupe query, label create, issue create) can be made to
+// fail independently without touching the network.
+// ---------------------------------------------------------------------------
+const FAKE_GH_SCRIPT = `#!/usr/bin/env bash
+set -u
+{ printf '%s %s\\n' "\${1:-}" "\${2:-}" >> "\${SPA_TEST_GH_LOG}"; } 2>/dev/null || true
+case "\${1:-} \${2:-}" in
+  "label create")
+    exit "\${SPA_TEST_GH_LABEL_EXIT:-0}"
+    ;;
+  "issue list")
+    if [ "\${SPA_TEST_GH_ISSUE_LIST_EXIT:-0}" != "0" ]; then
+      printf '%s\\n' "\${SPA_TEST_GH_ISSUE_LIST_STDERR:-gh: simulated issue-list failure}" >&2
+      exit "\${SPA_TEST_GH_ISSUE_LIST_EXIT}"
+    fi
+    # Real \`gh\` writes advisory notices to stderr on SUCCESSFUL calls too
+    # (new-release nags, auth/deprecation warnings). This knob reproduces
+    # that, which is what the SMI-6580d-followup regression test needs.
+    if [ -n "\${SPA_TEST_GH_ISSUE_LIST_STDERR_ON_SUCCESS:-}" ]; then
+      printf '%s\\n' "\${SPA_TEST_GH_ISSUE_LIST_STDERR_ON_SUCCESS}" >&2
+    fi
+    printf '%s' "\${SPA_TEST_GH_ISSUE_LIST_OUT:-}"
+    exit 0
+    ;;
+  "issue create")
+    if [ "\${SPA_TEST_GH_ISSUE_CREATE_EXIT:-0}" != "0" ]; then
+      printf '%s\\n' "\${SPA_TEST_GH_ISSUE_CREATE_STDERR:-gh: simulated issue-create failure}" >&2
+      exit "\${SPA_TEST_GH_ISSUE_CREATE_EXIT}"
+    fi
+    printf 'https://github.com/smith-horn/skillsmith/issues/9999\\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+
+const createdDirs: string[] = []
+
+function makeFakeGhDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'spa-fake-gh-'))
+  createdDirs.push(dir)
+  const ghPath = join(dir, 'gh')
+  writeFileSync(ghPath, FAKE_GH_SCRIPT)
+  chmodSync(ghPath, 0o755)
+  return dir
+}
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+interface RunResult {
+  status: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * `source`s the real script (main()'s side effects never run — see the
+ * BASH_SOURCE guard at its bottom) and calls `open_or_skip_issue`
+ * directly, with GITHUB_REPOSITORY/GITHUB_SHA/FAIL_LINE/RULE supplied via
+ * env, exactly as main() would set them as globals before dispatching.
+ */
+function callOpenOrSkipIssue(
+  env: NodeJS.ProcessEnv,
+  remediation = 'Run `./scripts/bump-docs-pointer.sh`.'
+): RunResult {
+  const result = spawnSync(
+    'bash',
+    ['-c', `source "${SCRIPT}"; open_or_skip_issue "$1"`, 'test-harness', remediation],
+    { encoding: 'utf8', env }
+  )
+  return { status: result.status ?? -1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
+}
+
+function baseEnv(overrides: NodeJS.ProcessEnv, fakeGhDir: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: `${fakeGhDir}:${process.env.PATH ?? ''}`,
+    GITHUB_REPOSITORY: 'smith-horn/skillsmith',
+    GITHUB_SHA: 'abc123def4567890abc123def4567890abc123d',
+    FAIL_LINE: 'FAIL [docs/internal]: R1: `deadbeef` was never pushed',
+    RULE: 'R1',
+    ...overrides,
+  }
+}
+
+function readLog(logFile: string): string[] {
+  try {
+    return readFileSync(logFile, 'utf8').split('\n').filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: open_or_skip_issue, via source + faked gh on PATH
+// ---------------------------------------------------------------------------
+
+describe('submodule-pointer-autorepair.sh — open_or_skip_issue (SMI-6580)', () => {
+  it('label create precedes issue create (the SMI-6580 root-cause ordering fix)', () => {
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+
+    const r = callOpenOrSkipIssue(
+      baseEnv(
+        {
+          SPA_TEST_GH_LOG: logFile,
+          SPA_TEST_GH_ISSUE_LIST_OUT: '',
+        },
+        fakeGhDir
+      )
+    )
+
+    expect(r.status).toBe(0)
+    const calls = readLog(logFile)
+    const labelIdx = calls.indexOf('label create')
+    const createIdx = calls.indexOf('issue create')
+    expect(labelIdx).toBeGreaterThanOrEqual(0)
+    expect(createIdx).toBeGreaterThanOrEqual(0)
+    expect(labelIdx).toBeLessThan(createIdx)
+  })
+
+  it('a failed issue create exits non-zero and names the real cause (SMI-6580b)', () => {
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+    const distinctiveCause =
+      "could not add label: 'submodule-pointer-regression' not found (HTTP 422: Validation Failed)"
+
+    const r = callOpenOrSkipIssue(
+      baseEnv(
+        {
+          SPA_TEST_GH_LOG: logFile,
+          SPA_TEST_GH_ISSUE_LIST_OUT: '',
+          SPA_TEST_GH_ISSUE_CREATE_EXIT: '1',
+          SPA_TEST_GH_ISSUE_CREATE_STDERR: distinctiveCause,
+        },
+        fakeGhDir
+      )
+    )
+
+    // The function's own return code IS the -c script's exit status (it is
+    // the last command run) -- this is the non-zero-exit half of the
+    // regression: before the fix, this returned 0 unconditionally.
+    expect(r.status).not.toBe(0)
+    expect(r.stdout).toContain('::error::')
+    expect(r.stdout).toContain(distinctiveCause)
+    // The old behavior discarded the cause into a generic ::warning::  --
+    // confirm that shape is gone, not just that ::error:: is present.
+    expect(r.stdout).not.toMatch(/::warning::gh issue create failed/)
+  })
+
+  it('a failed dedupe query does not silently proceed (SMI-6580d)', () => {
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+    const distinctiveCause = 'gh: API rate limit exceeded for installation ID 12345 (HTTP 403)'
+
+    const r = callOpenOrSkipIssue(
+      baseEnv(
+        {
+          SPA_TEST_GH_LOG: logFile,
+          SPA_TEST_GH_ISSUE_LIST_EXIT: '1',
+          SPA_TEST_GH_ISSUE_LIST_STDERR: distinctiveCause,
+        },
+        fakeGhDir
+      )
+    )
+
+    expect(r.status).not.toBe(0)
+    expect(r.stdout).toContain('::error::')
+    expect(r.stdout).toContain(distinctiveCause)
+    expect(r.stdout).toContain('dedupe query failed')
+
+    // The real proof that it didn't "silently proceed": neither the label
+    // nor the issue was ever created after the dedupe query blew up.
+    const calls = readLog(logFile)
+    expect(calls).not.toContain('label create')
+    expect(calls).not.toContain('issue create')
+  })
+
+  it('a SUCCESSFUL dedupe query that prints a stderr notice still alerts (SMI-6580d follow-up)', () => {
+    // Regression test for a defect introduced by SMI-6580d's own first fix.
+    // That fix captured the dedupe query as `$(gh issue list … 2>&1)`, which
+    // merges stderr into the captured value. Real `gh` writes advisory
+    // notices to stderr on successful calls, so on a run where NO issue
+    // existed the capture came back non-empty ("gh: A new release of gh is
+    // available") and the function read it as "already reported #<notice>"
+    // and skipped alerting — reintroducing the exact SMI-6580 silent miss
+    // the change was written to remove. stderr now goes to a file instead.
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+
+    const r = callOpenOrSkipIssue(
+      baseEnv(
+        {
+          SPA_TEST_GH_LOG: logFile,
+          // Query SUCCEEDS (exit 0) and finds nothing (empty stdout) — but
+          // is noisy on stderr, exactly as the real binary can be.
+          SPA_TEST_GH_ISSUE_LIST_OUT: '',
+          SPA_TEST_GH_ISSUE_LIST_STDERR_ON_SUCCESS:
+            'gh: A new release of gh is available: 2.40.0 → 2.41.0',
+        },
+        fakeGhDir
+      )
+    )
+
+    expect(r.status).toBe(0)
+    // The alert must actually be delivered. Before the fix this asserted
+    // false: no issue create happened at all.
+    const calls = readLog(logFile)
+    expect(calls).toContain('issue create')
+    // And it must not have been mistaken for an already-reported issue.
+    expect(r.stdout).not.toContain('already reported')
+  })
+
+  it('an existing issue for this commit is skipped without creating a duplicate', () => {
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+
+    const r = callOpenOrSkipIssue(
+      baseEnv(
+        {
+          SPA_TEST_GH_LOG: logFile,
+          SPA_TEST_GH_ISSUE_LIST_OUT: '4242',
+        },
+        fakeGhDir
+      )
+    )
+
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('already reported as issue #4242')
+    const calls = readLog(logFile)
+    expect(calls).not.toContain('label create')
+    expect(calls).not.toContain('issue create')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fixture plumbing for the two end-to-end (real subprocess, real git)
+// tests below -- mirrors check-submodule-pointer.test.ts's fixture shape,
+// since it's that script's own exit-code/FAIL-line contract being exercised.
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: makeFixtureEnv() }).trim()
+}
+
+function initRepo(dir: string, branch: string): void {
+  mkdirSync(dir, { recursive: true })
+  git(dir, 'init', '-q', '-b', branch)
+  git(dir, 'config', 'commit.gpgsign', 'false')
+}
+
+function commitFile(dir: string, relPath: string, content: string, message: string): string {
+  writeFileSync(join(dir, relPath), content)
+  git(dir, 'add', relPath)
+  git(dir, 'commit', '-q', '-m', message)
+  return git(dir, 'rev-parse', 'HEAD')
+}
+
+function commitGitlink(parentDir: string, sha: string, message: string): string {
+  git(parentDir, 'update-index', '--add', '--cacheinfo', `160000,${sha},docs/internal`)
+  git(parentDir, 'commit', '-q', '-m', message)
+  return git(parentDir, 'rev-parse', 'HEAD')
+}
+
+const createdRoots: string[] = []
+afterEach(() => {
+  while (createdRoots.length > 0) {
+    const dir = createdRoots.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function runAutorepair(cwd: string, env: NodeJS.ProcessEnv): RunResult {
+  const result = spawnSync('bash', [SCRIPT], { cwd, encoding: 'utf8', env })
+  return { status: result.status ?? -1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
+}
+
+describe('submodule-pointer-autorepair.sh — exit-code-2-vs-1 distinction (SMI-6580e)', () => {
+  it('a broken invocation (check-submodule-pointer.sh exit 2) fails loudly, never reaches gh', () => {
+    const root = makeFixtureTempDir('spa-exit2-fixture')
+    createdRoots.push(root)
+    initRepo(root, 'main')
+    writeFileSync(
+      join(root, '.gitmodules'),
+      '[submodule "docs/internal"]\n\tpath = docs/internal\n\turl = https://example.invalid/x.git\n'
+    )
+    git(root, 'add', '.gitmodules')
+    git(root, 'commit', '-q', '-m', 'init')
+    const head = git(root, 'rev-parse', 'HEAD')
+
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+
+    const r = runAutorepair(
+      root,
+      makeFixtureEnv({
+        PATH: `${fakeGhDir}:${process.env.PATH ?? ''}`,
+        GITHUB_SHA: FAKE_SHA_1, // unresolvable -> check-submodule-pointer.sh exits 2
+        BEFORE_SHA: head,
+        GITHUB_REPOSITORY: 'smith-horn/skillsmith',
+        SHADOW: '1',
+        MAIN_PUSH_PAT: '',
+        SPA_TEST_GH_LOG: logFile,
+      })
+    )
+
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('::error::')
+    expect(r.stdout).toContain('exited 2')
+    expect(r.stdout).toContain('broken invocation')
+    // Confirms this is NOT the pre-existing "nothing actionable" exit-0 path.
+    expect(r.stdout).not.toContain('nothing actionable')
+    expect(r.stdout).not.toContain('matched rule:')
+    // And confirms it never even reached the alerting path.
+    expect(readLog(logFile)).toHaveLength(0)
+  })
+
+  it('a real R1 content violation (exit 1) reaches the alert path end-to-end, distinct from exit 2', () => {
+    // Replays the real production defect shape: a genuine ADR-143 violation
+    // detected correctly, then alerted correctly (label before create,
+    // real gh calls observed in order) -- the exact path that silently
+    // failed before SMI-6580.
+    const root = makeFixtureTempDir('spa-r1-fixture')
+    createdRoots.push(root)
+    const subRemoteDir = join(root, 'sub-remote.git')
+    execFileSync('git', ['init', '-q', '--bare', '-b', 'main', subRemoteDir], {
+      env: makeFixtureEnv(),
+    })
+    const seedDir = join(root, 'seed')
+    initRepo(seedDir, 'main')
+    const base = commitFile(seedDir, 'f0.txt', 'base\n', 'base commit')
+    git(seedDir, 'remote', 'add', 'origin', subRemoteDir)
+    git(seedDir, 'push', '-q', 'origin', 'main')
+
+    const parentDir = join(root, 'parent')
+    initRepo(parentDir, 'main')
+    writeFileSync(
+      join(parentDir, '.gitmodules'),
+      `[submodule "docs/internal"]\n\tpath = docs/internal\n\turl = ${subRemoteDir}\n\tbranch = main\n`
+    )
+    git(parentDir, 'add', '.gitmodules')
+    git(parentDir, 'commit', '-q', '-m', 'init (no gitlink yet)')
+    const mountDir = join(parentDir, 'docs', 'internal')
+    execFileSync('git', ['clone', '-q', subRemoteDir, mountDir], { env: makeFixtureEnv() })
+
+    // c1 registers a resolvable pointer (the diff base / "before" state);
+    // the HEAD commit then bumps to a never-pushed SHA -- a real R1.
+    const c1 = commitGitlink(parentDir, base, 'base bump (target)')
+    const headSha = commitGitlink(parentDir, FAKE_SHA_1, 'S = never-pushed SHA')
+
+    const fakeGhDir = makeFakeGhDir()
+    const logFile = join(fakeGhDir, 'calls.log')
+
+    const r = runAutorepair(
+      parentDir,
+      makeFixtureEnv({
+        PATH: `${fakeGhDir}:${process.env.PATH ?? ''}`,
+        GITHUB_SHA: headSha,
+        BEFORE_SHA: c1,
+        GITHUB_REPOSITORY: 'smith-horn/skillsmith',
+        SHADOW: '1',
+        MAIN_PUSH_PAT: '',
+        SPA_TEST_GH_LOG: logFile,
+        SPA_TEST_GH_ISSUE_LIST_OUT: '',
+      })
+    )
+
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('matched rule: R1')
+    expect(r.stdout).not.toContain('exited 2')
+
+    const calls = readLog(logFile)
+    expect(calls).toEqual(['issue list', 'label create', 'issue create'])
+  })
+})

--- a/scripts/tests/submodule-pointer-autorepair.test.ts
+++ b/scripts/tests/submodule-pointer-autorepair.test.ts
@@ -219,10 +219,13 @@ describe('submodule-pointer-autorepair.sh — open_or_skip_issue (SMI-6580)', ()
     expect(r.stdout).toContain(distinctiveCause)
     expect(r.stdout).toContain('dedupe query failed')
 
-    // The real proof that it didn't "silently proceed": neither the label
-    // nor the issue was ever created after the dedupe query blew up.
+    // The real proof that it didn't "silently proceed": no issue was created
+    // after the dedupe query blew up. `label create` legitimately ran first —
+    // it is deliberately ordered ahead of the dedupe query, because that query
+    // is label-constrained and must not be the thing that discovers the label
+    // is missing.
     const calls = readLog(logFile)
-    expect(calls).not.toContain('label create')
+    expect(calls).toEqual(['label create', 'issue list'])
     expect(calls).not.toContain('issue create')
   })
 
@@ -277,8 +280,10 @@ describe('submodule-pointer-autorepair.sh — open_or_skip_issue (SMI-6580)', ()
 
     expect(r.status).toBe(0)
     expect(r.stdout).toContain('already reported as issue #4242')
+    // Stops at the dedupe hit — no duplicate issue. `label create` ran first
+    // by design (see the dedupe-failure test above for why).
     const calls = readLog(logFile)
-    expect(calls).not.toContain('label create')
+    expect(calls).toEqual(['label create', 'issue list'])
     expect(calls).not.toContain('issue create')
   })
 })
@@ -357,7 +362,7 @@ describe('submodule-pointer-autorepair.sh — exit-code-2-vs-1 distinction (SMI-
     expect(r.status).toBe(1)
     expect(r.stdout).toContain('::error::')
     expect(r.stdout).toContain('exited 2')
-    expect(r.stdout).toContain('broken invocation')
+    expect(r.stdout).toContain('invoked it wrongly')
     // Confirms this is NOT the pre-existing "nothing actionable" exit-0 path.
     expect(r.stdout).not.toContain('nothing actionable')
     expect(r.stdout).not.toContain('matched rule:')
@@ -419,7 +424,10 @@ describe('submodule-pointer-autorepair.sh — exit-code-2-vs-1 distinction (SMI-
     expect(r.stdout).toContain('matched rule: R1')
     expect(r.stdout).not.toContain('exited 2')
 
+    // Label first, THEN the label-constrained dedupe query, THEN the create.
+    // This exact ordering is the SMI-6580 fix: the label must exist before
+    // either of the two calls that reference it.
     const calls = readLog(logFile)
-    expect(calls).toEqual(['issue list', 'label create', 'issue create'])
+    expect(calls).toEqual(['label create', 'issue list', 'issue create'])
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:**

- `pointer-autorepair` now fails its job when it cannot deliver its alert, and names the cause in the log. It previously emitted a warning and reported success.
- The GitHub label that alert depends on now exists. It never had, so every alert this job has attempted since it shipped failed with `could not add label: 'submodule-pointer-regression' not found`.
- The pre-push submodule-pointer check now reports the correct verdict when run from a worktree. It previously reported `R1: was never pushed` for commits that are pushed and reachable, and because that check is a precondition, the false finding also suppressed the true one.

**Quality bar:** Plan-review (ADR-109 Stage 2) returned BLOCKED with 7 blockers, which cut the plan from four waves to two — two directions turned out to duplicate existing plans of record. Governance review then found one MAJOR issue in the first implementation, fixed here. Every behavioural claim in the diff was executed rather than reasoned about, and both regression tests were verified three ways: passing on the fix, **failing** on the reverted code, passing again on restore.

**Found along the way:**

- **SMI-6587 (Urgent)** — the required PR gate `pointer-check` fails *open*: when the `docs/internal` fetch fails, a real ancestry violation becomes a green required check. Demonstrated on identical trees (exit 1 with the submodule present, exit 0 without). It changes a required check's accept predicate, so it needs its own SPARC + plan-review under ADR-109 and is filed rather than fixed here.
- **SMI-6586** — two monitors name a GitHub label that nothing creates. This PR creates only the one it needs; the class, and the `audit:standards` check that would stop it recurring, belong to that issue.
- **SMI-6582** re-routed to SMI-6502 and **SMI-6581** to ADR-154, both of which already own those questions. The measured reasoning is preserved in the plan rather than deleted with the waves.

**Net result:** Both waves shipped. Three follow-ups tracked, one Urgent, none blocking this PR.

---

## Technical detail

### Wave 1 — `6686c3ab5`, SMI-6580

`open_or_skip_issue()` in `scripts/ci/submodule-pointer-autorepair.sh` had five paths that returned success on a failed alert:

| Line | Before | After |
|---|---|---|
| `:92-95` | `gh issue create … \|\| echo "::warning::"` | capture stderr, `::error::` with the real cause, return non-zero |
| `:77-79` | dedupe `gh issue list … \|\| echo ""` | query failure distinguished from "no existing issue" |
| `:61-65` | non-zero inner exit with no `FAIL` line → "nothing actionable" | exit 2 (broken invocation) distinguished from exit 1 (content verdict) |
| `:131`, `:149` | every path `exit 0` | status propagated |
| — | label assumed to exist | idempotent `gh label create`, plus a registry entry in `setup-github-labels.sh` |

Ordering is load-bearing: failing the step *without* creating the label first would leave the job permanently red while still opening no issue.

The script was restructured into `main()` behind a `BASH_SOURCE` guard so `open_or_skip_issue` can be unit-tested with a faked `gh` on `PATH`. It had zero test coverage; it now has 7 tests.

**One defect was introduced by this change and caught before commit.** The dedupe fix first captured `$(gh issue list … 2>&1)`, merging stderr into the value. `gh` writes advisory notices to stderr on *successful* calls, so a run where no issue existed came back non-empty and read as "already reported" — reintroducing the exact failure being removed. stderr now goes to a file.

### Wave 2 — `79b8e159b` + `1ccd0fb95`, SMI-6569

`git -C <dir>` does not override an absolute `GIT_DIR`: `-C` changes the working directory, but `GIT_DIR` still wins over repo discovery. Git exports an absolute `GIT_DIR` into hooks on a push from a **linked worktree**, which is this repo's default workspace.

```
GIT_DIR unset             -> git -C docs/internal cat-file -e <sha>^{commit} -> exit 0
GIT_DIR=<absolute>        -> same command                                    -> exit 128
GIT_DIR=".git" (RELATIVE) -> same command                                    -> exit 0
```

The effect is absolute-only; a relative `GIT_DIR` re-resolves against `-C`'s cwd. Scope is the whole helpers file, not the one line the symptom surfaced on — under contamination the fetch, the `origin/<branch>` rev-parse, and every `merge-base`/`rev-list`/`branch` comparison were also reading the outer repo. R1 fired first and masked them.

All 9 submodule-directed calls in `check-submodule-pointer.helpers.sh` route through a new `git_sub()`; the 2 in `submodule-pointer-autorepair.sh` route through a local `git_mount()`. Outer-repo calls are deliberately **not** wrapped — verified that `rev-parse --show-toplevel` and `ls-tree HEAD` return identical results with and without `GIT_DIR`, and that a bogus discovery var makes the script exit 2 with `not inside a git repository` rather than return a wrong verdict.

`1ccd0fb95` widens both wrappers from 2 vars to the 10 in `GIT_DISCOVERY_VARS` (`scripts/tests/_lib/git-fixture-env.ts`, SMI-4693), after governance confirmed `GIT_COMMON_DIR` and `GIT_OBJECT_DIRECTORY` redirect straight through a `GIT_DIR`-only unset. That list's last two entries, `GIT_CONFIG` and `XDG_CONFIG_HOME`, are deliberately not unset: they route config rather than discovery, and these wrappers run an authenticated `fetch` whose credentials come from `git config --global`. Measured that unsetting them would have been safe either way, so this is a scoping choice rather than a workaround.

### Testing

Both test files run on the host (`npx vitest run <file>`) — they spawn `bash` and need no container.

- `scripts/tests/submodule-pointer-autorepair.test.ts` — new, 7 tests.
- `scripts/tests/check-submodule-pointer.test.ts` — 23 tests, one new, asserting the invariant across `GIT_DIR`, `GIT_COMMON_DIR` and `GIT_OBJECT_DIRECTORY`.

The Wave 2 test asserts **stdout and exit-status equality** rather than a symptom name. Which symptom appears without the fix depends on whether the outer repo has an `origin` remote: production produces the fabricated `R1`, the fixture produces `R-FETCH` because the misdirected fetch fails outright. Asserting either name alone would let the test pass against the bug in one of the two environments.

### CI caveats

- No `workflow_dispatch` was added. `pointer-autorepair` fires only on push to `main`, so the plan's original acceptance test ("induce a failure on a scratch branch") was not executable; the binding acceptance is the unit tests, which do not need it.
- `shellcheck` is clean on all three shell files, but no CI job covers them — `ci.yml`'s shellcheck is scoped to `scripts/smoke-prod/*`.
- `SC2148` on `check-submodule-pointer.helpers.sh` is pre-existing and expected (sourced-only file, no shebang by design); verified against the committed baseline.
- The two `docs/internal` pointer commits carry the plan-review-amended implementation plan. The second is a re-bump: `docs/internal` main advanced mid-review, which is the SMI-6582 treadmill this PR's own plan documents, owned by SMI-6502.

### Plan

`docs/internal/implementation/smi-6580-6582-pointer-guard-integrity.md` (amended `55d0778`).
