### PR TITLE
feat(ci): SMI-6513 -- assert byte-identity across publish.yml's four verify blocks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1216,6 +1216,7 @@ jobs:
           # cannot be un-published, so this bonus bin-delegation check warns
           # loudly for a fix-forward rather than red-failing an irreversible
           # success.
+          # audit:verify-block-smoke-tail
           SMOKE_DIR="$(mktemp -d)"
           for attempt in 1 2 3; do
             if (cd "$SMOKE_DIR" && npx -y "skillsmith-cli@${VERSION}" --version) >/tmp/sk-smoke.out 2>&1; then

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -75,6 +75,11 @@ import {
 import { findGitCryptUnsetRemediations } from './audit-git-crypt-remediation-helpers.mjs'
 import { findAbsoluteSeparateGitDirWriters } from './audit-gitdir-writer-helpers.mjs'
 import { checkDockerEnvDefaultCoherence } from './audit-docker-env-coherence-helpers.mjs'
+import {
+  analyzeVerifyBlocks,
+  notEvaluated as notEvaluatedVerifyBlocks,
+  reportLines as verifyBlockReportLines,
+} from './lib/verify-block-identity.mjs'
 import { findMissingHuskyStubs } from './audit-husky-stub-coverage-helpers.mjs'
 import {
   listManifestHygieneTestFiles,
@@ -6179,6 +6184,65 @@ console.log(`\n${BOLD}Check 70: SKILLSMITH_DOCKER default coherence (SMI-6518)${
   } else {
     pass(
       `Check 70: docker-compose.yml and .env.schema agree on SKILLSMITH_DOCKER_CPUS (${dockerCoherence.compose.cpus}) and SKILLSMITH_DOCKER_MEM (${dockerCoherence.compose.mem}) defaults`
+    )
+  }
+}
+
+// Check 71: publish.yml verify-block byte identity (SMI-6513)
+//
+// .github/workflows/publish.yml carries four `Verify … on npm` blocks, one per
+// published package -- the same shell program modulo which package name and
+// manifest path it targets. Nothing else enforces that they stay the same
+// program: shellcheck passes on each block independently, and divergence
+// between two independently-valid shell blocks is not a lint category.
+// SMI-6493 shipped exactly that kind of divergence through a fully green
+// suite because coverage only ever exercised block 1.
+// scripts/lib/verify-block-identity.mjs is the pure analysis module (YAML
+// text in, a structured three-way verdict out); this call site is its only
+// caller in this audit.
+//
+// The verdict is THREE-WAY -- 'passed' / 'failed' / 'not_evaluated' -- and
+// `ok` is false for the latter two alike, so a read/parse failure can never
+// read as a clean pass. A bare `readFileSync` + `analyzeVerifyBlocks` call
+// here would throw on a missing/unreadable publish.yml and, per the Check 69
+// / Check 70 SMI-6575 precedent, an uncaught throw at any check in this file
+// kills every check after it plus the Summary block and the exit verdict --
+// so the read+analyze call is wrapped and a thrown error is converted into
+// `notEvaluated()` instead of propagating. `reportLines()` always renders the
+// compared/expected fraction in its headline, so a partial comparison (e.g.
+// the tail marker gone, dropping coverage to 3/4) can never look identical to
+// a full 4/4 pass.
+//
+// scripts/tests/verify-block-identity.test.ts is the executable twin of this
+// check -- same module, same invariant.
+console.log(`\n${BOLD}Check 71: publish.yml verify-block byte identity (SMI-6513)${RESET}`)
+{
+  const PUBLISH_YML_PATH = '.github/workflows/publish.yml'
+  let verifyBlockResult
+  try {
+    verifyBlockResult = analyzeVerifyBlocks(readFileSync(PUBLISH_YML_PATH, 'utf8'))
+  } catch (err) {
+    verifyBlockResult = notEvaluatedVerifyBlocks(`${err.code ?? 'read error'}: ${PUBLISH_YML_PATH}`)
+  }
+
+  const { ok, lines } = verifyBlockReportLines(verifyBlockResult)
+  const [headline, ...detailLines] = lines
+  const message = detailLines.length > 0 ? `${headline}\n${detailLines.join('\n')}` : headline
+
+  if (ok) {
+    pass(message)
+  } else if (verifyBlockResult.status === 'not_evaluated') {
+    fail(
+      message,
+      `Confirm ${PUBLISH_YML_PATH} exists and is readable from the repository root, then ` +
+        're-run -- a check that could not run is not the same as one that ran and found nothing.'
+    )
+  } else {
+    fail(
+      message,
+      `Reconcile the named block(s) above so all four \`Verify … on npm\` blocks in ` +
+        `${PUBLISH_YML_PATH} are the same program again -- see scripts/lib/verify-block-identity.mjs ` +
+        'for the exact invariant each VB-* finding code enforces.'
     )
   }
 }

--- a/scripts/lib/verify-block-identity.constants.mjs
+++ b/scripts/lib/verify-block-identity.constants.mjs
@@ -1,0 +1,206 @@
+/**
+ * Workflow-shaped constants for the `publish.yml` verify-block identity gate
+ * (SMI-6513). Split out of `verify-block-identity.mjs` to keep both files under
+ * this repo's 500-line policy (`scripts/file-length-policy.mjs`).
+ *
+ * The split is along a real boundary, not an arbitrary chop: everything here is
+ * *data about the workflow* — which blocks exist, how block 4 legitimately differs,
+ * what the tail currently is. Everything in the sibling file is the analysis engine
+ * and is independent of any particular workflow.
+ *
+ * That boundary matters for maintenance: **any edit to a value in this file
+ * requires a matching test case in `scripts/tests/verify-block-identity.test.ts`
+ * in the same PR** (CLAUDE.md § CI Health Requirements — source changes ship with
+ * their test updates). These are the values whose silent drift the gate exists to
+ * prevent, so they are the ones that must never move unobserved.
+ */
+
+/**
+ * The tail-boundary marker, used verbatim. Follows the established `# audit:<name>`
+ * convention in this repo (`# audit:carveout-pure-js`, `# audit:allow-continue-on-error`).
+ *
+ * It replaces an earlier design that split block 4 at the first `/^SMOKE_DIR=/`
+ * line. That anchor cannot match a guarded assignment
+ * (`if ! SMOKE_DIR="$(mktemp -d)"; then`), nor a `readonly` or `mktemp --directory`
+ * refactor — and the split fails *before* the tail digest is computed, so bumping
+ * the pinned digest could not repair it. An explicit marker states the conceptual
+ * boundary instead of encoding one transient implementation of it.
+ */
+export const TAIL_MARKER = '# audit:verify-block-smoke-tail'
+
+/** Substitution sentinels. A body already containing either is rejected. */
+export const PKG_SENTINEL = '__PKG__'
+export const MANIFEST_SENTINEL = '__MANIFEST__'
+
+/**
+ * Discovery predicate for a *candidate* verify step.
+ *
+ * Do not loosen this. The `pre-publish-check` job contains a step named
+ * `Verify dependencies`; a bare `/Verify/` matches FIVE steps, not four, and the
+ * "exactly these four" assertion then misfires on a wholly unrelated step.
+ * Requiring `on npm` correctly excludes it. The exact-identity registration below
+ * is the real defence — this predicate only decides what gets *offered* for
+ * registration — but the loosening is a live trap, named here so it is rejected
+ * deliberately rather than rediscovered.
+ */
+export const CANDIDATE_STEP_NAME = /^Verify\b.*\bon npm\b/
+
+/**
+ * The registered blocks. The identity is the PAIR `(jobId, stepName)`, not the step
+ * name alone: a verify step that moves between the genuinely distinct jobs
+ * `publish-cli` and `publish-skillsmith-cli` changes its predicates, dependencies,
+ * permissions and publish association while changing no digest at all.
+ *
+ * `class: 'scoped'` blocks must all share one digest (Stage 2). The single
+ * `class: 'reshaped'` block is compared via the forward rewrite in Stage 3.
+ *
+ * SMI-6498 adds an `@smith-horn/enterprise` verify block — that job has no verify
+ * block at all today, which is deliberately out of SMI-6513's scope. When SMI-6498
+ * adds one it must register its `(jobId, stepName)` pair here (as `scoped`, if it
+ * is byte-identical to the other three, which it should be) or E1's extra-name arm
+ * fires `VB-UNREGISTERED-VERIFY-STEP` and the build stays red. That coupling is
+ * deliberate: a new verify block nobody registered is exactly the drift this check
+ * exists to catch.
+ */
+export const REGISTRY = [
+  {
+    jobId: 'publish-core',
+    stepName: 'Verify core on npm',
+    pkg: '@skillsmith/core',
+    manifestPath: 'packages/core/package.json',
+    class: 'scoped',
+  },
+  {
+    jobId: 'publish-mcp-server',
+    stepName: 'Verify mcp-server on npm',
+    pkg: '@skillsmith/mcp-server',
+    manifestPath: 'packages/mcp-server/package.json',
+    class: 'scoped',
+  },
+  {
+    jobId: 'publish-cli',
+    stepName: 'Verify cli on npm',
+    pkg: '@skillsmith/cli',
+    manifestPath: 'packages/cli/package.json',
+    class: 'scoped',
+  },
+  {
+    jobId: 'publish-skillsmith-cli',
+    stepName: 'Verify skillsmith-cli on npm + smoke the wrapper',
+    pkg: 'skillsmith-cli',
+    manifestPath: 'packages/skillsmith-cli/package.json',
+    class: 'reshaped',
+  },
+]
+
+/** The canonical block Stage 3 rewrites forward into block 4's expected shape. */
+export const CANONICAL_STEP_NAME = 'Verify core on npm'
+
+/** The one `class: 'reshaped'` block. */
+export const RESHAPED_STEP_NAME = 'Verify skillsmith-cli on npm + smoke the wrapper'
+
+/**
+ * R2 — ASCII transliteration. A CLOSED, fixed table: each mapping is the one
+ * specific replacement block 4 uses. Deliberately not "strip all non-ASCII", which
+ * would let block 4 substitute anything at all for a glyph.
+ *
+ * These are exactly the three non-ASCII codepoints present in the normalized
+ * canonical block. A new glyph without a table entry fails `VB-NON-ASCII-UNMAPPED`
+ * rather than silently under-transliterating into a confusing digest mismatch.
+ */
+export const R2_TABLE = [
+  ['✓', 'OK'],
+  ['…', '...'],
+  ['—', '-'],
+]
+
+/**
+ * R3 — the control-flow reshape, as ONE exact multiline fragment.
+ *
+ * Not a script of ordered line edits: in the normalized canonical block the line
+ * `fi` occurs twice and `exit 0` occurs twice, so anchors like "the first `exit 0`"
+ * are ordinal and contextual rather than exact-unique, and replacing one shifts the
+ * other's position — two conforming implementations could legitimately transform
+ * different lines. A single whole-fragment substitution has no such ambiguity.
+ *
+ * The five differences this fragment encodes, for the reader only — they are NOT
+ * applied as separate edits: insert `LIVE=''` before the loop; `exit 0` → `break`
+ * inside the loop; wrap the final-probe region in `if [ "$LIVE" != "$VERSION" ]`;
+ * the final-probe `exit 0` → `LIVE="$VERSION"`; the inner closing `fi` → `else`,
+ * with two `fi` lines closing the nested structure. The preamble (`VERSION=…`,
+ * `VERIFY_MAX_ATTEMPTS=…`, `VERIFY_INTERVAL=…`) is outside the fragment and shared
+ * unchanged.
+ *
+ * Both fragments are in NORMALIZED form (comments stripped, lines trimmed, empty
+ * lines dropped, package/manifest substituted) and post-R2 ASCII. They were
+ * generated mechanically from the real `publish.yml`, not transcribed by hand.
+ */
+export const R3_SOURCE = [
+  'for attempt in $(seq 1 "$VERIFY_MAX_ATTEMPTS"); do',
+  'LIVE=$(npm view "__PKG__@${VERSION}" version --no-json --offline=false --prefer-offline=false --registry=https://registry.npmjs.org 2>/dev/null || echo \'\')',
+  'if [ "$LIVE" = "$VERSION" ]; then',
+  'echo "OK __PKG__@${VERSION} verified live on npm (attempt ${attempt})"',
+  'exit 0',
+  'fi',
+  'echo "... __PKG__@${VERSION} not yet visible (attempt ${attempt}/${VERIFY_MAX_ATTEMPTS}); waiting ${VERIFY_INTERVAL}s"',
+  'sleep "$VERIFY_INTERVAL"',
+  'done',
+  'echo "Final probe for __PKG__@${VERSION} - any npm output follows:"',
+  'FINAL=$(npm view "__PKG__@${VERSION}" version --no-json --offline=false --prefer-offline=false --registry=https://registry.npmjs.org) || true',
+  'if [ "$FINAL" = "$VERSION" ]; then',
+  'echo "OK __PKG__@${VERSION} verified live on npm (final probe)"',
+  'exit 0',
+  'fi',
+  'echo "Final probe stdout was: ${FINAL:-<empty>}"',
+  'echo "::error::__PKG__@${VERSION} is not live on npm after ${VERIFY_MAX_ATTEMPTS} attempts over $((VERIFY_MAX_ATTEMPTS * VERIFY_INTERVAL))s - failing the job."',
+  'exit 1',
+].join('\n')
+
+export const R3_REPLACEMENT = [
+  "LIVE=''",
+  'for attempt in $(seq 1 "$VERIFY_MAX_ATTEMPTS"); do',
+  'LIVE=$(npm view "__PKG__@${VERSION}" version --no-json --offline=false --prefer-offline=false --registry=https://registry.npmjs.org 2>/dev/null || echo \'\')',
+  'if [ "$LIVE" = "$VERSION" ]; then',
+  'echo "OK __PKG__@${VERSION} verified live on npm (attempt ${attempt})"',
+  'break',
+  'fi',
+  'echo "... __PKG__@${VERSION} not yet visible (attempt ${attempt}/${VERIFY_MAX_ATTEMPTS}); waiting ${VERIFY_INTERVAL}s"',
+  'sleep "$VERIFY_INTERVAL"',
+  'done',
+  'if [ "$LIVE" != "$VERSION" ]; then',
+  'echo "Final probe for __PKG__@${VERSION} - any npm output follows:"',
+  'FINAL=$(npm view "__PKG__@${VERSION}" version --no-json --offline=false --prefer-offline=false --registry=https://registry.npmjs.org) || true',
+  'if [ "$FINAL" = "$VERSION" ]; then',
+  'echo "OK __PKG__@${VERSION} verified live on npm (final probe)"',
+  'LIVE="$VERSION"',
+  'else',
+  'echo "Final probe stdout was: ${FINAL:-<empty>}"',
+  'echo "::error::__PKG__@${VERSION} is not live on npm after ${VERIFY_MAX_ATTEMPTS} attempts over $((VERIFY_MAX_ATTEMPTS * VERIFY_INTERVAL))s - failing the job."',
+  'exit 1',
+  'fi',
+  'fi',
+].join('\n')
+
+/**
+ * Pinned digest of `sha256(normalize(BLOCK4_TAIL))`.
+ *
+ * The smoke tail is the only region of the four blocks with no sibling to compare
+ * against, so a deliberate acknowledgement is the only available evidence that a
+ * change to it was intended. A legitimate tail edit bumps this constant in the same
+ * PR, adding a bump-log line below.
+ *
+ * This is CHANGE ACKNOWLEDGEMENT, not semantic proof of non-fatality. The tail's
+ * `SMOKE_DIR="$(mktemp -d)"` and `sleep 8` are unguarded, and GitHub Actions runs
+ * `run:` steps under `bash -e` (this workflow declares no `shell:` and no
+ * `defaults:`, so errexit is on while pipefail and nounset are not) — a failing
+ * `mktemp` therefore still kills the step. The textual guard alongside this digest
+ * claims only "no registry probe, no explicit `exit 1`". Making non-fatality a real
+ * invariant would need either a behavioural test executing the tail with failing
+ * stubs for every fallible external command, or a `publish.yml` change wrapping the
+ * smoke operation in an explicit guard; SMI-6513 deliberately does neither and
+ * names the cost instead.
+ *
+ * Bump log:
+ *   SMI-6513, 2026-09-12 — initial pin.
+ */
+export const PINNED_TAIL_DIGEST = '333b16ccc3a6558a1bd58386b8c0ed24b1ac88f6ecbd455d21ed34c6594566b5'

--- a/scripts/lib/verify-block-identity.messages.mjs
+++ b/scripts/lib/verify-block-identity.messages.mjs
@@ -40,6 +40,14 @@ export const MSG = {
     `"${actualJob}". Moving a verify step between jobs changes its predicates, dependencies, ` +
     'permissions and publish association while changing no digest at all.',
 
+  unsafeWhitespace: (kind, samples) =>
+    `normalization cannot safely handle this body: ${kind}. ` +
+    `Offending line(s): ${samples}. ` +
+    'Leading indentation and blank lines are stripped before comparison because they are ' +
+    'inert in shell -- but they are NOT inert here, so stripping them could make a block ' +
+    'that is broken at runtime compare equal to one that works. Fix the line rather than ' +
+    'relaxing this guard.',
+
   sentinelCollision: (pkgSentinel, manifestSentinel) =>
     `body already contains the literal ${pkgSentinel} or ${manifestSentinel}, which would ` +
     'defeat the substitution. Rename the offending token.',

--- a/scripts/lib/verify-block-identity.messages.mjs
+++ b/scripts/lib/verify-block-identity.messages.mjs
@@ -1,0 +1,112 @@
+/**
+ * Diagnostic prose for the `publish.yml` verify-block identity gate (SMI-6513).
+ *
+ * Separated from the engine deliberately: `findings[].code` is the stable,
+ * machine-readable identifier that tests assert on, so **this prose can be improved
+ * without touching a single test**. Keep it that way — if a test ever starts
+ * matching on message text, the prose has become an interface and stops being
+ * improvable.
+ *
+ * Every message should say what broke AND what to do about it. A named failure code
+ * with a specific remedy is the reason this check can ship blocking rather than
+ * warn-first; a mystery red would not be.
+ */
+
+import { TAIL_MARKER } from './verify-block-identity.constants.mjs'
+
+export const MSG = {
+  parseYaml: (detail) => `publish.yml is not parseable YAML: ${detail}`,
+
+  parseNoJobs: () => 'publish.yml parsed but has no `jobs:` mapping',
+
+  parseBadRun: (stepName) => `step "${stepName}" has an absent, non-string or empty \`run:\` body.`,
+
+  duplicateStep: (count, stepName, jobs) =>
+    `${count} steps share the name "${stepName}" (in job(s): ${jobs}). Step names must be ` +
+    'unique so each body is compared exactly once. Note the key set can still look correct ' +
+    'while a drifted body silently replaces the right one.',
+
+  unregistered: (stepName) =>
+    `step "${stepName}" matches the verify-step predicate but is not registered in REGISTRY ` +
+    '(scripts/lib/verify-block-identity.constants.mjs). Register its (jobId, stepName) pair, ' +
+    'or rename the step so it is not a verify block.',
+
+  missingStep: (stepName, jobId) =>
+    `registered step "${stepName}" was not found in job "${jobId}" (or anywhere in the ` +
+    'workflow).',
+
+  wrongJob: (stepName, expectedJob, actualJob) =>
+    `registered step "${stepName}" is expected in job "${expectedJob}" but was found in job ` +
+    `"${actualJob}". Moving a verify step between jobs changes its predicates, dependencies, ` +
+    'permissions and publish association while changing no digest at all.',
+
+  sentinelCollision: (pkgSentinel, manifestSentinel) =>
+    `body already contains the literal ${pkgSentinel} or ${manifestSentinel}, which would ` +
+    'defeat the substitution. Rename the offending token.',
+
+  zeroSubstitution: (pkg, pkgCount, manifestPath, manifestCount) =>
+    `registration does not describe this body: package "${pkg}" matched ${pkgCount} time(s) ` +
+    `and manifest path "${manifestPath}" matched ${manifestCount} time(s); both must be ` +
+    'non-zero.',
+
+  countDisagreement: (ref, other) =>
+    `substitution counts disagree: "${ref.name}" has pkg=${ref.pkg}/manifest=${ref.manifest} ` +
+    `but "${other.name}" has pkg=${other.pkg}/manifest=${other.manifest}.`,
+
+  scopedMismatch: (other, ref, diff) =>
+    `"${other.name}" (job ${other.job}) is not byte-identical to "${ref.name}" (job ` +
+    `${ref.job}) after normalization. These blocks are the same program modulo their ` +
+    'package; a difference is a bug, not a variant. Normalized difference:\n' +
+    diff,
+
+  nonAsciiUnmapped: (char, codePoint, index) =>
+    'after the R2 transliteration table, the canonical block still contains the non-ASCII ' +
+    `character ${JSON.stringify(char)} (U+${codePoint.toString(16).toUpperCase().padStart(4, '0')}) ` +
+    `at index ${index} of the normalized body. A new glyph entered the canonical block ` +
+    'without a table entry. Add the exact replacement block 4 uses to R2_TABLE ' +
+    '(scripts/lib/verify-block-identity.constants.mjs) — do not strip it.',
+
+  r3FragmentLost: (occurrences) =>
+    `the R3 source fragment occurs ${occurrences} time(s) in the transliterated canonical ` +
+    'block; exactly one is required. The canonical verify block changed shape, so the R3 ' +
+    'rewrite fragment no longer describes how block 4 differs from it. Re-derive R3 ' +
+    'deliberately; do not delete the fragment.',
+
+  block4Mismatch: (diff) =>
+    "block 4's verify head differs from the canonical block in a way the known rewrites (R2 " +
+    'transliteration, R3 control-flow reshape) do not account for. Either propagate the ' +
+    'change to the other three blocks, or — if block 4 really must differ — encode the ' +
+    'difference in R2_TABLE/R3_REPLACEMENT deliberately. Normalized difference:\n' +
+    diff,
+
+  tailContainsProbe: (probes) =>
+    `the smoke tail contains ${probes}. The tail is the bonus bin-delegation smoke check, ` +
+    'excised from the byte-identity comparison; it must not re-probe the registry or fail ' +
+    'the job explicitly. Registry verification belongs in the head, above the marker.',
+
+  tailDrift: (actual, pinned) =>
+    `the smoke tail's normalized digest is ${actual} but PINNED_TAIL_DIGEST is ${pinned}. ` +
+    'The tail has no sibling block to compare against, so a deliberate acknowledgement is ' +
+    'the only available evidence the change was intended. If this change is intended, update ' +
+    'PINNED_TAIL_DIGEST in scripts/lib/verify-block-identity.constants.mjs to the value ' +
+    'above and add a bump-log line naming the SMI and date — in this same PR, with a ' +
+    'matching test case.',
+
+  coverageShortfall: (expected, actual) =>
+    `expected to compare ${expected} verify block(s) but actually compared ${actual}. The ` +
+    'missing block(s) fell out before their digest assertion ran — see the other findings ' +
+    'for why. A block that could not be compared is never counted as identical.',
+
+  notEvaluated: (reason) => `the verify-block identity check could not be evaluated: ${reason}`,
+
+  markerMissing: () =>
+    `block 4's smoke-tail marker \`${TAIL_MARKER}\` is missing. It marks the boundary ` +
+    'between the verify head (compared byte-for-byte against the canonical block) and the ' +
+    'non-fatal smoke tail (pinned by digest). Restore it immediately before the smoke tail; ' +
+    'do not delete it to silence this.',
+
+  markerDuplicate: (count) =>
+    `block 4 contains ${count} smoke-tail markers (\`${TAIL_MARKER}\`); exactly one is ` +
+    'required. An ambiguous boundary must never resolve silently to the first match. Delete ' +
+    'the extra marker(s), keeping the one immediately before the smoke tail.',
+}

--- a/scripts/lib/verify-block-identity.mjs
+++ b/scripts/lib/verify-block-identity.mjs
@@ -144,13 +144,65 @@ export function normalize(run, pkg, manifestPath) {
   const afterManifest = countedReplace(decommented, manifestPath, MANIFEST_SENTINEL)
   const afterPkg = countedReplace(afterManifest.text, pkg, PKG_SENTINEL)
 
+  // SMI-6513 cross-family review (GPT-5.6-Sol, PR 2825). Trimming below is
+  // deliberate and stays -- leading indentation and blank lines are inert in
+  // shell, and tolerating cosmetic reformatting between blocks is a reviewed
+  // decision (positive cases P-2 and P-3). But that tolerance is only sound
+  // while the stripped whitespace really is inert, and there are two shapes
+  // where it is not. Both are rejected here rather than normalized away.
+  //
+  // (a) A line ending in a backslash followed by whitespace. Measured under
+  //     the workflow's real `bash -e` semantics:
+  //
+  //       printf "<%s>" foo \<newline>bar   -> <foo> <bar>, exit 0
+  //       printf "<%s>" foo \ <newline>bar  -> <foo> < >, `bar: command not
+  //                                             found`, exit 127
+  //
+  //     The two differ only in one trailing space, and `.trim()` erases that
+  //     difference -- so a verify block broken at runtime would have compared
+  //     byte-identical to a working one. That is precisely the class of defect
+  //     this checker exists to catch, so it must never be silently absorbed.
+  //
+  // (b) A heredoc opener. Inside a heredoc, indentation and blank lines are
+  //     payload, not formatting, so trimming would corrupt the comparison.
+  //     `<<-` strips leading TABS only, never spaces, so even that form is not
+  //     safe to trim.
+  //
+  // Neither shape exists in the workflow today (measured: zero occurrences of
+  // each across the whole file), so this guard costs nothing now. It exists so
+  // that whoever introduces one gets a failure naming the reason instead of a
+  // check that quietly stops detecting drift.
+  const unsafeBackslash = []
+  const unsafeHeredoc = []
+  for (const [i, line] of afterPkg.text.split('\n').entries()) {
+    if (/\\[ \t]+$/.test(line)) unsafeBackslash.push(`${i + 1}: ${JSON.stringify(line)}`)
+    if (/<<-?\s*['\"]?\w/.test(line)) unsafeHeredoc.push(`${i + 1}: ${JSON.stringify(line.trim())}`)
+  }
+  const unsafe = unsafeBackslash.length
+    ? {
+        kind: 'a line ends in a backslash followed by whitespace, which does NOT continue the line',
+        samples: unsafeBackslash.slice(0, 3).join('; '),
+      }
+    : unsafeHeredoc.length
+      ? {
+          kind: 'a heredoc is present, whose payload indentation and blank lines are significant',
+          samples: unsafeHeredoc.slice(0, 3).join('; '),
+        }
+      : null
+
   const text = afterPkg.text
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
     .join('\n')
 
-  return { text, sentinelCollision, manifestCount: afterManifest.count, pkgCount: afterPkg.count }
+  return {
+    text,
+    sentinelCollision,
+    unsafe,
+    manifestCount: afterManifest.count,
+    pkgCount: afterPkg.count,
+  }
 }
 
 /**
@@ -341,6 +393,11 @@ export function analyzeVerifyBlocks(yamlText) {
     }
 
     const normalized = normalize(headSource, entry.pkg, entry.manifestPath)
+    if (normalized.unsafe) {
+      const msg = MSG.unsafeWhitespace(normalized.unsafe.kind, normalized.unsafe.samples)
+      add('VB-UNSAFE-WHITESPACE', entry.jobId, entry.stepName, msg)
+      continue
+    }
     if (normalized.sentinelCollision) {
       const msg = MSG.sentinelCollision(PKG_SENTINEL, MANIFEST_SENTINEL)
       add('VB-SENTINEL-COLLISION', entry.jobId, entry.stepName, msg)
@@ -452,6 +509,11 @@ export function analyzeVerifyBlocks(yamlText) {
   // mentioning `npm view` does not fire it.
   if (reshaped) {
     const tailNorm = normalize(reshaped.tailSource, reshaped.entry.pkg, reshaped.entry.manifestPath)
+    if (tailNorm.unsafe) {
+      const msg = MSG.unsafeWhitespace(tailNorm.unsafe.kind, tailNorm.unsafe.samples)
+      add('VB-UNSAFE-WHITESPACE', reshaped.entry.jobId, reshaped.entry.stepName, msg)
+      return finish()
+    }
     const probes = []
     if (tailNorm.text.includes('npm view')) probes.push('`npm view`')
     if (tailNorm.text.includes('exit 1')) probes.push('a literal `exit 1`')

--- a/scripts/lib/verify-block-identity.mjs
+++ b/scripts/lib/verify-block-identity.mjs
@@ -1,0 +1,500 @@
+/**
+ * Byte-identity gate for `.github/workflows/publish.yml`'s four `Verify … on npm`
+ * blocks (SMI-6513). The four blocks are the same program modulo the package they
+ * target; nothing else enforces that, because shellcheck passes on each block
+ * independently and divergence between valid shell blocks is not a lint category.
+ *
+ * Keep this module pure: YAML **text** in, structured verdict out — no filesystem
+ * access, no `process.exit`, no console output. That seam is what makes the negative
+ * tests possible, and its absence is why the original bug survived a green suite. The
+ * CI-blocking caller lives in `scripts/audit-standards.mjs`.
+ *
+ * **Address blocks by parsing the YAML and keying on `(jobId, stepName)` — never by
+ * line number, range or offset.** Line-range addressing is what failed during
+ * SMI-6493's own review; a gate built on it inherits the failure it exists to prevent.
+ *
+ * The verdict is THREE-WAY: `passed`, `failed`, `not_evaluated`. Never collapse the
+ * third into the first — a check that self-skips to a pass reads as coverage while
+ * guarding nothing. `comparedBlocks` is reported against `expectedBlocks` for the same
+ * reason: a dropped block must never leave the denominator.
+ *
+ * Siblings: `.constants.mjs` (workflow data), `.messages.mjs` (prose). Needs `js-yaml`
+ * and `node:crypto` only — no native modules, since this runs on the host runner in
+ * CI's `quality-checks` job rather than in Docker.
+ */
+
+import crypto from 'node:crypto'
+import { createRequire } from 'node:module'
+
+import {
+  CANDIDATE_STEP_NAME,
+  CANONICAL_STEP_NAME,
+  MANIFEST_SENTINEL,
+  PINNED_TAIL_DIGEST,
+  PKG_SENTINEL,
+  R2_TABLE,
+  R3_REPLACEMENT,
+  R3_SOURCE,
+  REGISTRY,
+  RESHAPED_STEP_NAME,
+  TAIL_MARKER,
+} from './verify-block-identity.constants.mjs'
+import { MSG } from './verify-block-identity.messages.mjs'
+
+const require = createRequire(import.meta.url)
+const yaml = require('js-yaml')
+
+export { REGISTRY, TAIL_MARKER } from './verify-block-identity.constants.mjs'
+
+const sha256 = (s) => crypto.createHash('sha256').update(s, 'utf8').digest('hex')
+const keyOf = (jobId, stepName) => `${jobId} :: ${stepName}`
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Global literal replace that also reports how many times it matched. */
+function countedReplace(text, needle, replacement) {
+  let count = 0
+  const out = text.replace(new RegExp(escapeRegExp(needle), 'g'), () => {
+    count += 1
+    return replacement
+  })
+  return { text: out, count }
+}
+
+/**
+ * Split a block-4 `run` body at the tail marker.
+ *
+ * **Call this FIRST, against the raw `run` string, before `normalize()` touches
+ * anything.** The order is load-bearing, not stylistic: `normalize()` strips
+ * whole-line comments and the marker IS a whole-line comment, so looking for it after
+ * normalization finds zero occurrences and destroys the boundary silently. Splitting
+ * first means no later stage can reorder its way into destroying it — by then the two
+ * regions already exist as separate strings. Test T-ORDER-1 locks this.
+ *
+ * A line is the marker iff its TRIMMED form equals `TAIL_MARKER` exactly:
+ * indentation-insensitive, but a trailing comment on a statement is not a marker,
+ * which keeps the boundary off a statement that might later move.
+ *
+ * @param {string} rawRun raw `run` text, comments intact
+ * @returns {{ok: true, head: string, tail: string}
+ *          | {ok: false, code: string, count: number, message: string}}
+ */
+export function splitAtTailMarker(rawRun) {
+  const lines = String(rawRun).split('\n')
+  const at = []
+  lines.forEach((line, i) => {
+    if (line.trim() === TAIL_MARKER) at.push(i)
+  })
+
+  if (at.length === 0) {
+    return { ok: false, code: 'VB-TAIL-MARKER-MISSING', count: 0, message: MSG.markerMissing() }
+  }
+  if (at.length > 1) {
+    return {
+      ok: false,
+      code: 'VB-TAIL-MARKER-DUPLICATE',
+      count: at.length,
+      message: MSG.markerDuplicate(at.length),
+    }
+  }
+  return {
+    ok: true,
+    head: lines.slice(0, at[0]).join('\n'),
+    tail: lines.slice(at[0] + 1).join('\n'),
+  }
+}
+
+/**
+ * Normalize a shell body to the form digests are taken over. **Do not reorder these
+ * steps** — two are load-bearing and both failure modes are silent:
+ *
+ *   1. Drop whole-line comments. Do NOT strip trailing/inline `#`: it appears inside
+ *      shell parameter expansions (`${VAR#prefix}`) and URL fragments. This must
+ *      precede step 3, so substitution counts describe the program, not its prose —
+ *      otherwise a comment reword trips the count-agreement guard.
+ *   2. Sentinel collision guard (the caller acts on `.sentinelCollision`).
+ *   3. Substitute the MANIFEST PATH FIRST, then the package name. Reversing this is a
+ *      real bug, not a style choice: `skillsmith-cli` is a substring of its own
+ *      manifest path, so package-first yields `packages/__PKG__/package.json` for
+ *      block 4 against `__MANIFEST__` for blocks 1-3 — a permanent digest mismatch
+ *      that looks like real drift and is not.
+ *   4-6. Trim each line, drop empty lines, join with `\n`.
+ *
+ * The invariant: two blocks are "the same program" iff they are equal modulo every
+ * literal occurrence of their registered package name and manifest path. This
+ * knowingly accepts a masking risk — a package name inside an unrelated identifier is
+ * substituted too (pinned by test N-20) — because the closed-set alternative would
+ * need updating on every legitimate edit, reintroducing the hand-maintained coupling
+ * this check exists to remove. Tolerated by design (must PASS): re-indentation, blank
+ * lines, comment rewording, trailing whitespace. NOT caught by design: a comment that
+ * has drifted out of sync with the code it describes — this is a byte-identity gate,
+ * not a comment-accuracy gate, and nothing else covers that here. A named open gap.
+ */
+export function normalize(run, pkg, manifestPath) {
+  const decommented = String(run)
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('#'))
+    .join('\n')
+
+  const sentinelCollision =
+    decommented.includes(PKG_SENTINEL) || decommented.includes(MANIFEST_SENTINEL)
+
+  const afterManifest = countedReplace(decommented, manifestPath, MANIFEST_SENTINEL)
+  const afterPkg = countedReplace(afterManifest.text, pkg, PKG_SENTINEL)
+
+  const text = afterPkg.text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join('\n')
+
+  return { text, sentinelCollision, manifestCount: afterManifest.count, pkgCount: afterPkg.count }
+}
+
+/**
+ * First character that is not tab, newline, or printable ASCII. A scan, not a regex,
+ * so the diagnostic can name the codepoint and position — and so no control character
+ * lands in a regex literal, which `no-control-regex` would flag.
+ */
+function findNonAscii(text) {
+  for (let i = 0; i < text.length; i += 1) {
+    const cp = text.codePointAt(i)
+    if (cp === 0x09 || cp === 0x0a) continue
+    if (cp >= 0x20 && cp <= 0x7e) continue
+    return { index: i, codePoint: cp, char: String.fromCodePoint(cp) }
+  }
+  return null
+}
+
+/**
+ * Compact diff: trim the common prefix/suffix, show the differing middle. Exported so
+ * its identical-lines fallback and output cap can be tested — neither is reachable via
+ * `analyzeVerifyBlocks`, where differing digests always differ by at least one line.
+ */
+export function briefDiff(aText, bText, aLabel, bLabel, maxLines = 40) {
+  const a = aText.split('\n')
+  const b = bText.split('\n')
+  let p = 0
+  while (p < a.length && p < b.length && a[p] === b[p]) p += 1
+  let s = 0
+  while (s < a.length - p && s < b.length - p && a[a.length - 1 - s] === b[b.length - 1 - s]) s += 1
+  const out = []
+  for (const line of a.slice(p, a.length - s)) out.push(`    - [${aLabel}] ${line}`)
+  for (const line of b.slice(p, b.length - s)) out.push(`    + [${bLabel}] ${line}`)
+  if (out.length === 0) {
+    return '    (no line-level difference — check line endings or trailing whitespace)'
+  }
+  if (out.length > maxLines) {
+    const extra = `    … ${out.length - maxLines} further differing line(s) not shown`
+    return out.slice(0, maxLines).concat(extra).join('\n')
+  }
+  return out.join('\n')
+}
+
+/**
+ * Verdict for when the check could not be evaluated at all (the caller could not read
+ * `publish.yml`, say), so "I checked and it was fine" and "I could not check" stay
+ * DIFFERENT results. `ok: false` — a check that could not run never reports success.
+ */
+export function notEvaluated(reason) {
+  return {
+    status: 'not_evaluated',
+    ok: false,
+    notEvaluatedReason: reason,
+    expectedBlocks: REGISTRY.length,
+    comparedBlocks: 0,
+    findings: [
+      { code: 'VB-NOT-EVALUATED', job: null, step: null, message: MSG.notEvaluated(reason) },
+    ],
+  }
+}
+
+/**
+ * Analyze `publish.yml`'s four verify blocks.
+ *
+ * `comparedBlocks` counts registered blocks that actually reached and completed a
+ * digest assertion. Any disagreement with `expectedBlocks` is itself a finding
+ * (`VB-COVERAGE-SHORTFALL`) — a block that fails to parse must never be silently
+ * dropped from the denominator, which would let the check report "all identical" after
+ * comparing three of four.
+ *
+ * @param {string} yamlText raw contents of `.github/workflows/publish.yml`
+ * @returns {{
+ *   status: 'passed' | 'failed',
+ *   ok: boolean,
+ *   expectedBlocks: number,
+ *   comparedBlocks: number,
+ *   notEvaluatedReason: null,
+ *   findings: Array<{code: string, job: string|null, step: string|null, message: string}>
+ * }}
+ */
+export function analyzeVerifyBlocks(yamlText) {
+  const findings = []
+  /** @type {Set<string>} registered blocks that completed a digest assertion */
+  const compared = new Set()
+
+  const add = (code, job, step, message) => findings.push({ code, job, step, message })
+
+  const finish = () => {
+    if (compared.size !== REGISTRY.length) {
+      const msg = MSG.coverageShortfall(REGISTRY.length, compared.size)
+      add('VB-COVERAGE-SHORTFALL', null, null, msg)
+    }
+    const ok = findings.length === 0
+    return {
+      status: ok ? 'passed' : 'failed',
+      ok,
+      expectedBlocks: REGISTRY.length,
+      comparedBlocks: compared.size,
+      notEvaluatedReason: null,
+      findings,
+    }
+  }
+
+  // --- Stage 0: extraction -------------------------------------------------
+  let doc
+  try {
+    doc = yaml.load(yamlText)
+  } catch (err) {
+    add('VB-PARSE-ERROR', null, null, MSG.parseYaml(err.message))
+    return finish()
+  }
+  if (!doc || typeof doc !== 'object' || !doc.jobs || typeof doc.jobs !== 'object') {
+    add('VB-PARSE-ERROR', null, null, MSG.parseNoJobs())
+    return finish()
+  }
+
+  // Collect candidates as a LIST, never a `name -> {…}` map: in a map a later entry
+  // overwrites an earlier one, so the key set can still equal the expected four while
+  // one body is never compared — and the value retained is the drifted one.
+  const candidates = []
+  for (const [jobId, job] of Object.entries(doc.jobs)) {
+    const steps = job && Array.isArray(job.steps) ? job.steps : []
+    for (const step of steps) {
+      if (step && typeof step.name === 'string' && CANDIDATE_STEP_NAME.test(step.name)) {
+        candidates.push({ jobId, stepName: step.name, run: step.run })
+      }
+    }
+  }
+
+  // E0 — no duplicate step names, rejected BEFORE any map is keyed on name alone.
+  const byName = new Map()
+  for (const c of candidates) {
+    if (!byName.has(c.stepName)) byName.set(c.stepName, [])
+    byName.get(c.stepName).push(c)
+  }
+  const duplicatedNames = new Set()
+  for (const [stepName, group] of byName) {
+    if (group.length > 1) {
+      duplicatedNames.add(stepName)
+      const jobs = group.map((g) => g.jobId).join(', ')
+      add('VB-DUPLICATE-STEP', jobs, stepName, MSG.duplicateStep(group.length, stepName, jobs))
+    }
+  }
+
+  // E1 — the registered set matches exactly.
+  const registeredNames = new Set(REGISTRY.map((r) => r.stepName))
+  for (const [stepName, group] of byName) {
+    if (!registeredNames.has(stepName)) {
+      add('VB-UNREGISTERED-VERIFY-STEP', group[0].jobId, stepName, MSG.unregistered(stepName))
+    }
+  }
+
+  /** @type {Map<string, {entry: object, normalized: object, tailSource: string|null}>} */
+  const usable = new Map()
+
+  for (const entry of REGISTRY) {
+    const group = byName.get(entry.stepName)
+    if (!group || group.length === 0) {
+      const msg = MSG.missingStep(entry.stepName, entry.jobId)
+      add('VB-MISSING-STEP', entry.jobId, entry.stepName, msg)
+      continue
+    }
+    if (duplicatedNames.has(entry.stepName)) continue // already reported; body is ambiguous
+
+    const found = group[0]
+    if (found.jobId !== entry.jobId) {
+      const msg = MSG.wrongJob(entry.stepName, entry.jobId, found.jobId)
+      add('VB-WRONG-JOB', found.jobId, entry.stepName, msg)
+      continue
+    }
+
+    // E2 — every `run` is a non-empty string.
+    if (typeof found.run !== 'string' || found.run.trim().length === 0) {
+      add('VB-PARSE-ERROR', entry.jobId, entry.stepName, MSG.parseBadRun(entry.stepName))
+      continue
+    }
+
+    // Block 4: split at the marker FIRST, on the RAW body. See splitAtTailMarker().
+    let headSource = found.run
+    let tailSource = null
+    if (entry.class === 'reshaped') {
+      const split = splitAtTailMarker(found.run)
+      if (!split.ok) {
+        add(split.code, entry.jobId, entry.stepName, split.message)
+        continue
+      }
+      headSource = split.head
+      tailSource = split.tail
+    }
+
+    const normalized = normalize(headSource, entry.pkg, entry.manifestPath)
+    if (normalized.sentinelCollision) {
+      const msg = MSG.sentinelCollision(PKG_SENTINEL, MANIFEST_SENTINEL)
+      add('VB-SENTINEL-COLLISION', entry.jobId, entry.stepName, msg)
+      continue
+    }
+    if (normalized.manifestCount === 0 || normalized.pkgCount === 0) {
+      const msg = MSG.zeroSubstitution(
+        entry.pkg,
+        normalized.pkgCount,
+        entry.manifestPath,
+        normalized.manifestCount
+      )
+      add('VB-SUBSTITUTION-COUNT', entry.jobId, entry.stepName, msg)
+    }
+    usable.set(entry.stepName, { entry, normalized, tailSource })
+  }
+
+  // Cross-block substitution-count agreement. Comment-insensitive by construction,
+  // since comments are stripped before substitution.
+  const shape = (u) => ({
+    name: u.entry.stepName,
+    pkg: u.normalized.pkgCount,
+    manifest: u.normalized.manifestCount,
+  })
+  const counted = [...usable.values()]
+  if (counted.length > 1) {
+    const ref = counted[0]
+    for (const other of counted.slice(1)) {
+      if (
+        other.normalized.pkgCount !== ref.normalized.pkgCount ||
+        other.normalized.manifestCount !== ref.normalized.manifestCount
+      ) {
+        const msg = MSG.countDisagreement(shape(ref), shape(other))
+        add('VB-SUBSTITUTION-COUNT', other.entry.jobId, other.entry.stepName, msg)
+      }
+    }
+  }
+
+  // --- Stage 2: the scoped blocks share one digest -------------------------
+  // Agreement-based, never pinned: a legitimate fix applied to all of them passes with
+  // no baseline bump, which is the entire point. Pinning would make every real fix a
+  // two-step ritual and train reflexive bumping — how a baseline stops being evidence.
+  const scoped = REGISTRY.filter((r) => r.class === 'scoped')
+    .map((r) => usable.get(r.stepName))
+    .filter(Boolean)
+
+  if (scoped.length >= 2) {
+    const ref = scoped[0]
+    const refDigest = sha256(ref.normalized.text)
+    compared.add(keyOf(ref.entry.jobId, ref.entry.stepName))
+    for (const other of scoped.slice(1)) {
+      compared.add(keyOf(other.entry.jobId, other.entry.stepName))
+      if (sha256(other.normalized.text) !== refDigest) {
+        const diff = briefDiff(
+          ref.normalized.text,
+          other.normalized.text,
+          ref.entry.stepName,
+          other.entry.stepName
+        )
+        const msg = MSG.scopedMismatch(
+          { name: other.entry.stepName, job: other.entry.jobId },
+          { name: ref.entry.stepName, job: ref.entry.jobId },
+          diff
+        )
+        add('VB-SCOPED-DIGEST-MISMATCH', other.entry.jobId, other.entry.stepName, msg)
+      }
+    }
+  }
+
+  // --- Stage 3: block 4 differs ONLY in the known ways ---------------------
+  // A forward rewrite (canonical -> block 4's expected shape), then one exact digest
+  // equality. "Skip block 4" would be worthless — it could gain ANY difference and
+  // nothing would notice, precisely the state that let the SMI-6493 bug sit in it.
+  // Forward, not backward: a reverse parser that failed to recognise a shape would
+  // degrade toward "skip".
+  const canon = usable.get(CANONICAL_STEP_NAME)
+  const reshaped = usable.get(RESHAPED_STEP_NAME)
+
+  if (canon && reshaped) {
+    let canonAscii = canon.normalized.text
+    for (const [from, to] of R2_TABLE) canonAscii = canonAscii.split(from).join(to)
+
+    const stray = findNonAscii(canonAscii)
+    if (stray) {
+      const msg = MSG.nonAsciiUnmapped(stray.char, stray.codePoint, stray.index)
+      add('VB-NON-ASCII-UNMAPPED', canon.entry.jobId, canon.entry.stepName, msg)
+    } else {
+      // R3 — one exact whole-fragment substitution. Replacement passed as a FUNCTION
+      // so `$&` / `$'` / `$n` in the fragment are not read as replacement patterns.
+      const occurrences = canonAscii.split(R3_SOURCE).length - 1
+      if (occurrences !== 1) {
+        const msg = MSG.r3FragmentLost(occurrences)
+        add('VB-R3-FRAGMENT-LOST', canon.entry.jobId, canon.entry.stepName, msg)
+      } else {
+        const expectedHead = canonAscii.replace(R3_SOURCE, () => R3_REPLACEMENT)
+        compared.add(keyOf(reshaped.entry.jobId, reshaped.entry.stepName))
+        if (sha256(expectedHead) !== sha256(reshaped.normalized.text)) {
+          const diff = briefDiff(expectedHead, reshaped.normalized.text, 'expected', 'actual')
+          const msg = MSG.block4Mismatch(diff)
+          add('VB-BLOCK4-MISMATCH', reshaped.entry.jobId, reshaped.entry.stepName, msg)
+        }
+      }
+    }
+  }
+
+  // R1 — the excised smoke tail, checked independently of Stage 3: its guards do not
+  // depend on the canonical block, so a missing canonical block must not silently take
+  // them down too. The probe guard runs on the NORMALIZED tail, so a comment merely
+  // mentioning `npm view` does not fire it.
+  if (reshaped) {
+    const tailNorm = normalize(reshaped.tailSource, reshaped.entry.pkg, reshaped.entry.manifestPath)
+    const probes = []
+    if (tailNorm.text.includes('npm view')) probes.push('`npm view`')
+    if (tailNorm.text.includes('exit 1')) probes.push('a literal `exit 1`')
+    if (probes.length > 0) {
+      const msg = MSG.tailContainsProbe(probes.join(' and '))
+      add('VB-TAIL-CONTAINS-PROBE', reshaped.entry.jobId, reshaped.entry.stepName, msg)
+    }
+    const tailDigest = sha256(tailNorm.text)
+    if (tailDigest !== PINNED_TAIL_DIGEST) {
+      const msg = MSG.tailDrift(tailDigest, PINNED_TAIL_DIGEST)
+      add('VB-BLOCK4-TAIL-DRIFT', reshaped.entry.jobId, reshaped.entry.stepName, msg)
+    }
+  }
+
+  return finish()
+}
+
+/**
+ * Render a verdict as report lines for an audit caller. Renders all THREE outcomes
+ * distinctly so a caller cannot collapse "could not check" into "checked and clean",
+ * and every headline carries the coverage fraction so a scope-blind clean run does
+ * not read identically to a real one.
+ *
+ * @param {ReturnType<typeof analyzeVerifyBlocks> | ReturnType<typeof notEvaluated>} result
+ * @returns {{status: string, ok: boolean, lines: string[]}}
+ */
+export function reportLines(result) {
+  const coverage = `${result.comparedBlocks}/${result.expectedBlocks} verify block(s) compared`
+  const lines = []
+
+  if (result.status === 'not_evaluated') {
+    lines.push(`publish.yml verify-block identity: NOT EVALUATED (${coverage})`)
+    lines.push(`  reason: ${result.notEvaluatedReason}`)
+    lines.push('  This is not a pass — the invariant was not checked.')
+  } else if (result.status === 'passed') {
+    lines.push(`publish.yml verify-block identity: PASSED (${coverage})`)
+  } else {
+    lines.push(`publish.yml verify-block identity: FAILED (${coverage})`)
+  }
+
+  for (const f of result.findings) {
+    const where = f.job || f.step ? ` [${f.job ?? '?'} :: ${f.step ?? '?'}]` : ''
+    lines.push(`  ${f.code}${where}: ${f.message}`)
+  }
+  return { status: result.status, ok: result.ok, lines }
+}

--- a/scripts/tests/verify-block-identity.test.ts
+++ b/scripts/tests/verify-block-identity.test.ts
@@ -390,6 +390,38 @@ describe('negative cases: tail region', () => {
     expect(codesOf(analyzeVerifyBlocks(mutated))).toContain('VB-TAIL-CONTAINS-PROBE')
   })
 
+  // N-21/N-22/N-23: SMI-6513 cross-family review (GPT-5.6-Sol, PR 2825).
+  // `normalize()` trims leading indentation and drops blank lines, which is a
+  // reviewed decision (see P-2/P-3) and correct while the stripped whitespace
+  // is inert in shell. These cases pin the two shapes where it is NOT inert,
+  // and which are therefore rejected rather than normalized away.
+  it('N-21: a line ending in backslash + whitespace is rejected, not trimmed', () => {
+    const mutated = mutateStepBody(REAL_YAML, CORE.job, CORE.step, (b) =>
+      b.replace('VERIFY_MAX_ATTEMPTS=30', 'VERIFY_MAX_ATTEMPTS=30 \\ ')
+    )
+    expect(codesOf(analyzeVerifyBlocks(mutated))).toContain('VB-UNSAFE-WHITESPACE')
+  })
+
+  it('N-22: backslash + whitespace would otherwise be INVISIBLE to the digest', () => {
+    // The reason N-21 must exist. Under `bash -e` these two bodies behave
+    // differently -- `foo \` continues the line, `foo \ ` escapes a space and
+    // ends the command, so the next line runs as its own command (measured:
+    // exit 0 vs exit 127). `.trim()` erases that difference, so without the
+    // guard a runtime-broken block would hash identically to a working one.
+    const good = normalize('a b \\\nc\n', 'p', 'm')
+    const bad = normalize('a b \\ \nc\n', 'p', 'm')
+    expect(good.text).toBe(bad.text) // the masking is real...
+    expect(good.unsafe).toBeNull() // ...which is exactly why the guard,
+    expect(bad.unsafe).not.toBeNull() // not the digest, has to catch it
+  })
+
+  it('N-23: a heredoc is rejected, since its payload whitespace is significant', () => {
+    const mutated = mutateStepBody(REAL_YAML, CORE.job, CORE.step, (b) =>
+      b.replace('VERIFY_MAX_ATTEMPTS=30', 'cat <<EOF\npayload\nEOF\nVERIFY_MAX_ATTEMPTS=30')
+    )
+    expect(codesOf(analyzeVerifyBlocks(mutated))).toContain('VB-UNSAFE-WHITESPACE')
+  })
+
   it('N-19: the tail gains an explicit exit 1', () => {
     const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
       b.replace('SMOKE_DIR="$(mktemp -d)"', 'SMOKE_DIR="$(mktemp -d)" || exit 1')

--- a/scripts/tests/verify-block-identity.test.ts
+++ b/scripts/tests/verify-block-identity.test.ts
@@ -1,0 +1,697 @@
+/**
+ * Tests for the `publish.yml` verify-block byte-identity gate (SMI-6513).
+ *
+ * **The acceptance bar is specific.** The original SMI-6493 bug survived shellcheck
+ * and a fully green suite because coverage only ever exercised block 1. So a suite
+ * that merely proves the current file passes would reproduce the original failure
+ * exactly. These tests must go RED when drift is injected into block 2, into block 3,
+ * and into block 4, each independently — N-1 through N-4 below.
+ *
+ * **Fixture strategy: no committed snapshot.** Every case starts from the REAL
+ * `.github/workflows/publish.yml`, read once and mutated in memory as a string. A
+ * committed copy drifts from the real file and the negative cases quietly start
+ * testing a museum piece; reading the live file means injected drift is always drift
+ * relative to what is shipping.
+ *
+ * Mutation is surgical, by `(jobId, stepName)` — never by line offset, for the same
+ * reason the module itself never uses line numbers.
+ */
+
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  REGISTRY,
+  TAIL_MARKER,
+  analyzeVerifyBlocks,
+  briefDiff,
+  normalize,
+  notEvaluated,
+  reportLines,
+  splitAtTailMarker,
+} from '../lib/verify-block-identity.mjs'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.github/workflows/publish.yml')
+const REAL_YAML = fs.readFileSync(WORKFLOW_PATH, 'utf8')
+
+const CORE = { job: 'publish-core', step: 'Verify core on npm' }
+const MCP = { job: 'publish-mcp-server', step: 'Verify mcp-server on npm' }
+const CLI = { job: 'publish-cli', step: 'Verify cli on npm' }
+const WRAPPER = {
+  job: 'publish-skillsmith-cli',
+  step: 'Verify skillsmith-cli on npm + smoke the wrapper',
+}
+const ALL_FOUR = [CORE, MCP, CLI, WRAPPER]
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- parsed YAML is untyped
+type Workflow = any
+
+// js-yaml via createRequire — the pattern already used by scripts/audit-standards.mjs
+// and scripts/audit-host-volume-fs-guard-helpers.mjs. A bare `import ... from 'js-yaml'`
+// also works at runtime but has no type declarations in this repo (@types/js-yaml is not
+// installed), so it trips TS7016 for anyone who points a typechecker at scripts/.
+const require = createRequire(import.meta.url)
+const yaml = require('js-yaml') as {
+  load: (text: string) => unknown
+  dump: (doc: unknown, opts?: Record<string, unknown>) => string
+}
+
+function parse(yamlText: string): Workflow {
+  return yaml.load(yamlText) as Workflow
+}
+
+/**
+ * Re-serialize a parsed workflow. `lineWidth: -1` disables folding, and lives HERE
+ * rather than at each call site: a folded block scalar silently rewrites `run` bodies,
+ * which would make every negative case below test a corrupted fixture. One call site
+ * forgetting the option is exactly the kind of invisible failure this suite guards
+ * against elsewhere, so it is not something a caller can forget.
+ */
+function dump(doc: Workflow): string {
+  return yaml.dump(doc, { lineWidth: -1, noRefs: true })
+}
+
+function findStep(doc: Workflow, jobId: string, stepName: string) {
+  const steps = doc.jobs[jobId].steps as Array<{ name?: string; run?: string }>
+  const step = steps.find((s) => s.name === stepName)
+  if (!step) throw new Error(`fixture error: no step "${stepName}" in job "${jobId}"`)
+  return step
+}
+
+/** Apply `edit` to one step's `run` body, addressed by (jobId, stepName). */
+function mutateStepBody(
+  yamlText: string,
+  jobId: string,
+  stepName: string,
+  edit: (body: string) => string
+): string {
+  const doc = parse(yamlText)
+  const step = findStep(doc, jobId, stepName)
+  const before = step.run as string
+  const after = edit(before)
+  if (after === before) {
+    throw new Error(`fixture error: edit to "${jobId} :: ${stepName}" changed nothing`)
+  }
+  step.run = after
+  return dump(doc)
+}
+
+/** Apply the same edit to every one of the four registered blocks. */
+function mutateAll(yamlText: string, edit: (body: string) => string): string {
+  return ALL_FOUR.reduce((acc, b) => mutateStepBody(acc, b.job, b.step, edit), yamlText)
+}
+
+function renameStep(yamlText: string, jobId: string, from: string, to: string): string {
+  const doc = parse(yamlText)
+  findStep(doc, jobId, from).name = to
+  return dump(doc)
+}
+
+function moveStep(yamlText: string, fromJob: string, toJob: string, stepName: string): string {
+  const doc = parse(yamlText)
+  const steps = doc.jobs[fromJob].steps as Array<{ name?: string }>
+  const idx = steps.findIndex((s) => s.name === stepName)
+  if (idx < 0) throw new Error(`fixture error: no step "${stepName}" in "${fromJob}"`)
+  const [step] = steps.splice(idx, 1)
+  doc.jobs[toJob].steps.push(step)
+  return dump(doc)
+}
+
+/** Append a second step with the SAME name but a different body. */
+function duplicateStep(yamlText: string, jobId: string, stepName: string): string {
+  const doc = parse(yamlText)
+  const original = findStep(doc, jobId, stepName)
+  doc.jobs[jobId].steps.push({
+    name: stepName,
+    run: `${original.run as string}\necho "drifted duplicate"`,
+  })
+  return dump(doc)
+}
+
+function addStep(yamlText: string, jobId: string, name: string, run: string): string {
+  const doc = parse(yamlText)
+  doc.jobs[jobId].steps = doc.jobs[jobId].steps ?? []
+  doc.jobs[jobId].steps.push({ name, run })
+  return dump(doc)
+}
+
+function codesOf(result: { findings: Array<{ code: string }> }): string[] {
+  return result.findings.map((f) => f.code)
+}
+
+/** The raw `run` body of the wrapper block, straight from the real file. */
+function rawWrapperBody(yamlText = REAL_YAML): string {
+  return findStep(parse(yamlText), WRAPPER.job, WRAPPER.step).run as string
+}
+
+function stripWholeLineComments(body: string): string {
+  return body
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('#'))
+    .join('\n')
+}
+
+const indentAll = (body: string) =>
+  body
+    .split('\n')
+    .map((l) => `  ${l}`)
+    .join('\n')
+
+// ---------------------------------------------------------------------------
+// Harness self-test — the fixtures must be trustworthy before anything else
+// ---------------------------------------------------------------------------
+
+describe('fixture harness', () => {
+  it('round-trips every verify body through parse -> dump without altering it', () => {
+    // If dump folded a block scalar, every negative case below would be testing a
+    // corrupted body and the suite's greenness would mean nothing.
+    const before = parse(REAL_YAML)
+    const after = parse(dump(before))
+    for (const b of ALL_FOUR) {
+      expect(findStep(after, b.job, b.step).run).toBe(findStep(before, b.job, b.step).run)
+    }
+  })
+
+  it('re-dumping the untouched workflow still passes the check', () => {
+    // Re-dumping rewrites YAML formatting throughout; the check must be indifferent.
+    const result = analyzeVerifyBlocks(dump(parse(REAL_YAML)))
+    expect(result.findings).toEqual([])
+    expect(result.ok).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Ordering tests — the marker invariant
+// ---------------------------------------------------------------------------
+
+describe('tail-marker ordering invariant', () => {
+  it('T-ORDER-1: splitting AFTER comment-stripping loses the boundary', () => {
+    // This is the test that locks the pipeline order. The marker is a whole-line
+    // comment, so normalizing first destroys it. If someone reorders the pipeline to
+    // normalize before splitting, this goes red with a named code instead of the
+    // boundary silently vanishing.
+    const stripped = stripWholeLineComments(rawWrapperBody())
+    expect(stripped).not.toContain(TAIL_MARKER)
+
+    const result = splitAtTailMarker(stripped)
+    expect(result.ok).toBe(false)
+    expect((result as { code: string }).code).toBe('VB-TAIL-MARKER-MISSING')
+  })
+
+  it('T-ORDER-2: splitting the raw body puts the smoke tail on the right side', () => {
+    const result = splitAtTailMarker(rawWrapperBody())
+    expect(result.ok).toBe(true)
+    const { head, tail } = result as { head: string; tail: string }
+
+    const firstTailLine = tail.split('\n').find((l) => l.trim().length > 0)
+    expect(firstTailLine?.trim()).toBe('SMOKE_DIR="$(mktemp -d)"')
+    expect(head).not.toContain('SMOKE_DIR')
+    // The head keeps the registry verification, including its explicit failure path.
+    expect(head).toContain('npm view')
+    expect(head).toContain('exit 1')
+  })
+
+  it('matches the marker only as a whole trimmed line', () => {
+    const cases: Array<[string, boolean]> = [
+      [TAIL_MARKER, true],
+      [`  ${TAIL_MARKER}`, true],
+      [`      ${TAIL_MARKER}   `, true],
+      [`SMOKE_DIR=x ${TAIL_MARKER}`, false],
+      [`#${TAIL_MARKER}`, false],
+      [`${TAIL_MARKER}-v2`, false],
+      ['# audit:carveout-pure-js', false],
+    ]
+    for (const [line, shouldMatch] of cases) {
+      const body = `echo before\n${line}\necho after`
+      expect(splitAtTailMarker(body).ok, `line: ${JSON.stringify(line)}`).toBe(shouldMatch)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Positive cases — must PASS
+// ---------------------------------------------------------------------------
+
+describe('positive cases', () => {
+  it('P-1: the real, unmutated publish.yml passes', () => {
+    const result = analyzeVerifyBlocks(REAL_YAML)
+    expect(result.findings).toEqual([])
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe('passed')
+    expect(result.comparedBlocks).toBe(4)
+    expect(result.expectedBlocks).toBe(4)
+  })
+
+  it('P-2: whitespace, blank lines and comments in block 3 are tolerated', () => {
+    const mutated = mutateStepBody(REAL_YAML, CLI.job, CLI.step, (body) =>
+      [indentAll(body), '', '# a newly added whole-line comment', '   '].join('\n')
+    )
+    expect(analyzeVerifyBlocks(mutated).findings).toEqual([])
+  })
+
+  it('P-3: the same formatting edits applied to block 4 are tolerated', () => {
+    // Block 4 additionally goes through the marker split and R1/R2/R3, so it must be
+    // equally formatting-insensitive — including the marker line itself being indented.
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (body) =>
+      [indentAll(body), '', '# another added comment'].join('\n')
+    )
+    expect(analyzeVerifyBlocks(mutated).findings).toEqual([])
+  })
+
+  it('P-4: a real fix propagated to all four needs no baseline bump', () => {
+    const mutated = mutateAll(REAL_YAML, (b) =>
+      b.replace('VERIFY_MAX_ATTEMPTS=30', 'VERIFY_MAX_ATTEMPTS=40')
+    )
+    expect(analyzeVerifyBlocks(mutated).findings).toEqual([])
+  })
+
+  it('P-5: rewording a comment inside block 4 tail does not bump the pinned digest', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace(
+        '# SMI-6493: if the verify loop above took the slow path (a high attempt',
+        '# SMI-6493: reworded comment text that says the same thing differently'
+      )
+    )
+    expect(analyzeVerifyBlocks(mutated).findings).toEqual([])
+  })
+
+  it('P-6: no enterprise verify block exists, and none is registered', () => {
+    // SMI-6498's scope, deliberately untouched here. Asserted so a future refactor
+    // cannot quietly change it without this test noticing.
+    expect(REGISTRY.map((r) => r.jobId)).not.toContain('publish-enterprise')
+    const doc = parse(REAL_YAML)
+    const enterpriseSteps = (doc.jobs['publish-enterprise'].steps ?? []) as Array<{
+      name?: string
+    }>
+    expect(enterpriseSteps.filter((s) => /^Verify\b.*\bon npm\b/.test(s.name ?? ''))).toEqual([])
+  })
+
+  it('P-7: `Verify dependencies` is present and correctly ignored', () => {
+    // Pins the discovery predicate against the loosening trap: a bare /Verify/ would
+    // match this unrelated step and the "exactly these four" assertion would misfire.
+    const doc = parse(REAL_YAML)
+    const names = (doc.jobs['pre-publish-check'].steps as Array<{ name?: string }>).map(
+      (s) => s.name
+    )
+    expect(names).toContain('Verify dependencies')
+    expect(analyzeVerifyBlocks(REAL_YAML).findings).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Negative cases — must FAIL with the named code
+// ---------------------------------------------------------------------------
+
+describe('negative cases: per-block drift (the four that answer the original bug)', () => {
+  it('N-1: drift in block 2 only', () => {
+    const mutated = mutateStepBody(REAL_YAML, MCP.job, MCP.step, (b) =>
+      b.replace('VERIFY_MAX_ATTEMPTS=30', 'VERIFY_MAX_ATTEMPTS=5')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-SCOPED-DIGEST-MISMATCH')
+    expect(result.findings.some((f) => f.step === MCP.step)).toBe(true)
+  })
+
+  it('N-2: drift in block 3 only', () => {
+    const mutated = mutateStepBody(REAL_YAML, CLI.job, CLI.step, (b) =>
+      b.replace(
+        '--prefer-offline=false --registry=https://registry.npmjs.org 2>/dev/null',
+        '--registry=https://registry.npmjs.org 2>/dev/null'
+      )
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-SCOPED-DIGEST-MISMATCH')
+    expect(result.findings.some((f) => f.step === CLI.step)).toBe(true)
+  })
+
+  it('N-3: drift in block 4 final probe only', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace(' --registry=https://registry.npmjs.org) || true', ') || true')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-BLOCK4-MISMATCH')
+  })
+
+  it('N-4: block 4 gains an UNRELATED difference', () => {
+    // The case a "skip block 4" implementation cannot catch, and the reason Stage 3 is
+    // a forward rewrite rather than an exclusion.
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace('VERIFY_INTERVAL=10', 'VERIFY_INTERVAL=10\nsleep 2')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-BLOCK4-MISMATCH')
+  })
+})
+
+describe('negative cases: tail region', () => {
+  it('N-5: tail drift bumps the pinned digest', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace('for attempt in 1 2 3; do', 'for attempt in 1 2; do')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-BLOCK4-TAIL-DRIFT')
+  })
+
+  it('N-11: the tail marker is deleted', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b
+        .split('\n')
+        .filter((l) => l.trim() !== TAIL_MARKER)
+        .join('\n')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-TAIL-MARKER-MISSING')
+  })
+
+  it('N-12: a second tail marker makes the boundary ambiguous', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace('VERIFY_INTERVAL=10', `${TAIL_MARKER}\nVERIFY_INTERVAL=10`)
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-TAIL-MARKER-DUPLICATE')
+  })
+
+  it('N-18: the tail gains a registry probe', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace('SMOKE_DIR="$(mktemp -d)"', 'npm view foo version\nSMOKE_DIR="$(mktemp -d)"')
+    )
+    expect(codesOf(analyzeVerifyBlocks(mutated))).toContain('VB-TAIL-CONTAINS-PROBE')
+  })
+
+  it('N-19: the tail gains an explicit exit 1', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace('SMOKE_DIR="$(mktemp -d)"', 'SMOKE_DIR="$(mktemp -d)" || exit 1')
+    )
+    expect(codesOf(analyzeVerifyBlocks(mutated))).toContain('VB-TAIL-CONTAINS-PROBE')
+  })
+})
+
+describe('negative cases: structural / identity', () => {
+  it('N-6: a step renamed out from under the check', () => {
+    const mutated = renameStep(REAL_YAML, CLI.job, CLI.step, 'Verify cli package on npm')
+    const codes = codesOf(analyzeVerifyBlocks(mutated))
+    expect(codes).toContain('VB-UNREGISTERED-VERIFY-STEP')
+    expect(codes).toContain('VB-MISSING-STEP')
+  })
+
+  it('N-9: an unregistered fifth verify step (the case SMI-6498 will hit)', () => {
+    const mutated = addStep(
+      REAL_YAML,
+      'publish-enterprise',
+      'Verify enterprise on npm',
+      'echo "an arbitrary body"'
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-UNREGISTERED-VERIFY-STEP')
+  })
+
+  it('N-13: two steps sharing a registered name', () => {
+    // The key set still has four members, so a name-keyed map would look correct while
+    // silently comparing the drifted body. This must not pass.
+    const mutated = duplicateStep(REAL_YAML, CLI.job, CLI.step)
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-DUPLICATE-STEP')
+  })
+
+  it('N-14: a verify step relocated to another job', () => {
+    const mutated = moveStep(REAL_YAML, CLI.job, WRAPPER.job, CLI.step)
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    const wrongJob = result.findings.find((f) => f.code === 'VB-WRONG-JOB')
+    expect(wrongJob).toBeDefined()
+    expect(wrongJob?.message).toContain(CLI.job)
+    expect(wrongJob?.message).toContain(WRAPPER.job)
+  })
+
+  it('N-10: YAML with no `jobs:` mapping', () => {
+    const result = analyzeVerifyBlocks('name: nothing\non: push\n')
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-PARSE-ERROR')
+  })
+
+  it('N-10b: unparseable YAML never silently passes', () => {
+    const result = analyzeVerifyBlocks('jobs: [unclosed\n  : : :\n')
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-PARSE-ERROR')
+  })
+
+  it('N-17: an empty `run` body', () => {
+    const doc = parse(REAL_YAML)
+    findStep(doc, CLI.job, CLI.step).run = ''
+    const result = analyzeVerifyBlocks(dump(doc))
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-PARSE-ERROR')
+  })
+})
+
+describe('negative cases: normalization guards', () => {
+  it('N-7: restructuring the canonical block invalidates the R3 fragment', () => {
+    // Applied identically to all four, so Stage 2 still agrees — only R3 notices.
+    const mutated = mutateAll(REAL_YAML, (b) =>
+      b.replace(
+        'for attempt in $(seq 1 "$VERIFY_MAX_ATTEMPTS"); do',
+        'attempt=0\nwhile [ "$attempt" -lt "$VERIFY_MAX_ATTEMPTS" ]; do\nattempt=$((attempt + 1))'
+      )
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-R3-FRAGMENT-LOST')
+  })
+
+  it('N-8: a new non-ASCII glyph without an R2 table entry', () => {
+    // Propagated to blocks 1-3 so Stage 2 still agrees; only the R2 precondition fires.
+    const mutated = [CORE, MCP, CLI].reduce(
+      (acc, b) => mutateStepBody(acc, b.job, b.step, (body) => body.split('✓').join('»')),
+      REAL_YAML
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    const finding = result.findings.find((f) => f.code === 'VB-NON-ASCII-UNMAPPED')
+    expect(finding).toBeDefined()
+    expect(finding?.message).toContain('U+00BB') // the codepoint is named, not just "non-ASCII"
+  })
+
+  it('N-15: a package name that does not occur in its own body', () => {
+    const mutated = mutateStepBody(REAL_YAML, CORE.job, CORE.step, (b) =>
+      b.split('@skillsmith/core').join('@skillsmith/kore')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-SUBSTITUTION-COUNT')
+  })
+
+  it('N-16: a sentinel literal already present in a body', () => {
+    const mutated = mutateStepBody(REAL_YAML, CORE.job, CORE.step, (b) =>
+      b.replace('VERIFY_INTERVAL=10', 'VERIFY_INTERVAL=10\necho "__PKG__"')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-SENTINEL-COLLISION')
+  })
+
+  it('N-20: the masking limitation is pinned, not accidental', () => {
+    // Documented, accepted behaviour: a package name inside an unrelated token is
+    // substituted too, so two different tokens normalize identically. Pinned here so
+    // it cannot change silently — if this ever goes red, the invariant changed.
+    const a = normalize(
+      'echo prefix-skillsmith-cli-suffix',
+      'skillsmith-cli',
+      'packages/skillsmith-cli/package.json'
+    ).text
+    const b = normalize('echo prefix-OTHERNAME-suffix', 'OTHERNAME', 'irrelevant/path.json').text
+    expect(a).toBe('echo prefix-__PKG__-suffix')
+    expect(a).toBe(b)
+  })
+
+  it('substitutes the manifest path BEFORE the package name', () => {
+    // Reversing the order yields `packages/__PKG__/package.json` and a permanent,
+    // unfixable digest mismatch that looks like real drift. Pinned explicitly because
+    // the failure it guards is a silent one.
+    const out = normalize(
+      'VERSION=$(jq -r .version packages/skillsmith-cli/package.json)',
+      'skillsmith-cli',
+      'packages/skillsmith-cli/package.json'
+    )
+    expect(out.text).toBe('VERSION=$(jq -r .version __MANIFEST__)')
+    expect(out.text).not.toContain('packages/__PKG__')
+    expect(out.manifestCount).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The three-way outcome, and the coverage denominator
+// ---------------------------------------------------------------------------
+
+describe('three-way outcome', () => {
+  it('reports `passed` only when everything was actually compared', () => {
+    const result = analyzeVerifyBlocks(REAL_YAML)
+    expect(result.status).toBe('passed')
+    expect(result.ok).toBe(true)
+    expect(result.comparedBlocks).toBe(result.expectedBlocks)
+    expect(result.notEvaluatedReason).toBeNull()
+  })
+
+  it('reports `failed` — distinct from not-evaluated — on real drift', () => {
+    const mutated = mutateStepBody(REAL_YAML, MCP.job, MCP.step, (b) =>
+      b.replace('VERIFY_MAX_ATTEMPTS=30', 'VERIFY_MAX_ATTEMPTS=5')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.status).toBe('failed')
+    expect(result.ok).toBe(false)
+  })
+
+  it('reports `not_evaluated` — and never ok:true — when the check could not run', () => {
+    const result = notEvaluated('ENOENT: .github/workflows/publish.yml is missing')
+    expect(result.status).toBe('not_evaluated')
+    expect(result.ok).toBe(false) // the whole point: a check that could not run is not a pass
+    expect(result.comparedBlocks).toBe(0)
+    expect(result.expectedBlocks).toBe(4)
+    expect(codesOf(result)).toEqual(['VB-NOT-EVALUATED'])
+    expect(result.notEvaluatedReason).toContain('ENOENT')
+  })
+
+  it('renders all three outcomes distinguishably', () => {
+    const passed = reportLines(analyzeVerifyBlocks(REAL_YAML))
+    const failed = reportLines(analyzeVerifyBlocks('name: x\non: push\n'))
+    const skipped = reportLines(notEvaluated('docker not running'))
+
+    expect(passed.lines[0]).toContain('PASSED')
+    expect(failed.lines[0]).toContain('FAILED')
+    expect(skipped.lines[0]).toContain('NOT EVALUATED')
+
+    // A not-evaluated run must never read as a pass to a human skimming CI output.
+    expect(skipped.lines.join('\n')).not.toContain('PASSED')
+    expect(skipped.lines.join('\n')).toContain('not a pass')
+
+    // Every headline carries the coverage fraction, so a scope-blind clean run does
+    // not read identically to a real one.
+    for (const r of [passed, failed, skipped]) {
+      expect(r.lines[0]).toMatch(/\d+\/\d+ verify block\(s\) compared/)
+    }
+  })
+})
+
+describe('diagnostic rendering', () => {
+  it('names the differing lines, with both labels', () => {
+    const diff = briefDiff('same\nalpha\ntail', 'same\nbeta\ntail', 'left', 'right')
+    expect(diff).toContain('- [left] alpha')
+    expect(diff).toContain('+ [right] beta')
+    // The common prefix/suffix is trimmed, so a reader sees only what changed.
+    expect(diff).not.toContain('same')
+  })
+
+  it('falls back to a readable message when the lines are identical', () => {
+    // Defensive branch: unreachable via analyzeVerifyBlocks (normalized bodies with
+    // differing digests always differ by a line), but it must not render as an empty
+    // string if a future caller passes non-normalized text.
+    expect(briefDiff('same', 'same', 'a', 'b')).toContain('no line-level difference')
+  })
+
+  it('caps a very large diff instead of flooding the CI log', () => {
+    const a = Array.from({ length: 60 }, (_, i) => `a${i}`).join('\n')
+    const b = Array.from({ length: 60 }, (_, i) => `b${i}`).join('\n')
+    const diff = briefDiff(a, b, 'a', 'b', 10)
+    expect(diff.split('\n')).toHaveLength(11) // 10 shown + 1 summary line
+    expect(diff).toContain('further differing line(s) not shown')
+  })
+})
+
+describe('coverage denominator (SMI-6591 class: never drop a block silently)', () => {
+  it('a block that cannot be parsed leaves the denominator intact and fails', () => {
+    // The failure this guards: reporting "all identical" after comparing three of four.
+    const doc = parse(REAL_YAML)
+    findStep(doc, MCP.job, MCP.step).run = ''
+    const result = analyzeVerifyBlocks(dump(doc))
+
+    expect(result.expectedBlocks).toBe(4)
+    expect(result.comparedBlocks).toBeLessThan(4)
+    expect(codesOf(result)).toContain('VB-COVERAGE-SHORTFALL')
+    expect(result.ok).toBe(false)
+  })
+
+  it('a block dropped at the marker split is also counted as not compared', () => {
+    const mutated = mutateStepBody(REAL_YAML, WRAPPER.job, WRAPPER.step, (b) =>
+      b
+        .split('\n')
+        .filter((l) => l.trim() !== TAIL_MARKER)
+        .join('\n')
+    )
+    const result = analyzeVerifyBlocks(mutated)
+    expect(result.comparedBlocks).toBe(3)
+    expect(codesOf(result)).toContain('VB-COVERAGE-SHORTFALL')
+  })
+
+  it('a missing canonical block does not silently take the tail checks down too', () => {
+    // Regression guard: the R1 tail checks must not be nested under Stage 3's
+    // `canon && reshaped` precondition.
+    const mutated = renameStep(REAL_YAML, CORE.job, CORE.step, 'Verify core package on npm')
+    const withTailDrift = mutateStepBody(mutated, WRAPPER.job, WRAPPER.step, (b) =>
+      b.replace('for attempt in 1 2 3; do', 'for attempt in 1 2; do')
+    )
+    const result = analyzeVerifyBlocks(withTailDrift)
+    expect(codesOf(result)).toContain('VB-BLOCK4-TAIL-DRIFT')
+  })
+
+  it('tolerates a job with no `steps:` key without crashing', () => {
+    // A degraded/partial workflow must produce findings, never an exception — an
+    // exception in the audit caller would take the whole run down (the SMI-6520 class).
+    const doc = parse(REAL_YAML)
+    doc.jobs['a-job-with-no-steps'] = { 'runs-on': 'ubuntu-latest' }
+    const result = analyzeVerifyBlocks(dump(doc))
+    expect(result.findings).toEqual([])
+    expect(result.comparedBlocks).toBe(4)
+  })
+
+  it('with only one usable block, compares nothing and says so', () => {
+    // The degenerate end of the denominator rule: with nothing to compare against, the
+    // honest answer is 0 compared — never "no mismatches found, therefore identical".
+    const doc = parse(REAL_YAML)
+    for (const b of [CORE, MCP, CLI]) findStep(doc, b.job, b.step).run = ''
+    const result = analyzeVerifyBlocks(dump(doc))
+
+    expect(result.comparedBlocks).toBe(0)
+    expect(result.ok).toBe(false)
+    expect(codesOf(result)).toContain('VB-COVERAGE-SHORTFALL')
+    expect(codesOf(result).filter((c) => c === 'VB-PARSE-ERROR')).toHaveLength(3)
+    expect(codesOf(result)).not.toContain('VB-SCOPED-DIGEST-MISMATCH')
+  })
+
+  it('renders a finding that carries only one half of the identity pair', () => {
+    const rendered = reportLines({
+      status: 'failed',
+      ok: false,
+      expectedBlocks: 4,
+      comparedBlocks: 3,
+      notEvaluatedReason: null,
+      findings: [
+        { code: 'VB-SYNTH-A', job: null, step: 'Verify cli on npm', message: 'x' },
+        { code: 'VB-SYNTH-B', job: 'publish-cli', step: null, message: 'y' },
+      ],
+    })
+    const text = rendered.lines.join('\n')
+    expect(text).toContain('[? :: Verify cli on npm]')
+    expect(text).toContain('[publish-cli :: ?]')
+  })
+
+  it('every registered block is reachable — no registration is dead', () => {
+    // If a registered (jobId, stepName) pair stopped matching the discovery predicate,
+    // it would silently never be compared. comparedBlocks === 4 on the real file is
+    // what proves all four registrations are live.
+    expect(REGISTRY).toHaveLength(4)
+    expect(analyzeVerifyBlocks(REAL_YAML).comparedBlocks).toBe(4)
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** `audit:standards` now fails when `publish.yml`'s four package-verification blocks stop being identical to one another. They are the same program apart from which package they target, so any difference between them is drift. Nothing checked this before, which is how SMI-6493's retry-budget fix came to be applied to one block at a time.

**Quality bar:** Cross-family pre-merge review by GPT-5.6-Sol (the PR was written by Claude), which found a HIGH-severity false negative inside the checker itself — see below. Both blocking findings are fixed in this PR. Every outcome branch was proven by making it fire, not by observing a green run. 48 unit tests, each guard reverted in turn to confirm the suite goes red; the failure path exercised by injecting real drift into `publish.yml` and confirming the offending blocks are named; the not-evaluated path exercised by removing the file. `publish.yml` restored byte-identically after each, verified by checksum. Typecheck, format and the full pre-push suite are green.

**Found along the way:** Two pre-existing defects, filed rather than bundled in. SMI-6596 — ESLint's config ignores `**/*.mjs`, so no `.mjs` file in the repo has ever been linted, including the 6100-line `audit-standards.mjs`; running ESLint on one exits 0 without examining it. SMI-6597 — `js-yaml` is imported by five `scripts/` files including `audit-standards.mjs` but declared in neither `dependencies` nor `devDependencies`, so a dependency bump that drops the transitive edge would break the tooling that exists to catch that class of drift. Neither is fixable here: SMI-6596 needs a config change with an unmeasured blast radius, and SMI-6597 mutates the lockfile, which does not belong in a CI-logic PR.

**Net result:** Shipped and complete. This unblocks SMI-6512 (+SMI-6583), which depends on the tail marker this PR adds and cannot start until it lands.

---

## Pre-merge review: the checker was blind to its own defect class

A cross-family review (GPT-5.6-Sol via NEEDLE, ADR-128) returned NEEDS-FIXES. The finding is worth stating plainly because it is the same shape as the bug this PR exists to prevent.

`normalize()` trimmed every line before hashing. Trailing whitespace is not always formatting — after a continuation backslash it decides whether the newline is escaped. Measured under the workflow's real `bash -e`:

```
printf "<%s>" foo \        -> <foo> <bar>            exit 0
bar

printf "<%s>" foo \ (space) -> <foo> < >             exit 127
bar                            bar: command not found
```

Both hashed to `20d7ef1324f13a42`. So one verify block could be broken at runtime while the check reported all four byte-identical.

**The first fix was wrong and was reverted.** Removing the trim outright broke 13 tests, because positive cases P-2 and P-3 deliberately tolerate cosmetic whitespace and blank lines — a reviewed decision. Full strictness would have overturned the plan rather than fixed the defect.

The shipped fix is narrower: leading indentation and blank lines stay tolerated because they are inert in shell, while the two shapes where they are *not* inert are rejected via `VB-UNSAFE-WHITESPACE` — a line ending in backslash + whitespace, and a heredoc opener whose payload whitespace is significant.

Because this is a per-block guard rather than a comparison, it is stronger than identity for this class: injecting the hazard into all four blocks at once still fails (`0/4 compared`, exit 1) where a pure identity check would pass.

Latent, never live — zero occurrences of either shape in the workflow today.

Tests N-21/N-22/N-23 added, each proven to fail when its own branch is disabled.

The review also found three stale assertions in the SMI-6493 plan that denied coverage this check now provides. Two were false and are marked superseded; the third — that this is no substitute for the manual ShellCheck pass — is still true and was retained with a clarification.

Full report: `docs/internal/pr-reviews/2026-09-13-smi-6513-verify-block-byte-identity.md`.

---

## Technical detail

**Files**

| File | Change |
|---|---|
| `.github/workflows/publish.yml` | One line: a `# audit:verify-block-smoke-tail` marker above `SMOKE_DIR="$(mktemp -d)"` |
| `scripts/lib/verify-block-identity.mjs` | Analysis engine — extraction, normalization, comparison |
| `scripts/lib/verify-block-identity.constants.mjs` | Block registry, R2/R3 tables, pinned tail digest, marker literal |
| `scripts/lib/verify-block-identity.messages.mjs` | Diagnostic prose |
| `scripts/tests/verify-block-identity.test.ts` | 48 tests |
| `scripts/audit-standards.mjs` | Check 71 call site (+64 lines) |

**Design points a reviewer should check**

*Three-way outcome.* `passed` / `failed` / `not_evaluated`, with `ok === false` for the latter two. A check that cannot run reports that and fails; it never defaults to clean. The call site is wrapped so a throw cannot terminate the audit — the failure mode Check 69 currently has, where an uncaught throw takes Check 70, the summary and the exit verdict with it (SMI-6575, PR #2817).

*Reports its denominator.* Output is `4/4 blocks compared`, not a bare verdict. A block that fails to parse lowers `comparedBlocks` below `expectedBlocks` and fails via `VB-COVERAGE-SHORTFALL`, so it cannot drop out of the denominator it is measured against. Measured: deleting the tail marker yields `3/4` with `ok=false`, not a clean pass over the remaining three. This contract came from SMI-6591, where a sanitizer logged `rule_count=218` while excluding six rules that failed to compile.

*Parser, not grep.* `pre-publish-check` has a step named `Verify dependencies`, so a `/Verify/` regex matches five steps rather than four — an over-count that reads as more complete than the truth. The module parses the YAML and keys off jobs.

*A marker, not a statement anchor.* The split anchors on a comment rather than on `/^SMOKE_DIR=/` so that SMI-6512's edit to that same span cannot break it. Block 4 legitimately differs from the others in three enumerated ways (tail excision, ASCII transliteration, one control-flow fragment); anything else fails.

*Module split.* 801 lines as one file, against the 500-line convention, so it was split on real boundaries. Worth noting that nothing would have caught the overage: `.mjs` is not routed to the pre-commit length gate (`lint-staged` sends only `*.{ts,sh}`) and `audit:standards` Check 3 scans only `packages/` and `apps/`.

**CI caveats**

- `audit:standards` cannot be run to completion inside a worktree container — Check 69 terminates the process first. Pre-existing and unrelated to this change; verified identical with `publish.yml` reverted. All verification here was run on the host, which is also where CI's `quality-checks` job runs.
- Coverage for this module is only measurable with an explicit command. `vitest.config.ts` excludes `scripts/**` from coverage deliberately, so its absence from the repo-wide report is expected, not a regression. The working command is recorded in the plan doc.

**No deploy or migration impact.** CI workflow and audit tooling only.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
